### PR TITLE
Set 1-day retention on release build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           name: grans-linux-x86_64
           path: target/ci-release/grans
+          retention-days: 1
 
   build-macos:
     name: Build macOS
@@ -89,6 +90,7 @@ jobs:
         with:
           name: grans-macos-aarch64
           path: target/aarch64-apple-darwin/ci-release/grans
+          retention-days: 1
 
   build-windows:
     name: Build Windows
@@ -114,6 +116,7 @@ jobs:
         with:
           name: grans-windows-x86_64.exe
           path: target/x86_64-pc-windows-msvc/ci-release/grans.exe
+          retention-days: 1
 
   release:
     name: Create Release


### PR DESCRIPTION
## Summary
- Add `retention-days: 1` to the three `upload-artifact` steps in `release.yml` (linux, macOS, windows builds).
- These artifacts are pass-through between the build jobs and the `release` job in the same workflow run. Once `release` uploads the binaries to the GitHub Release, they're no longer needed.

## Why
Without an explicit retention, uploads default to 90 days. A parallel cleanup on the original `grans` repo (which shared this workflow) had accumulated ~3.5 GB of live artifacts across ~100 release runs and pushed the account over its 2 GB Actions storage allowance. This PR prevents the same accumulation here.

GitHub Release assets are stored separately from Actions artifacts and are unaffected by this change.

## Test plan
- [ ] Next release run completes successfully (release job can still download the artifacts from the preceding build jobs in the same run).
- [ ] Artifacts auto-expire within a day after the run.