### PR TITLE
Fix quoting of allowed-tools in issue labeler workflow

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -22,7 +22,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowed-tools Bash(gh issue edit*)'
+          claude_args: '--allowed-tools "Bash(gh issue edit*)"'
           prompt: |
             Analyze the following GitHub issue and apply appropriate labels using `gh issue edit`.
 


### PR DESCRIPTION
## Summary

- The `claude_args` value `'--allowed-tools Bash(gh issue edit*)'` was being split by the `shell-quote` parser into `["Bash", "gh", "issue"]` because parentheses are shell operators and spaces delimit tokens
- Adding inner double quotes keeps `Bash(gh issue edit*)` as a single token so the intended tool permission is applied
- This was always broken (confirmed by comparing SDK options logs from both successful and failed runs — both showed the same wrong parsing), but runs succeeded anyway since Claude could still invoke `gh`

## Test plan

- [ ] Create a test issue and verify the labeler workflow succeeds
- [ ] Check the workflow run logs to confirm `allowedTools` contains `["Bash(gh issue edit*)"]` as a single entry instead of `["Bash", "gh", "issue"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)