### PR TITLE
Decrypt Granola's encrypted token store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,7 +444,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -781,9 +836,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "grans"
 version = "0.0.0-dev"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "assert_cmd",
  "base64 0.22.1",
@@ -810,6 +876,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1123,6 +1190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,6 +1588,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2492,6 +2586,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ open = "5"
 self-replace = "1.5"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["color"] }
+aes-gcm = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2.1.2"
@@ -43,3 +44,6 @@ tempfile = "3"
 [profile.ci-release]
 inherits = "release"
 codegen-units = 4   # More parallelism (release default is 1)
+
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Security_Cryptography", "Win32_Foundation"] }

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ grans sync panels --limit 10          # Fetch panels for up to 10 documents
 grans sync panels --retry             # Retry previously failed panel fetches
 ```
 
-**Note:** Sync requires a Granola auth token. By default, it reads the token from Granola's local config file. You can also provide a token explicitly with `--token`:
+**Note:** Sync requires a Granola auth token. By default, it reads the token from Granola's local config, transparently decrypting the `supabase.json.enc` store that recent Granola versions use (falling back to the legacy plaintext `supabase.json`). You can also provide a token explicitly with `--token`:
 
 ```bash
 grans --token <TOKEN> sync

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -281,7 +281,7 @@ flowchart LR
 ```
 
 The `grans sync` command:
-1. Authenticates using the token from Granola's `supabase.json` config
+1. Authenticates using the token from Granola's local config (the encrypted `supabase.json.enc` store on recent versions, or the legacy plaintext `supabase.json`)
 2. Fetches data from Granola API endpoints (`get-documents`, `get-people`, etc.)
 3. Upserts records into the local SQLite database
 4. Tracks last sync time per entity type in the `metadata` table

--- a/scripts/granola-token.py
+++ b/scripts/granola-token.py
@@ -1,0 +1,177 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["cryptography"]
+# ///
+"""Prototype: decrypt Granola's encrypted local token store on Windows.
+
+Granola (an Electron app) now stores its Supabase auth token in an encrypted
+`supabase.json.enc` file instead of the old plaintext `supabase.json`. The
+encryption is the standard Chromium/Electron `os_crypt` + safeStorage scheme:
+
+    Local State -> os_crypt.encrypted_key  (DPAPI-wrapped AES-256 master key)
+    storage.dek                            (master-key-encrypted data key)
+    supabase.json.enc                      (data-key-encrypted token JSON)
+
+DPAPI ties the master key to the current Windows user, so any process running
+as that user (including this script and, eventually, grans) can decrypt it.
+
+Usage:
+    uv run scripts/granola-token.py           # verbose: report format + expiry
+    uv run scripts/granola-token.py --raw     # print only the token on stdout
+                                              #   e.g. grans sync --token "$(...)"
+
+Diagnostics always go to stderr, so --raw stdout is exactly the token.
+"""
+
+from __future__ import annotations
+
+import base64
+import ctypes
+import ctypes.wintypes as wt
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+def log(*args, **kwargs) -> None:
+    kwargs.setdefault("file", sys.stderr)
+    print(*args, **kwargs)
+
+
+def granola_dir() -> Path:
+    appdata = os.environ.get("APPDATA")
+    if not appdata:
+        sys.exit("APPDATA not set; this prototype is Windows-only.")
+    return Path(appdata) / "Granola"
+
+
+# --- DPAPI (CryptUnprotectData) via ctypes, no pywin32 dependency ----------
+
+
+class DATA_BLOB(ctypes.Structure):
+    _fields_ = [("cbData", wt.DWORD), ("pbData", ctypes.POINTER(ctypes.c_char))]
+
+
+def dpapi_decrypt(blob: bytes) -> bytes:
+    src = DATA_BLOB(len(blob), ctypes.cast(ctypes.c_char_p(blob), ctypes.POINTER(ctypes.c_char)))
+    out = DATA_BLOB()
+    ok = ctypes.windll.crypt32.CryptUnprotectData(
+        ctypes.byref(src), None, None, None, None, 0, ctypes.byref(out)
+    )
+    if not ok:
+        raise OSError(f"CryptUnprotectData failed (GetLastError={ctypes.get_last_error()})")
+    try:
+        return ctypes.string_at(out.pbData, out.cbData)
+    finally:
+        ctypes.windll.kernel32.LocalFree(out.pbData)
+
+
+# --- os_crypt key + AES-GCM helpers ----------------------------------------
+
+
+def master_key(g: Path) -> bytes:
+    local_state = json.loads((g / "Local State").read_text(encoding="utf-8"))
+    encrypted_key = base64.b64decode(local_state["os_crypt"]["encrypted_key"])
+    if encrypted_key[:5] != b"DPAPI":
+        raise ValueError(f"unexpected key prefix: {encrypted_key[:5]!r}")
+    key = dpapi_decrypt(encrypted_key[5:])
+    log(f"[master key] {len(key)} bytes")
+    return key
+
+
+def try_gcm(label: str, key: bytes, blob: bytes) -> bytes | None:
+    """Try several framings of an os_crypt-style GCM blob; return plaintext of
+    the first that authenticates, else None. The GCM auth tag guarantees a wrong
+    framing fails rather than returning garbage."""
+    hyps = [
+        ("strip 'v10', nonce=12", 3, 12),
+        ("strip 'v10;', nonce=12", 4, 12),
+        ("no prefix, nonce=12", 0, 12),
+    ]
+    aes = AESGCM(key)
+    for name, prefix_len, nonce_len in hyps:
+        body = blob[prefix_len:]
+        nonce, ct_tag = body[:nonce_len], body[nonce_len:]
+        try:
+            pt = aes.decrypt(nonce, ct_tag, None)
+        except Exception:
+            continue
+        log(f"[{label}] framing OK: {name} -> {len(pt)} bytes plaintext")
+        return pt
+    log(f"[{label}] no framing authenticated (prefix={blob[:4]!r}, len={len(blob)})")
+    return None
+
+
+def maybe_b64(pt: bytes) -> bytes:
+    """The data key is stored as base64 text inside its GCM blob; token JSON is
+    not. Decode base64-looking plaintext, else pass through."""
+    stripped = pt.strip()
+    try:
+        decoded = base64.b64decode(stripped, validate=True)
+    except Exception:
+        return pt
+    if base64.b64encode(decoded) == stripped:
+        log(f"    (plaintext was base64 -> {len(decoded)} raw bytes)")
+        return decoded
+    return pt
+
+
+def extract_token(g: Path) -> str:
+    key = master_key(g)
+
+    dek_pt = try_gcm("storage.dek", key, (g / "storage.dek").read_bytes())
+    if dek_pt is None:
+        sys.exit("Could not decrypt storage.dek; framing hypotheses exhausted.")
+    data_key = maybe_b64(dek_pt)
+    log(f"[data key] {len(data_key)} bytes")
+
+    token_pt = try_gcm("supabase.json.enc", data_key, (g / "supabase.json.enc").read_bytes())
+    if token_pt is None:
+        sys.exit("Could not decrypt supabase.json.enc with the data key.")
+
+    token_json = json.loads(token_pt)
+    wt_field = token_json.get("workos_tokens")
+    if isinstance(wt_field, str):
+        wt_field = json.loads(wt_field)
+    access_token = (wt_field or {}).get("access_token") if wt_field else None
+    if not access_token:
+        sys.exit("No access_token found in decrypted payload.")
+    return access_token
+
+
+def jwt_exp(token: str) -> int | None:
+    try:
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload_b64)).get("exp")
+    except Exception:
+        return None
+
+
+def main() -> None:
+    raw = "--raw" in sys.argv[1:]
+    g = granola_dir()
+    log(f"Granola dir: {g}")
+
+    access_token = extract_token(g)
+
+    if raw:
+        sys.stdout.write(access_token)
+        return
+
+    exp = jwt_exp(access_token)
+    print("\n=== access_token ===")
+    print(f"length: {len(access_token)}")
+    print(f"prefix: {access_token[:24]}...")
+    if exp is not None:
+        exp_dt = dt.datetime.fromtimestamp(exp)
+        status = "EXPIRED" if dt.datetime.now() > exp_dt else "valid"
+        print(f"expires: {exp_dt}  ({status})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,9 +1,11 @@
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use log::debug;
 use serde::Deserialize;
+
+use super::token_store;
 
 /// Structure representing the relevant parts of Granola's supabase.json
 #[derive(Debug, Deserialize)]
@@ -62,40 +64,65 @@ pub fn resolve_token(override_token: Option<&str>) -> Result<String> {
     }
 }
 
-/// Get the authentication token from Granola's supabase.json file
+/// Get the authentication token from Granola's local config.
+///
+/// Prefers the encrypted `supabase.json.enc` store used by recent Granola
+/// versions, falling back to the legacy plaintext `supabase.json`.
 pub fn get_auth_token() -> Result<String> {
-    let config_path = find_supabase_json()?;
+    let dir = find_granola_dir()?;
+    let json = read_token_json(&dir)?;
+    extract_access_token(&json, &dir)
+}
 
-    let content = std::fs::read_to_string(&config_path)
-        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+/// Read the raw token JSON from a Granola config directory, preferring the
+/// encrypted store and falling back to the legacy plaintext file.
+fn read_token_json(dir: &Path) -> Result<String> {
+    let encrypted = dir.join("supabase.json.enc");
+    if encrypted.exists() {
+        debug!("Reading encrypted token store at {}", encrypted.display());
+        return token_store::decrypt_token_json(dir).with_context(|| {
+            format!("Failed to read encrypted Granola token store in {}", dir.display())
+        });
+    }
 
-    let config: SupabaseConfig = serde_json::from_str(&content)
-        .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+    let plaintext = dir.join("supabase.json");
+    debug!("Reading plaintext token store at {}", plaintext.display());
+    std::fs::read_to_string(&plaintext)
+        .with_context(|| format!("Failed to read {}", plaintext.display()))
+}
+
+/// Parse the token JSON and extract a non-empty access token.
+fn extract_access_token(json: &str, dir: &Path) -> Result<String> {
+    let config: SupabaseConfig = serde_json::from_str(json)
+        .with_context(|| format!("Failed to parse Granola token JSON from {}", dir.display()))?;
 
     let token = config
         .workos_tokens
         .and_then(|t| t.access_token)
         .ok_or_else(|| anyhow::anyhow!(
-            "No access token found in {}. Please ensure you are logged into Granola.",
-            config_path.display()
+            "No access token found in Granola config at {}. Please ensure you are logged into Granola.",
+            dir.display()
         ))?;
 
     if token.is_empty() {
-        bail!("Access token is empty in {}. Please re-login to Granola.", config_path.display());
+        bail!("Access token is empty in Granola config at {}. Please re-login to Granola.", dir.display());
     }
 
-    debug!("Loaded auth token from {} ({} chars)", config_path.display(), token.len());
+    debug!("Loaded auth token ({} chars)", token.len());
     Ok(token)
 }
 
-/// Find the supabase.json file in platform-specific locations
-fn find_supabase_json() -> Result<PathBuf> {
-    let candidates = supabase_json_candidates();
-    debug!("Searching for supabase.json in {} locations", candidates.len());
+/// Find the Granola config directory in platform-specific locations. A
+/// directory qualifies if it contains either token store file.
+fn find_granola_dir() -> Result<PathBuf> {
+    let candidates = granola_dir_candidates();
+    debug!("Searching for Granola config in {} locations", candidates.len());
 
     for candidate in &candidates {
         debug!("  checking: {}", candidate.display());
-        if candidate.exists() {
+        if candidate.join("supabase.json.enc").exists()
+            || candidate.join("supabase.json").exists()
+        {
             debug!("  found: {}", candidate.display());
             return Ok(candidate.clone());
         }
@@ -146,57 +173,44 @@ fn wsl_windows_username() -> Option<String> {
     None
 }
 
-/// Get Windows-side supabase.json path candidates when running on WSL
-fn wsl_windows_supabase_candidates() -> Option<Vec<PathBuf>> {
+/// Get Windows-side Granola config directory candidates when running on WSL
+fn wsl_windows_granola_dirs() -> Option<Vec<PathBuf>> {
     let username = wsl_windows_username()?;
 
-    let mut candidates = Vec::new();
-
-    // Windows AppData Roaming path via WSL mount
-    let roaming_path = PathBuf::from(format!(
-        "/mnt/c/Users/{}/AppData/Roaming/Granola/supabase.json",
-        username
-    ));
-    candidates.push(roaming_path);
-
-    // Also check Local AppData as a fallback
-    let local_path = PathBuf::from(format!(
-        "/mnt/c/Users/{}/AppData/Local/Granola/supabase.json",
-        username
-    ));
-    candidates.push(local_path);
-
-    Some(candidates)
+    Some(vec![
+        // Windows AppData Roaming path via WSL mount
+        PathBuf::from(format!("/mnt/c/Users/{}/AppData/Roaming/Granola", username)),
+        // Also check Local AppData as a fallback
+        PathBuf::from(format!("/mnt/c/Users/{}/AppData/Local/Granola", username)),
+    ])
 }
 
-fn supabase_json_candidates() -> Vec<PathBuf> {
+fn granola_dir_candidates() -> Vec<PathBuf> {
     let mut candidates = Vec::new();
 
     // WSL: Check Windows paths first (higher priority)
     if is_wsl() {
-        if let Some(windows_paths) = wsl_windows_supabase_candidates() {
+        if let Some(windows_paths) = wsl_windows_granola_dirs() {
             candidates.extend(windows_paths);
         }
     }
 
     if let Some(home) = dirs_home() {
         // macOS
-        candidates.push(
-            home.join("Library/Application Support/Granola/supabase.json"),
-        );
+        candidates.push(home.join("Library/Application Support/Granola"));
 
         // Linux / WSL fallback
-        candidates.push(home.join(".config/Granola/supabase.json"));
+        candidates.push(home.join(".config/Granola"));
 
         // XDG
         if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
-            candidates.push(PathBuf::from(xdg).join("Granola/supabase.json"));
+            candidates.push(PathBuf::from(xdg).join("Granola"));
         }
     }
 
     // Windows (native)
     if let Ok(appdata) = env::var("APPDATA") {
-        candidates.push(PathBuf::from(appdata).join("Granola/supabase.json"));
+        candidates.push(PathBuf::from(appdata).join("Granola"));
     }
 
     candidates
@@ -277,15 +291,14 @@ mod tests {
     }
 
     #[test]
-    fn test_wsl_windows_supabase_candidates() {
+    fn test_wsl_windows_granola_dirs() {
         // Test that the function returns paths in the expected format
         // Even if we can't determine the username, it should not panic
-        if let Some(candidates) = wsl_windows_supabase_candidates() {
+        if let Some(candidates) = wsl_windows_granola_dirs() {
             for path in &candidates {
                 let path_str = path.to_string_lossy();
                 assert!(
-                    path_str.contains("/mnt/c/Users/")
-                        && path_str.contains("Granola/supabase.json")
+                    path_str.contains("/mnt/c/Users/") && path_str.ends_with("Granola")
                 );
             }
         }
@@ -312,9 +325,9 @@ mod tests {
     }
 
     #[test]
-    fn test_supabase_json_candidates_no_panic() {
-        // Ensure supabase_json_candidates doesn't panic
-        let candidates = supabase_json_candidates();
+    fn test_granola_dir_candidates_no_panic() {
+        // Ensure granola_dir_candidates doesn't panic
+        let candidates = granola_dir_candidates();
         // Should return at least some candidates
         assert!(!candidates.is_empty() || cfg!(target_os = "unknown"));
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,6 @@
 mod auth;
 pub mod client;
+mod token_store;
 pub mod types;
 
 pub use auth::{get_auth_token, resolve_token};

--- a/src/api/token_store.rs
+++ b/src/api/token_store.rs
@@ -1,0 +1,204 @@
+//! Decrypt Granola's encrypted local token store.
+//!
+//! Recent Granola versions no longer keep the Supabase auth token in a
+//! plaintext `supabase.json`. Instead they use the standard Chromium/Electron
+//! `os_crypt` + safeStorage scheme, with three layers:
+//!
+//! ```text
+//! Local State -> os_crypt.encrypted_key  (OS-wrapped AES-256 master key)
+//! storage.dek                            (master-key-encrypted data key)
+//! supabase.json.enc                      (data-key-encrypted token JSON)
+//! ```
+//!
+//! The master key is unwrapped by the OS credential store (DPAPI on Windows,
+//! keyed to the current user), so any process running as that user can decrypt
+//! the token without a password. Both inner layers are AES-256-GCM with a
+//! 12-byte nonce; the GCM auth tag makes a wrong framing fail loudly rather
+//! than returning garbage.
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
+use anyhow::{bail, Context, Result};
+use base64::Engine;
+use log::debug;
+use serde::Deserialize;
+use std::path::Path;
+
+const NONCE_LEN: usize = 12;
+
+#[derive(Deserialize)]
+struct LocalState {
+    os_crypt: OsCrypt,
+}
+
+#[derive(Deserialize)]
+struct OsCrypt {
+    encrypted_key: String,
+}
+
+/// Decrypt the Granola token store in `granola_dir` and return the raw JSON
+/// string that the plaintext `supabase.json` used to contain.
+pub fn decrypt_token_json(granola_dir: &Path) -> Result<String> {
+    let master = master_key(granola_dir)?;
+
+    let dek_blob = std::fs::read(granola_dir.join("storage.dek"))
+        .context("Failed to read storage.dek")?;
+    // storage.dek is a "v10"-prefixed os_crypt blob whose plaintext is the
+    // base64-encoded data key.
+    let dek_plaintext = gcm_open(&master, &dek_blob, 3).context("Failed to decrypt storage.dek")?;
+    let data_key = base64::engine::general_purpose::STANDARD
+        .decode(dek_plaintext.trim_ascii())
+        .context("storage.dek plaintext was not valid base64")?;
+
+    let token_blob = std::fs::read(granola_dir.join("supabase.json.enc"))
+        .context("Failed to read supabase.json.enc")?;
+    // supabase.json.enc carries no version prefix: nonce + ciphertext + tag.
+    let token_plaintext =
+        gcm_open(&data_key, &token_blob, 0).context("Failed to decrypt supabase.json.enc")?;
+
+    String::from_utf8(token_plaintext).context("Decrypted token payload was not valid UTF-8")
+}
+
+/// Read and OS-unwrap the AES-256 master key from Granola's `Local State`.
+fn master_key(granola_dir: &Path) -> Result<Vec<u8>> {
+    let content = std::fs::read_to_string(granola_dir.join("Local State"))
+        .context("Failed to read Local State")?;
+    let state: LocalState =
+        serde_json::from_str(&content).context("Failed to parse Local State")?;
+
+    let wrapped = base64::engine::general_purpose::STANDARD
+        .decode(&state.os_crypt.encrypted_key)
+        .context("os_crypt.encrypted_key was not valid base64")?;
+
+    let stripped = wrapped
+        .strip_prefix(b"DPAPI")
+        .context("os_crypt.encrypted_key missing expected 'DPAPI' prefix")?;
+
+    let key = os_unwrap(stripped)?;
+    debug!("Unwrapped os_crypt master key ({} bytes)", key.len());
+    Ok(key)
+}
+
+/// Decrypt an os_crypt-style AES-256-GCM blob laid out as
+/// `[prefix][12-byte nonce][ciphertext + 16-byte tag]`.
+fn gcm_open(key: &[u8], blob: &[u8], prefix_len: usize) -> Result<Vec<u8>> {
+    let body = blob
+        .get(prefix_len..)
+        .context("Encrypted blob shorter than its version prefix")?;
+    let (nonce, ciphertext) = body
+        .split_at_checked(NONCE_LEN)
+        .context("Encrypted blob too short to contain a nonce")?;
+
+    if key.len() != 32 {
+        bail!("AES-256 key must be 32 bytes, got {}", key.len());
+    }
+    let key = Key::<Aes256Gcm>::from_slice(key);
+    Aes256Gcm::new(key)
+        .decrypt(Nonce::from_slice(nonce), ciphertext)
+        .map_err(|_| anyhow::anyhow!("AES-GCM authentication failed (wrong key or corrupt data)"))
+}
+
+/// Unwrap a key blob using the OS credential store.
+#[cfg(windows)]
+fn os_unwrap(blob: &[u8]) -> Result<Vec<u8>> {
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Cryptography::{CryptUnprotectData, CRYPT_INTEGER_BLOB};
+
+    let mut input = CRYPT_INTEGER_BLOB {
+        cbData: blob.len() as u32,
+        pbData: blob.as_ptr() as *mut u8,
+    };
+    let mut output = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+
+    // SAFETY: `input` points at `blob` for the duration of the call; on success
+    // Windows allocates `output.pbData`, which we copy out and then LocalFree.
+    let ok = unsafe {
+        CryptUnprotectData(
+            &mut input,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            0,
+            &mut output,
+        )
+    };
+    if ok == 0 {
+        bail!("CryptUnprotectData failed; is Granola installed under this Windows user?");
+    }
+
+    // SAFETY: on success `output.pbData` is valid for `output.cbData` bytes.
+    let key = unsafe {
+        std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec()
+    };
+    // SAFETY: freeing the buffer Windows allocated for us.
+    unsafe { LocalFree(output.pbData as _) };
+    Ok(key)
+}
+
+#[cfg(not(windows))]
+fn os_unwrap(_blob: &[u8]) -> Result<Vec<u8>> {
+    bail!(
+        "Reading Granola's encrypted token store is currently implemented only on \
+         Windows. On this platform, pass a token explicitly with --token."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aes_gcm::aead::Aead;
+
+    /// Encrypt with the same framing Granola uses, so we can exercise gcm_open
+    /// without depending on the OS credential store.
+    fn seal(key: &[u8], nonce: &[u8], plaintext: &[u8], prefix: &[u8]) -> Vec<u8> {
+        let key = Key::<Aes256Gcm>::from_slice(key);
+        let ciphertext = Aes256Gcm::new(key)
+            .encrypt(Nonce::from_slice(nonce), plaintext)
+            .unwrap();
+        [prefix, nonce, &ciphertext].concat()
+    }
+
+    #[test]
+    fn gcm_open_round_trips_with_v10_prefix() {
+        let key = [7u8; 32];
+        let nonce = [3u8; NONCE_LEN];
+        let blob = seal(&key, &nonce, b"the data key", b"v10");
+
+        let out = gcm_open(&key, &blob, 3).unwrap();
+        assert_eq!(out, b"the data key");
+    }
+
+    #[test]
+    fn gcm_open_round_trips_without_prefix() {
+        let key = [9u8; 32];
+        let nonce = [1u8; NONCE_LEN];
+        let blob = seal(&key, &nonce, b"{\"workos_tokens\":{}}", b"");
+
+        let out = gcm_open(&key, &blob, 0).unwrap();
+        assert_eq!(out, b"{\"workos_tokens\":{}}");
+    }
+
+    #[test]
+    fn gcm_open_rejects_wrong_key() {
+        let nonce = [1u8; NONCE_LEN];
+        let blob = seal(&[9u8; 32], &nonce, b"secret", b"");
+
+        let result = gcm_open(&[0u8; 32], &blob, 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn gcm_open_rejects_short_blob() {
+        assert!(gcm_open(&[0u8; 32], b"v10short", 3).is_err());
+    }
+
+    #[test]
+    fn gcm_open_rejects_bad_key_length() {
+        let blob = seal(&[9u8; 32], &[1u8; NONCE_LEN], b"x", b"");
+        assert!(gcm_open(&[0u8; 16], &blob, 0).is_err());
+    }
+}


### PR DESCRIPTION
## Problem

Sync stopped working entirely: every endpoint returned `401 Authentication failed`.

Root cause is a change on Granola's side, not a regression in grans. Recent Granola versions **stopped refreshing the plaintext `supabase.json`** and now keep the auth token only in an encrypted `supabase.json.enc`. grans kept reading the stale plaintext file, whose token had expired months earlier, so it handed the API a long-dead token on every request.

Granola encrypts the token with the standard Chromium/Electron `os_crypt` + safeStorage scheme, three layers deep:

```
Local State -> os_crypt.encrypted_key   (OS-wrapped AES-256 master key)
storage.dek                             (master-key-encrypted data key)
supabase.json.enc                       (data-key-encrypted token JSON)
```

The master key is unwrapped by the OS credential store (DPAPI on Windows), keyed to the current user, so any process running as that user can decrypt it without a password. This is exactly the model that lets grans read the user's own token locally, as it always has.

## Change

- New `src/api/token_store.rs`: unwraps the `os_crypt` master key via DPAPI, AES-256-GCM decrypts `storage.dek` to recover the data key, then decrypts `supabase.json.enc`. AES-GCM's auth tag means a wrong framing fails loudly rather than returning garbage.
- `src/api/auth.rs`: now resolves the Granola **config directory** and prefers the encrypted store, falling back to the legacy plaintext `supabase.json` for older installs. This also fixes `grans admin token`, which shares the same auth path.
- Windows is implemented. macOS (Keychain) and Linux (libsecret) master-key sources return a clear error pointing at `--token` until they are added.
- `scripts/granola-token.py`: a standalone reference/debug tool that performs the same decryption and documents the exact file format (mirrors `scripts/granola-api.py`).

## Verification

The full `grans sync` was restored end-to-end with a decrypted token (185 documents, 51 events, recipes, etc.). Because the local full-binary build is blocked by an unrelated ONNX Runtime / MSVC linker mismatch, the Rust `token_store` code was additionally compiled and run directly against the live Granola files in a standalone harness, decrypting to the same valid token the API accepts. Unit tests cover the GCM framing (both the `v10`-prefixed and prefix-less layouts) and the error paths, and run in CI on Linux where the ONNX linker issue does not occur.

## Notes

Granola encrypts `granola.db` too (SQLCipher-style), so any future feature that wants to read meeting content from the local DB rather than the API is a separate decryption problem. Out of scope here; API-based sync is fully restored.