### PR TITLE
#24: Show 8-char ID prefix in all list commands and support ID prefix matching

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -389,7 +389,7 @@ pub enum PeopleAction {
     },
     /// Show person details
     Show {
-        /// Name or email fragment
+        /// Person ID, name, or email fragment
         query: String,
     },
 }
@@ -443,7 +443,7 @@ pub enum RecipesAction {
     },
     /// Show recipe details
     Show {
-        /// Recipe ID or slug
+        /// Recipe ID or name substring
         query: String,
     },
 }

--- a/src/db/people.rs
+++ b/src/db/people.rs
@@ -62,11 +62,12 @@ pub fn list_people(conn: &Connection, company: Option<&str>) -> Result<Vec<Perso
 
 pub fn find_person(conn: &Connection, query: &str) -> Result<Vec<Person>> {
     let pattern = format!("%{}%", query);
+    let prefix_pattern = format!("{}%", query);
     let mut stmt = conn.prepare(
-        "SELECT id, name, email, company_name, job_title, extra_json FROM people WHERE name LIKE ?1 OR email LIKE ?1",
+        "SELECT id, name, email, company_name, job_title, extra_json FROM people WHERE id = ?1 OR id LIKE ?2 OR name LIKE ?3 OR email LIKE ?3",
     )?;
 
-    let rows = stmt.query_map([&pattern], |row| {
+    let rows = stmt.query_map(rusqlite::params![query, prefix_pattern, pattern], |row| {
         Ok(PersonRow {
             id: row.get(0)?,
             name: row.get(1)?,

--- a/src/db/recipes.rs
+++ b/src/db/recipes.rs
@@ -41,12 +41,13 @@ pub fn list_recipes(conn: &Connection, visibility: Option<&str>) -> Result<Vec<R
 
 pub fn show_recipe(conn: &Connection, query: &str) -> Result<Option<Recipe>> {
     let mut stmt = conn.prepare(
-        "SELECT id, slug, visibility, publisher_slug, creator_name, config_json, created_at, updated_at, deleted_at, user_id, workspace_id, extra_json FROM recipes WHERE id = ?1 OR slug = ?1 OR slug LIKE ?2 LIMIT 1",
+        "SELECT id, slug, visibility, publisher_slug, creator_name, config_json, created_at, updated_at, deleted_at, user_id, workspace_id, extra_json FROM recipes WHERE id = ?1 OR id LIKE ?2 OR slug = ?1 OR slug LIKE ?3 LIMIT 1",
     )?;
 
     let pattern = format!("%{}%", query);
+    let prefix_pattern = format!("{}%", query);
     let result = stmt
-        .query_row(rusqlite::params![query, pattern], |row| {
+        .query_row(rusqlite::params![query, prefix_pattern, pattern], |row| {
             Ok(RecipeRow {
                 id: row.get(0)?,
                 slug: row.get(1)?,

--- a/src/db/templates.rs
+++ b/src/db/templates.rs
@@ -43,12 +43,13 @@ pub fn list_templates(conn: &Connection, category: Option<&str>) -> Result<Vec<P
 
 pub fn show_template(conn: &Connection, query: &str) -> Result<Option<PanelTemplate>> {
     let mut stmt = conn.prepare(
-        "SELECT id, title, category, symbol, color, description, is_granola, owner_id, sections_json, created_at, updated_at, deleted_at, chat_suggestions_json, extra_json FROM templates WHERE id = ?1 OR title LIKE ?2 LIMIT 1",
+        "SELECT id, title, category, symbol, color, description, is_granola, owner_id, sections_json, created_at, updated_at, deleted_at, chat_suggestions_json, extra_json FROM templates WHERE id = ?1 OR id LIKE ?2 OR title LIKE ?3 LIMIT 1",
     )?;
 
     let pattern = format!("%{}%", query);
+    let prefix_pattern = format!("{}%", query);
     let result = stmt
-        .query_row(rusqlite::params![query, pattern], |row| {
+        .query_row(rusqlite::params![query, prefix_pattern, pattern], |row| {
             Ok(TemplateRow {
                 id: row.get(0)?,
                 title: row.get(1)?,

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -133,6 +133,15 @@ pub fn format_utterance(utt: &TranscriptUtterance, highlight: bool, tz: &FixedOf
 
 /// Format a person for TTY list display.
 pub fn format_person_row(person: &Person) -> String {
+    let id = person
+        .id
+        .as_deref()
+        .unwrap_or("")
+        .chars()
+        .take(8)
+        .collect::<String>()
+        .dimmed()
+        .to_string();
     let name = person
         .name
         .as_deref()
@@ -153,18 +162,27 @@ pub fn format_person_row(person: &Person) -> String {
         .dimmed()
         .to_string();
 
-    format!("{} {}{}", name, email, company)
+    format!("{} {} {}{}", id, name, email, company)
 }
 
 /// Format a calendar for TTY list display.
 pub fn format_calendar_row(cal: &Calendar) -> String {
+    let id = cal
+        .id
+        .as_deref()
+        .unwrap_or("")
+        .chars()
+        .take(8)
+        .collect::<String>()
+        .dimmed()
+        .to_string();
     let summary = cal.summary.as_deref().unwrap_or("(unnamed)");
     let primary = if cal.primary == Some(true) {
         " ★".yellow().to_string()
     } else {
         String::new()
     };
-    format!("{}{}", summary, primary)
+    format!("{} {}{}", id, summary, primary)
 }
 
 /// Format an event for TTY display.
@@ -189,6 +207,15 @@ pub fn format_event_row(event: &CalendarEvent, tz: &FixedOffset) -> String {
 
 /// Format a template for TTY list display.
 pub fn format_template_row(tmpl: &PanelTemplate) -> String {
+    let id = tmpl
+        .id
+        .as_deref()
+        .unwrap_or("")
+        .chars()
+        .take(8)
+        .collect::<String>()
+        .dimmed()
+        .to_string();
     let title = tmpl
         .title
         .as_deref()
@@ -204,11 +231,20 @@ pub fn format_template_row(tmpl: &PanelTemplate) -> String {
         .to_string();
     let symbol = tmpl.symbol.as_deref().unwrap_or("");
 
-    format!("{} {}{}", symbol, title, category)
+    format!("{} {} {}{}", id, symbol, title, category)
 }
 
 /// Format a recipe for TTY list display.
 pub fn format_recipe_row(recipe: &Recipe) -> String {
+    let id = recipe
+        .id
+        .as_deref()
+        .unwrap_or("")
+        .chars()
+        .take(8)
+        .collect::<String>()
+        .dimmed()
+        .to_string();
     let name = recipe
         .config
         .as_ref()
@@ -225,7 +261,7 @@ pub fn format_recipe_row(recipe: &Recipe) -> String {
         .dimmed()
         .to_string();
 
-    format!("{}{}", name, visibility)
+    format!("{} {}{}", id, name, visibility)
 }
 
 /// Fixed content width for search separator dash-fill calculation.


### PR DESCRIPTION
## Summary
- All browse list commands (people, calendars, templates, recipes) now display a truncated 8-char ID prefix, consistent with meetings
- Show/find queries for people, templates, and recipes now accept ID prefix matches in addition to name/title substrings
- Updated CLI help text to clearly describe available query options (recipes: "slug" → "name substring", people: added "Person ID")

Closes #24

## Test plan
- [ ] Run `grans browse recipes list` and verify 8-char IDs appear
- [ ] Run `grans browse people list` and verify 8-char IDs appear
- [ ] Run `grans browse templates list` and verify 8-char IDs appear
- [ ] Run `grans browse calendars list` and verify 8-char IDs appear
- [ ] Copy an 8-char ID from list output and use it with `show` — verify it resolves correctly
- [ ] Verify `--help` text for each show command describes ID as an option
- [ ] Run `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)