### PR TITLE
Add workflow_dispatch trigger to issue labeler

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -3,6 +3,12 @@ name: Issue Labeler
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to label'
+        required: true
+        type: number
 
 jobs:
   label-issue:
@@ -18,6 +24,23 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Resolve issue number
+        id: issue
+        run: echo "number=${{ github.event.issue.number || inputs.issue_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch issue details
+        id: details
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue view ${{ steps.issue.outputs.number }} --json title,body --jq '{title, body}' > /tmp/issue.json
+          echo "title=$(jq -r .title /tmp/issue.json)" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<ISSUE_BODY_EOF"
+            jq -r .body /tmp/issue.json
+            echo "ISSUE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Label Issue with Claude
         uses: anthropics/claude-code-action@v1
         with:
@@ -26,10 +49,10 @@ jobs:
           prompt: |
             Analyze the following GitHub issue and apply appropriate labels using `gh issue edit`.
 
-            Issue #${{ github.event.issue.number }}
-            Title: ${{ github.event.issue.title }}
+            Issue #${{ steps.issue.outputs.number }}
+            Title: ${{ steps.details.outputs.title }}
             Body:
-            ${{ github.event.issue.body }}
+            ${{ steps.details.outputs.body }}
 
             ## Label Schema
 
@@ -64,5 +87,5 @@ jobs:
 
             1. Analyze the issue title and body to understand what it's about
             2. Select appropriate labels from each category
-            3. Apply labels using: `gh issue edit ${{ github.event.issue.number }} --add-label "label1" --add-label "label2" ...`
+            3. Apply labels using: `gh issue edit ${{ steps.issue.outputs.number }} --add-label "label1" --add-label "label2" ...`
             4. Do NOT comment on the issue - just apply the labels silently


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` trigger with an `issue_number` input so the labeler can be manually re-run for any issue
- Refactors the prompt to fetch issue details via `gh issue view` instead of relying on `github.event.issue`, so both trigger paths work consistently
- Useful for retrying after failures (like the SDK crash on #18) or labeling issues that were missed

## Test plan

- [ ] Merge, then manually dispatch the workflow with issue number `18` from the Actions tab
- [ ] Verify issue #18 gets labeled
- [ ] Create a new test issue and verify the `issues: opened` trigger still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)