### PR TITLE
#38: Retriever-agnostic benchmark harness with ID-based matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ grans uses a task-centric CLI design. Common tasks are promoted to top-level com
 **Admin Commands** (maintenance):
 - `admin db` - Database management (clear, info, list)
 - `admin token` - Print the current Granola API token
-- `benchmark quality` - Measure semantic search quality against a test suite
+- `benchmark quality` - Measure search quality (FTS or semantic) against a labeled test suite
 
 ### Sync
 
@@ -542,42 +542,57 @@ grans update --check
 
 ### Benchmark Quality
 
-Measure semantic search quality against a suite of queries with known expected results. The suite is a JSON file you author, since the expected results are the exact titles of meetings in your own database:
+Measure search quality against a suite of queries with known expected results. The suite is a JSON file you author against your own database:
 
 ```json
 {
-  "description": "My semantic search suite",
+  "description": "My search quality suite",
   "queries": [
     {
       "query": "what did we decide about the API redesign",
+      "query_type": "paraphrase",
       "relevant_meetings": ["Architecture Sync", "API v2 Planning"],
-      "rationale": "Paraphrase query; both meetings covered the decision"
+      "relevant_meeting_ids": ["abc123", "def456"],
+      "rationale": "Both meetings covered the decision"
     }
   ]
 }
 ```
 
-Each query lists the meeting titles that should appear in the results (`relevant_meetings` are matched exactly against titles); `rationale` is a free-text note for your own reference.
+Results are matched to labels by document ID when `relevant_meeting_ids` is present, otherwise by exact title against `relevant_meetings` (ID matching is preferred; recurring meetings often share one title, which over-credits title matching). `query_type` is an optional stratum label (for example `exact-term`, `paraphrase`, `mixed`); when present, the report includes a per-stratum breakdown. `rationale` is a free-text note for your own reference.
 
 ```bash
-# Run benchmark with default settings (precision@10)
+# Score semantic search (the default mode) at k=10
 grans benchmark quality --file my-benchmark.json
 
-# Check top 5 results (precision@5)
+# Score keyword (FTS) search instead
+grans benchmark quality --file my-benchmark.json --mode fts
+
+# Compare modes: per-query rank table plus win/loss/tie summary
+grans benchmark quality --file my-benchmark.json --compare fts,semantic
+
+# Check top 5 results
 grans benchmark quality --file my-benchmark.json --k 5
 
 # Show detailed results for each query
 grans benchmark quality --file my-benchmark.json --detail
+
+# Append the run to the results ledger (ledger.jsonl in the benchmarks
+# directory, with full per-query output under runs/)
+grans benchmark quality --file my-benchmark.json --record --note "baseline"
 ```
 
 The benchmark reports:
-- **Precision@k**: Percentage of queries where an expected meeting appears in the top k results
-- **Mean Reciprocal Rank (MRR)**: Average of 1/rank for found matches (measures how high expected results appear)
+- **hit-rate@k**: Percentage of queries where an expected meeting appears in the top k results
+- **recall@k**: Fraction of each query's expected meetings found in the top k, averaged over queries
+- **MRR@k**: Average of 1/rank of the first relevant result (0 when it falls outside the top k)
+- **Latency**: Average and median per-query search time for the mode
 
 This is useful for:
+- Comparing keyword and semantic retrieval on the same suite
 - Testing chunking strategy changes
 - Evaluating embedding model updates
-- Comparing semantic search performance across database versions
+- Comparing search performance across database versions
 
 Use the `--db` flag to benchmark against a different database file without affecting your main database:
 

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -48,20 +48,20 @@ v2 schema: top-level `{description, created, queries}`; each query is
 `{query, query_type, provenance, relevant_meetings, relevant_meeting_ids, rationale}`
 where `query_type` is `exact-term|paraphrase|mixed`, `provenance` is `v1|v2`, `relevant_meetings` holds exact titles, and `relevant_meeting_ids` holds document IDs. Since Phase 0 (#38) the harness matches by `relevant_meeting_ids` and stratifies by `query_type`; title matching remains only as the fallback for files without IDs (the v1 set).
 
-Semantic baseline on v2 (nomic-embed-text-v1.5, k=10, **title matching**):
+Phase 0 baselines on v2 (2026-07-10, k=10, **ID matching**, commit 046d6d6):
 
-| Stratum | n | hit-rate@10 | MRR |
-|---|---|---|---|
-| exact-term | 12 | 0.92 | 0.81 |
-| mixed | 43 | 0.86 | 0.77 |
-| paraphrase | 38 | 0.79 | 0.59 |
-| overall | 93 | 0.84 | 0.70 |
+| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
+|---|---|---|---|---|
+| fts | 0.05 | 0.03 | 0.04 | ~5 ms |
+| semantic | 0.86 | 0.76 | 0.72 | ~58 ms |
 
-(v1-file baseline for reference: hit-rate@10 ~73%, MRR ~0.55.)
+Semantic per stratum (hit-rate / MRR): exact-term 0.92 / 0.81, mixed 0.86 / 0.77, paraphrase 0.84 / 0.64. FTS beats semantic on best rank for 1 of 93 queries (90 losses, 2 ties); its collapse outside exact-term is the phrase-quoting bug plus recency-only ordering, which Phase 1 addresses. Full per-stratum metrics for both modes are in the ledger.
+
+(v1-file baseline for reference: hit-rate@10 ~73%, MRR ~0.55, title matching.)
 
 Caveats a maintainer must know:
 
-- These numbers were measured with title matching, which over-credits recurring-title meetings. After switching to ID-based matching (Phase 0), re-record the baseline; do not compare ID-matched numbers against this table.
+- Ledger entries recorded before 2026-07-10 used title matching, which over-credits recurring-title meetings; do not compare them against ID-matched numbers.
 - `query_type` labels were assigned relative to the current phrase-matching keyword behavior: several queries were demoted from exact-term to mixed only because the full query fails as a phrase. After Phase 1 lands implicit-AND semantics, re-audit the strata; the exact-term stratum (n=12) is currently thin and noisy.
 - For stable numbers across syncs, benchmark against a frozen copy of the database via the global `--db` flag rather than the live one.
 - Open review items: the 11 v1 queries' `query_type` values were hand-assigned and unreviewed, and two v1 queries ("AI phone agent...", "changing an intermittent caregiving leave...") had their ID labels expanded across recurring-title instances that may over-include.

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -7,7 +7,7 @@ A staged plan to evolve `grans search` from two separate modes (FTS5 keyword, se
 - **Keyword search**: FTS5 `MATCH` used as a boolean filter; results ordered by `created_at DESC`. No relevance ranking. Additionally, `sanitize_fts_query` wraps the whole query in double quotes, which FTS5 interprets as a phrase query: multi-word searches only match the words adjacent and in order, not AND semantics.
 - **Semantic search** (`--semantic`): nomic-embed-text-v1.5 (768d) via fastembed, brute-force cosine over in-memory vectors, `min_score` cutoff. Chunkers for transcripts (adaptive window), panels (section), notes (paragraph).
 - The two modes are mutually exclusive; `commands/search.rs` dispatches to one or the other.
-- **Evaluation**: `grans benchmark quality --file <golden-set.json>` scores the semantic pipeline only (hardcoded in `commands/benchmark.rs`) and matches results to labels by exact title. See "Golden set" below for the dataset and baselines. No FTS baseline exists yet.
+- **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. Implemented in `commands/benchmark/`.
 
 ## Target pipeline
 
@@ -33,7 +33,7 @@ Every phase below ships with a before/after run of the quality benchmark, and th
    - no query whose first relevant result currently ranks in the top 3 falls out of the top k.
    One catastrophic regression outweighs several mild improvements.
 3. **Strata.** Golden-set queries carry a `query_type` label (`exact-term`, `paraphrase`, `mixed`). Success reads as: hybrid ≈ FTS on exact-term, hybrid ≈ semantic on paraphrase, hybrid ≥ both on mixed.
-4. **Results ledger.** Each benchmark run is appended to a dated ledger file kept next to the golden set (outside the repo): commit hash, mode, metrics, latency, notes. Trends stay visible across months.
+4. **Results ledger.** Each benchmark run is appended to a dated ledger file kept next to the golden set (outside the repo): commit hash, mode, metrics, latency, notes. `benchmark quality --record` does this automatically. Trends stay visible across months.
 5. **Failures feed the suite.** Any real-world search that returns bad results becomes a new labeled query in the golden set. The suite gets more trustworthy exactly where it was wrong.
 6. **Escape hatches stay.** `--keyword` and `--semantic` remain after hybrid becomes the default, so a missed regression is recoverable and diagnosable (run the same query in all three modes).
 
@@ -46,7 +46,7 @@ Golden-set files live in the `benchmarks/` subdirectory of the grans data direct
 
 v2 schema: top-level `{description, created, queries}`; each query is
 `{query, query_type, provenance, relevant_meetings, relevant_meeting_ids, rationale}`
-where `query_type` is `exact-term|paraphrase|mixed`, `provenance` is `v1|v2`, `relevant_meetings` holds exact titles (what the current harness matches on), and `relevant_meeting_ids` holds document IDs (what ID-based matching should use). The current harness ignores the extra fields, so v2 runs on the existing binary.
+where `query_type` is `exact-term|paraphrase|mixed`, `provenance` is `v1|v2`, `relevant_meetings` holds exact titles, and `relevant_meeting_ids` holds document IDs. Since Phase 0 (#38) the harness matches by `relevant_meeting_ids` and stratifies by `query_type`; title matching remains only as the fallback for files without IDs (the v1 set).
 
 Semantic baseline on v2 (nomic-embed-text-v1.5, k=10, **title matching**):
 

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -63,7 +63,7 @@ Caveats a maintainer must know:
 
 - Ledger entries recorded before 2026-07-10 used title matching, which over-credits recurring-title meetings; do not compare them against ID-matched numbers.
 - `query_type` labels were assigned relative to the current phrase-matching keyword behavior: several queries were demoted from exact-term to mixed only because the full query fails as a phrase. After Phase 1 lands implicit-AND semantics, re-audit the strata; the exact-term stratum (n=12) is currently thin and noisy.
-- For stable numbers across syncs, benchmark against a frozen copy of the database via the global `--db` flag rather than the live one.
+- For stable numbers across syncs, benchmark against the frozen snapshot rather than the live database: `grans --db <benchmarks-dir>/grans-snapshot-2026-07-09.db benchmark quality ...`. The snapshot is byte-identical to the state the Phase 0 baselines were recorded against (872 docs, 33,510 chunks); the live database drifts with every `grans sync`, which invalidates per-query comparison against earlier ledger entries.
 - Open review items: the 11 v1 queries' `query_type` values were hand-assigned and unreviewed, and two v1 queries ("AI phone agent...", "changing an intermittent caregiving leave...") had their ID labels expanded across recurring-title instances that may over-include.
 
 ## Phases

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -280,15 +280,23 @@ pub enum BenchmarkAction {
         min_score: f32,
     },
 
-    /// Run semantic search quality benchmark against test suite
+    /// Run search quality benchmark against a labeled golden set
     Quality {
         /// Path to benchmark JSON file
         #[arg(long)]
         file: std::path::PathBuf,
 
-        /// Number of top results to check for expected matches (precision@k)
+        /// Number of top results scored (hit-rate@k, recall@k, MRR@k)
         #[arg(long, default_value = "10")]
         k: usize,
+
+        /// Search mode to benchmark
+        #[arg(long, value_enum, default_value = "semantic", conflicts_with = "compare")]
+        mode: QualityMode,
+
+        /// Compare modes: per-query rank table plus win/loss/tie summary
+        #[arg(long, value_enum, value_delimiter = ',', num_args = 2..)]
+        compare: Vec<QualityMode>,
 
         /// Show detailed results for each query
         #[arg(long)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -294,8 +294,9 @@ pub enum BenchmarkAction {
         #[arg(long, value_enum, default_value = "semantic", conflicts_with = "compare")]
         mode: QualityMode,
 
-        /// Compare modes: per-query rank table plus win/loss/tie summary
-        #[arg(long, value_enum, value_delimiter = ',', num_args = 2..)]
+        /// Compare modes, e.g. fts,semantic: per-query rank table plus
+        /// win/loss/tie summary
+        #[arg(long, value_enum, value_delimiter = ',')]
         compare: Vec<QualityMode>,
 
         /// Show detailed results for each query
@@ -549,6 +550,63 @@ mod tests {
     #[test]
     fn verify_cli() {
         Cli::command().debug_assert();
+    }
+
+    fn quality_compare(cli: &Cli) -> &[QualityMode] {
+        match &cli.command {
+            Commands::Benchmark {
+                action: BenchmarkAction::Quality { compare, .. },
+            } => compare,
+            _ => panic!("expected benchmark quality subcommand"),
+        }
+    }
+
+    #[test]
+    fn benchmark_quality_compare_accepts_comma_separated_modes() {
+        let cli = Cli::try_parse_from([
+            "grans",
+            "benchmark",
+            "quality",
+            "--file",
+            "golden.json",
+            "--compare",
+            "fts,semantic",
+        ])
+        .unwrap();
+        assert_eq!(
+            quality_compare(&cli),
+            &[QualityMode::Fts, QualityMode::Semantic]
+        );
+    }
+
+    #[test]
+    fn benchmark_quality_mode_conflicts_with_compare() {
+        let result = Cli::try_parse_from([
+            "grans",
+            "benchmark",
+            "quality",
+            "--file",
+            "golden.json",
+            "--mode",
+            "fts",
+            "--compare",
+            "fts,semantic",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn benchmark_quality_note_requires_record() {
+        let result = Cli::try_parse_from([
+            "grans",
+            "benchmark",
+            "quality",
+            "--file",
+            "golden.json",
+            "--note",
+            "some note",
+        ]);
+        assert!(result.is_err());
     }
 
     fn transcripts_action(cli: &Cli) -> &SyncAction {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -301,6 +301,15 @@ pub enum BenchmarkAction {
         /// Show detailed results for each query
         #[arg(long)]
         detail: bool,
+
+        /// Append results to the ledger and save per-query output under runs/
+        /// (both in the benchmarks directory next to the golden set)
+        #[arg(long)]
+        record: bool,
+
+        /// Note stored with the ledger entry
+        #[arg(long, requires = "record")]
+        note: Option<String>,
     },
 }
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::models::SpeakerFilter;
 
@@ -235,6 +235,25 @@ pub enum Commands {
 }
 
 // === Benchmark Subcommands ===
+
+/// Search mode measured by the quality benchmark. New modes appear here as
+/// the hybrid pipeline phases land.
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QualityMode {
+    /// FTS5 keyword search (current production behavior)
+    Fts,
+    /// Semantic search over embeddings
+    Semantic,
+}
+
+impl QualityMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            QualityMode::Fts => "fts",
+            QualityMode::Semantic => "semantic",
+        }
+    }
+}
 
 #[derive(Subcommand, Debug)]
 pub enum BenchmarkAction {

--- a/src/commands/benchmark/ledger.rs
+++ b/src/commands/benchmark/ledger.rs
@@ -1,0 +1,247 @@
+//! Results ledger: persist quality benchmark runs next to the golden set.
+//!
+//! Each recorded run appends one JSON line to `ledger.jsonl` in the
+//! benchmarks directory and writes the full per-query output under `runs/`,
+//! so capture does not depend on remembering to do it by hand.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use super::metrics::AggregateMetrics;
+use super::quality::{LatencyStats, ModeRun};
+
+/// Run-independent context for recording: where, when, and what was measured.
+pub(super) struct RecordContext<'a> {
+    pub benchmarks_dir: &'a Path,
+    /// Run date, YYYY-MM-DD.
+    pub date: &'a str,
+    /// Golden-set file name.
+    pub set: &'a str,
+    /// Binary version string.
+    pub binary: &'a str,
+    /// Database the queries ran against.
+    pub db: &'a str,
+    pub note: Option<&'a str>,
+}
+
+/// One line in ledger.jsonl.
+#[derive(Serialize)]
+struct LedgerEntry<'a> {
+    date: &'a str,
+    set: &'a str,
+    mode: &'a str,
+    matching: &'a str,
+    k: usize,
+    queries: usize,
+    hit_rate_at_k: f64,
+    recall_at_k: f64,
+    mrr: f64,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    strata: &'a BTreeMap<String, AggregateMetrics>,
+    latency_ms: &'a LatencyStats,
+    binary: &'a str,
+    db: &'a str,
+    /// Path of the full per-query output, relative to the benchmarks dir.
+    per_query_results: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    notes: Option<&'a str>,
+}
+
+/// Full per-query output saved under runs/.
+#[derive(Serialize)]
+struct RunFile<'a> {
+    date: &'a str,
+    set: &'a str,
+    binary: &'a str,
+    db: &'a str,
+    #[serde(flatten)]
+    run: &'a ModeRun,
+}
+
+/// Record one mode's run: write the per-query output under `runs/` and
+/// append a summary line to `ledger.jsonl`. Returns the run-file path.
+pub(super) fn record_run(ctx: &RecordContext, run: &ModeRun) -> Result<PathBuf> {
+    let runs_dir = ctx.benchmarks_dir.join("runs");
+    fs::create_dir_all(&runs_dir)
+        .with_context(|| format!("Failed to create runs directory: {}", runs_dir.display()))?;
+
+    let set_stem = Path::new(ctx.set)
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "set".to_string());
+    let base = format!("{}-{}-{}-{}", ctx.date, run.mode, run.matching, set_stem);
+
+    let run_file = RunFile {
+        date: ctx.date,
+        set: ctx.set,
+        binary: ctx.binary,
+        db: ctx.db,
+        run,
+    };
+    let (run_path, rel_path) = write_unique(&runs_dir, &base, &serde_json::to_string_pretty(&run_file)?)?;
+
+    let entry = LedgerEntry {
+        date: ctx.date,
+        set: ctx.set,
+        mode: run.mode,
+        matching: run.matching,
+        k: run.k,
+        queries: run.overall.n,
+        hit_rate_at_k: run.overall.hit_rate_at_k,
+        recall_at_k: run.overall.recall_at_k,
+        mrr: run.overall.mrr,
+        strata: &run.strata,
+        latency_ms: &run.latency,
+        binary: ctx.binary,
+        db: ctx.db,
+        per_query_results: rel_path,
+        notes: ctx.note,
+    };
+    append_ledger_line(&ctx.benchmarks_dir.join("ledger.jsonl"), &entry)?;
+
+    Ok(run_path)
+}
+
+/// Create `<base>.json` in `dir`, appending `-2`, `-3`, ... when a same-named
+/// file already exists. Uses create_new so a concurrent run cannot clobber.
+/// Returns the full path and the path relative to the benchmarks dir
+/// (`runs/<name>.json`).
+fn write_unique(dir: &Path, base: &str, content: &str) -> Result<(PathBuf, String)> {
+    for attempt in 1..1000 {
+        let name = if attempt == 1 {
+            format!("{}.json", base)
+        } else {
+            format!("{}-{}.json", base, attempt)
+        };
+        let path = dir.join(&name);
+        match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                file.write_all(content.as_bytes())
+                    .with_context(|| format!("Failed to write run file: {}", path.display()))?;
+                return Ok((path, format!("runs/{}", name)));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("Failed to create run file: {}", path.display()))
+            }
+        }
+    }
+    anyhow::bail!("Could not find a free run-file name for {}", base);
+}
+
+fn append_ledger_line(ledger_path: &Path, entry: &LedgerEntry) -> Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(ledger_path)
+        .with_context(|| format!("Failed to open ledger: {}", ledger_path.display()))?;
+    let line = serde_json::to_string(entry)?;
+    writeln!(file, "{}", line)
+        .with_context(|| format!("Failed to append to ledger: {}", ledger_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::benchmark::metrics::AggregateMetrics;
+
+    fn test_run(mode: &'static str) -> ModeRun {
+        ModeRun {
+            mode,
+            matching: "id",
+            k: 10,
+            overall: AggregateMetrics {
+                n: 2,
+                queries_with_match: 1,
+                hit_rate_at_k: 0.5,
+                recall_at_k: 0.25,
+                mrr: 0.5,
+            },
+            strata: BTreeMap::new(),
+            latency: LatencyStats {
+                avg_ms: 12.5,
+                p50_ms: 11.0,
+            },
+            query_results: Vec::new(),
+        }
+    }
+
+    fn test_ctx(dir: &Path) -> RecordContext<'_> {
+        RecordContext {
+            benchmarks_dir: dir,
+            date: "2026-07-11",
+            set: "golden.json",
+            binary: "grans dev",
+            db: "C:/data/grans.db",
+            note: Some("test note"),
+        }
+    }
+
+    #[test]
+    fn record_run_appends_ledger_line_and_writes_run_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(dir.path());
+        let run = test_run("fts");
+
+        let run_path = record_run(&ctx, &run).unwrap();
+
+        assert!(run_path.exists());
+        let run_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&run_path).unwrap()).unwrap();
+        assert_eq!(run_json["mode"], "fts");
+        assert_eq!(run_json["date"], "2026-07-11");
+        assert_eq!(run_json["set"], "golden.json");
+
+        let ledger = fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+        let lines: Vec<&str> = ledger.lines().collect();
+        assert_eq!(lines.len(), 1);
+        let entry: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(entry["date"], "2026-07-11");
+        assert_eq!(entry["mode"], "fts");
+        assert_eq!(entry["matching"], "id");
+        assert_eq!(entry["k"], 10);
+        assert_eq!(entry["queries"], 2);
+        assert!((entry["hit_rate_at_k"].as_f64().unwrap() - 0.5).abs() < 1e-9);
+        assert!((entry["recall_at_k"].as_f64().unwrap() - 0.25).abs() < 1e-9);
+        assert_eq!(entry["notes"], "test note");
+        // Empty strata are omitted, matching hand-written v1 entries.
+        assert!(entry.get("strata").is_none());
+
+        // The ledger points at the run file, relative to the benchmarks dir.
+        let rel = entry["per_query_results"].as_str().unwrap();
+        assert!(dir.path().join(rel).exists());
+    }
+
+    #[test]
+    fn record_run_appends_without_clobbering() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = test_ctx(dir.path());
+
+        let path_a = record_run(&ctx, &test_run("fts")).unwrap();
+        let path_b = record_run(&ctx, &test_run("fts")).unwrap();
+
+        assert_ne!(path_a, path_b, "same-day same-mode runs must not overwrite");
+        let ledger = fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+        assert_eq!(ledger.lines().count(), 2);
+    }
+
+    #[test]
+    fn record_run_omits_missing_note() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = test_ctx(dir.path());
+        ctx.note = None;
+
+        record_run(&ctx, &test_run("semantic")).unwrap();
+
+        let ledger = fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
+        let entry: serde_json::Value = serde_json::from_str(ledger.lines().next().unwrap()).unwrap();
+        assert!(entry.get("notes").is_none());
+    }
+}

--- a/src/commands/benchmark/metrics.rs
+++ b/src/commands/benchmark/metrics.rs
@@ -1,0 +1,383 @@
+//! Pure scoring functions for the search quality benchmark.
+//!
+//! Retrievers produce a ranked, document-level list per query; these functions
+//! score that list against the query's relevance labels. Labels are matched by
+//! document ID when the golden set provides IDs, falling back to exact title
+//! for older files that only carry titles.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use serde::Serialize;
+
+/// A document in a retriever's ranked result list. One entry per document
+/// (retrievers dedupe chunk-level hits before scoring).
+#[derive(Debug, Clone)]
+pub struct RankedDoc {
+    pub document_id: String,
+    /// Relevance score, for retrievers that produce one (semantic). None for
+    /// modes with no ranking signal (FTS ordered by recency).
+    pub score: Option<f32>,
+}
+
+/// How a query's relevance labels are matched against result documents.
+pub enum LabelMatcher<'a> {
+    /// Match by document ID.
+    Ids(HashSet<&'a str>),
+    /// Match by exact title via a document-id-to-title map.
+    Titles {
+        titles: HashSet<&'a str>,
+        title_map: &'a HashMap<String, String>,
+    },
+}
+
+impl LabelMatcher<'_> {
+    /// The label (ID or title) a result document covers, or None if the
+    /// document is not relevant to the query.
+    pub fn label_for(&self, doc_id: &str) -> Option<&str> {
+        match self {
+            LabelMatcher::Ids(ids) => ids.get(doc_id).copied(),
+            LabelMatcher::Titles { titles, title_map } => title_map
+                .get(doc_id)
+                .and_then(|title| titles.get(title.as_str()).copied()),
+        }
+    }
+
+    /// Number of labels in the query's full label list.
+    pub fn label_count(&self) -> usize {
+        match self {
+            LabelMatcher::Ids(ids) => ids.len(),
+            LabelMatcher::Titles { titles, .. } => titles.len(),
+        }
+    }
+
+    /// Matching method name for reporting ("id" or "title").
+    pub fn method(&self) -> &'static str {
+        match self {
+            LabelMatcher::Ids(_) => "id",
+            LabelMatcher::Titles { .. } => "title",
+        }
+    }
+}
+
+/// Scores for a single query against a single retriever's ranked list.
+#[derive(Debug, Clone, Serialize)]
+pub struct QueryScore {
+    /// 1-indexed rank of the first relevant document over the full ranked
+    /// list (may exceed k).
+    pub best_rank: Option<usize>,
+    pub best_score: Option<f32>,
+    pub found_in_top_k: bool,
+    /// Distinct labels covered within the top k results.
+    pub labels_found_at_k: usize,
+    pub label_count: usize,
+    pub recall_at_k: f64,
+    /// 1/best_rank when the first relevant document is within the top k,
+    /// otherwise 0 (MRR@k).
+    pub reciprocal_rank: f64,
+}
+
+/// Score one query's ranked document list against its labels.
+///
+/// Precondition: the caller validates that the label list is non-empty.
+pub fn score_query(ranked: &[RankedDoc], matcher: &LabelMatcher, k: usize) -> QueryScore {
+    let mut best_rank: Option<usize> = None;
+    let mut best_score: Option<f32> = None;
+    let mut labels_covered: HashSet<&str> = HashSet::new();
+
+    for (i, doc) in ranked.iter().enumerate() {
+        if let Some(label) = matcher.label_for(&doc.document_id) {
+            if best_rank.is_none() {
+                best_rank = Some(i + 1);
+                best_score = doc.score;
+            }
+            if i < k {
+                labels_covered.insert(label);
+            }
+        }
+    }
+
+    let label_count = matcher.label_count();
+    let found_in_top_k = best_rank.is_some_and(|r| r <= k);
+
+    QueryScore {
+        best_rank,
+        best_score,
+        found_in_top_k,
+        labels_found_at_k: labels_covered.len(),
+        label_count,
+        recall_at_k: labels_covered.len() as f64 / label_count as f64,
+        reciprocal_rank: match best_rank {
+            Some(rank) if rank <= k => 1.0 / rank as f64,
+            _ => 0.0,
+        },
+    }
+}
+
+/// Aggregate metrics over a set of scored queries.
+#[derive(Debug, Clone, Serialize)]
+pub struct AggregateMetrics {
+    pub n: usize,
+    pub queries_with_match: usize,
+    pub hit_rate_at_k: f64,
+    pub recall_at_k: f64,
+    pub mrr: f64,
+}
+
+pub fn aggregate<'a>(scores: impl IntoIterator<Item = &'a QueryScore>) -> AggregateMetrics {
+    let scores: Vec<&QueryScore> = scores.into_iter().collect();
+    let n = scores.len();
+    let queries_with_match = scores.iter().filter(|s| s.found_in_top_k).count();
+    let recall_sum: f64 = scores.iter().map(|s| s.recall_at_k).sum();
+    let rr_sum: f64 = scores.iter().map(|s| s.reciprocal_rank).sum();
+
+    AggregateMetrics {
+        n,
+        queries_with_match,
+        hit_rate_at_k: queries_with_match as f64 / n as f64,
+        recall_at_k: recall_sum / n as f64,
+        mrr: rr_sum / n as f64,
+    }
+}
+
+/// Group scores by stratum name and aggregate each group. Queries without a
+/// stratum label should be passed as "unlabeled" by the caller.
+pub fn aggregate_by_stratum(strata: &[(&str, &QueryScore)]) -> BTreeMap<String, AggregateMetrics> {
+    let mut groups: BTreeMap<&str, Vec<&QueryScore>> = BTreeMap::new();
+    for (stratum, score) in strata {
+        groups.entry(stratum).or_default().push(score);
+    }
+    groups
+        .into_iter()
+        .map(|(stratum, scores)| (stratum.to_string(), aggregate(scores.into_iter())))
+        .collect()
+}
+
+/// Pairwise win/loss/tie between two modes' per-query best ranks.
+#[derive(Debug, Clone, Serialize)]
+pub struct WinLossTie {
+    pub wins: usize,
+    pub losses: usize,
+    pub ties: usize,
+}
+
+/// Compare per-query best ranks of mode A against mode B. A lower rank wins;
+/// a missing rank always loses to a present one; equal ranks (or both
+/// missing) tie. Slices must be index-aligned by query.
+pub fn compare_ranks(a: &[Option<usize>], b: &[Option<usize>]) -> WinLossTie {
+    debug_assert_eq!(a.len(), b.len());
+    let mut wlt = WinLossTie {
+        wins: 0,
+        losses: 0,
+        ties: 0,
+    };
+    for (ra, rb) in a.iter().zip(b) {
+        match (ra, rb) {
+            (Some(ra), Some(rb)) if ra < rb => wlt.wins += 1,
+            (Some(ra), Some(rb)) if ra > rb => wlt.losses += 1,
+            (Some(_), None) => wlt.wins += 1,
+            (None, Some(_)) => wlt.losses += 1,
+            _ => wlt.ties += 1,
+        }
+    }
+    wlt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ranked(ids: &[&str]) -> Vec<RankedDoc> {
+        ids.iter()
+            .map(|id| RankedDoc {
+                document_id: id.to_string(),
+                score: None,
+            })
+            .collect()
+    }
+
+    fn id_matcher<'a>(ids: &[&'a str]) -> LabelMatcher<'a> {
+        LabelMatcher::Ids(ids.iter().copied().collect())
+    }
+
+    #[test]
+    fn score_query_finds_first_relevant_by_id() {
+        let ranked = ranked(&["d1", "d2", "d3"]);
+        let matcher = id_matcher(&["d2", "d9"]);
+        let score = score_query(&ranked, &matcher, 10);
+
+        assert_eq!(score.best_rank, Some(2));
+        assert!(score.found_in_top_k);
+        assert_eq!(score.labels_found_at_k, 1);
+        assert_eq!(score.label_count, 2);
+        assert!((score.recall_at_k - 0.5).abs() < 1e-9);
+        assert!((score.reciprocal_rank - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn score_query_rank_beyond_k_is_reported_but_not_credited() {
+        let ranked = ranked(&["d1", "d2", "d3", "d4", "d5"]);
+        let matcher = id_matcher(&["d4"]);
+        let score = score_query(&ranked, &matcher, 3);
+
+        assert_eq!(score.best_rank, Some(4));
+        assert!(!score.found_in_top_k);
+        assert_eq!(score.labels_found_at_k, 0);
+        assert_eq!(score.recall_at_k, 0.0);
+        assert_eq!(score.reciprocal_rank, 0.0);
+    }
+
+    #[test]
+    fn score_query_no_match() {
+        let ranked = ranked(&["d1", "d2"]);
+        let matcher = id_matcher(&["d9"]);
+        let score = score_query(&ranked, &matcher, 10);
+
+        assert_eq!(score.best_rank, None);
+        assert!(!score.found_in_top_k);
+        assert_eq!(score.recall_at_k, 0.0);
+        assert_eq!(score.reciprocal_rank, 0.0);
+    }
+
+    #[test]
+    fn score_query_recall_counts_distinct_labels() {
+        let ranked = ranked(&["a", "b", "x", "y"]);
+        let matcher = id_matcher(&["a", "b", "c"]);
+        let score = score_query(&ranked, &matcher, 4);
+
+        assert_eq!(score.labels_found_at_k, 2);
+        assert!((score.recall_at_k - 2.0 / 3.0).abs() < 1e-9);
+        assert_eq!(score.best_rank, Some(1));
+        assert!((score.reciprocal_rank - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn score_query_propagates_best_score() {
+        let ranked = vec![
+            RankedDoc {
+                document_id: "d1".into(),
+                score: Some(0.9),
+            },
+            RankedDoc {
+                document_id: "d2".into(),
+                score: Some(0.8),
+            },
+        ];
+        let matcher = id_matcher(&["d2"]);
+        let score = score_query(&ranked, &matcher, 10);
+
+        assert_eq!(score.best_score, Some(0.8));
+    }
+
+    #[test]
+    fn title_matching_covers_one_label_across_recurring_docs() {
+        // Two documents share the "Weekly Sync" title (recurring meeting).
+        let title_map: HashMap<String, String> = [
+            ("d1".to_string(), "Weekly Sync".to_string()),
+            ("d2".to_string(), "Weekly Sync".to_string()),
+            ("d3".to_string(), "Planning".to_string()),
+        ]
+        .into();
+        let titles: HashSet<&str> = ["Weekly Sync"].into();
+        let matcher = LabelMatcher::Titles {
+            titles,
+            title_map: &title_map,
+        };
+
+        let ranked = ranked(&["d3", "d1", "d2"]);
+        let score = score_query(&ranked, &matcher, 3);
+
+        assert_eq!(score.best_rank, Some(2));
+        // Both d1 and d2 cover the same title label: counted once.
+        assert_eq!(score.labels_found_at_k, 1);
+        assert_eq!(score.label_count, 1);
+        assert!((score.recall_at_k - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn matcher_methods() {
+        let ids = id_matcher(&["a", "b"]);
+        assert_eq!(ids.method(), "id");
+        assert_eq!(ids.label_count(), 2);
+        assert_eq!(ids.label_for("a"), Some("a"));
+        assert_eq!(ids.label_for("z"), None);
+
+        let title_map: HashMap<String, String> =
+            [("d1".to_string(), "Weekly Sync".to_string())].into();
+        let titles = LabelMatcher::Titles {
+            titles: ["Weekly Sync"].into(),
+            title_map: &title_map,
+        };
+        assert_eq!(titles.method(), "title");
+        assert_eq!(titles.label_count(), 1);
+        assert_eq!(titles.label_for("d1"), Some("Weekly Sync"));
+        assert_eq!(titles.label_for("d2"), None);
+    }
+
+    fn qs(best_rank: Option<usize>, k: usize, recall: f64) -> QueryScore {
+        let found = best_rank.is_some_and(|r| r <= k);
+        QueryScore {
+            best_rank,
+            best_score: None,
+            found_in_top_k: found,
+            labels_found_at_k: 0,
+            label_count: 1,
+            recall_at_k: recall,
+            reciprocal_rank: if found {
+                1.0 / best_rank.unwrap() as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    #[test]
+    fn aggregate_means() {
+        let scores = vec![
+            qs(Some(1), 10, 1.0),
+            qs(Some(4), 10, 0.5),
+            qs(None, 10, 0.0),
+            qs(Some(20), 10, 0.0), // beyond k: no hit, no rr credit
+        ];
+        let agg = aggregate(&scores);
+
+        assert_eq!(agg.n, 4);
+        assert_eq!(agg.queries_with_match, 2);
+        assert!((agg.hit_rate_at_k - 0.5).abs() < 1e-9);
+        assert!((agg.recall_at_k - 0.375).abs() < 1e-9);
+        assert!((agg.mrr - (1.0 + 0.25) / 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn aggregate_by_stratum_groups() {
+        let a = qs(Some(1), 10, 1.0);
+        let b = qs(None, 10, 0.0);
+        let c = qs(Some(2), 10, 1.0);
+        let strata = vec![
+            ("exact-term", &a),
+            ("paraphrase", &b),
+            ("exact-term", &c),
+        ];
+        let by = aggregate_by_stratum(&strata);
+
+        assert_eq!(by.len(), 2);
+        let exact = &by["exact-term"];
+        assert_eq!(exact.n, 2);
+        assert_eq!(exact.queries_with_match, 2);
+        assert!((exact.mrr - 0.75).abs() < 1e-9);
+        let para = &by["paraphrase"];
+        assert_eq!(para.n, 1);
+        assert_eq!(para.queries_with_match, 0);
+    }
+
+    #[test]
+    fn compare_ranks_win_loss_tie() {
+        let a = vec![Some(1), Some(5), None, Some(3), None];
+        let b = vec![Some(2), Some(5), Some(9), None, None];
+        let wlt = compare_ranks(&a, &b);
+
+        // a wins q1 (1<2) and q4 (Some beats None); loses q3; ties q2 and q5.
+        assert_eq!(wlt.wins, 2);
+        assert_eq!(wlt.losses, 1);
+        assert_eq!(wlt.ties, 2);
+    }
+}

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -3,6 +3,7 @@
 mod metrics;
 mod perf;
 mod quality;
+mod retriever;
 
 use anyhow::Result;
 use rusqlite::Connection;

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -1,9 +1,12 @@
 //! Benchmark commands: search performance and quality measurement.
 
+mod ledger;
 mod metrics;
 mod perf;
 mod quality;
 mod retriever;
+
+use std::path::Path;
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -11,7 +14,12 @@ use rusqlite::Connection;
 use crate::cli::args::BenchmarkAction;
 use crate::output::format::OutputMode;
 
-pub fn run(conn: &Connection, action: &BenchmarkAction, output_mode: OutputMode) -> Result<()> {
+pub fn run(
+    conn: &Connection,
+    action: &BenchmarkAction,
+    db_path: Option<&Path>,
+    output_mode: OutputMode,
+) -> Result<()> {
     match action {
         BenchmarkAction::SemanticSearch {
             queries,
@@ -34,6 +42,8 @@ pub fn run(conn: &Connection, action: &BenchmarkAction, output_mode: OutputMode)
             mode,
             compare,
             detail,
+            record,
+            note,
         } => {
             let args = quality::QualityArgs {
                 file,
@@ -41,6 +51,9 @@ pub fn run(conn: &Connection, action: &BenchmarkAction, output_mode: OutputMode)
                 mode: *mode,
                 compare,
                 detail: *detail,
+                record: *record,
+                note: note.as_deref(),
+                db: db_path,
             };
             quality::run_quality_benchmark(conn, &args, output_mode)
         }

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -4,6 +4,7 @@ mod ledger;
 mod metrics;
 mod perf;
 mod quality;
+mod report;
 mod retriever;
 
 use std::path::Path;

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -28,8 +28,21 @@ pub fn run(conn: &Connection, action: &BenchmarkAction, output_mode: OutputMode)
             *min_score,
             output_mode,
         ),
-        BenchmarkAction::Quality { file, k, detail } => {
-            quality::run_quality_benchmark(conn, file, *k, *detail, output_mode)
+        BenchmarkAction::Quality {
+            file,
+            k,
+            mode,
+            compare,
+            detail,
+        } => {
+            let args = quality::QualityArgs {
+                file,
+                k: *k,
+                mode: *mode,
+                compare,
+                detail: *detail,
+            };
+            quality::run_quality_benchmark(conn, &args, output_mode)
         }
     }
 }

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -1,5 +1,6 @@
 //! Benchmark commands: search performance and quality measurement.
 
+mod metrics;
 mod perf;
 mod quality;
 

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -1,0 +1,33 @@
+//! Benchmark commands: search performance and quality measurement.
+
+mod perf;
+mod quality;
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::cli::args::BenchmarkAction;
+use crate::output::format::OutputMode;
+
+pub fn run(conn: &Connection, action: &BenchmarkAction, output_mode: OutputMode) -> Result<()> {
+    match action {
+        BenchmarkAction::SemanticSearch {
+            queries,
+            synthetic,
+            vectors,
+            warmup,
+            min_score,
+        } => perf::run_semantic_search_benchmark(
+            conn,
+            *queries,
+            *synthetic,
+            *vectors,
+            *warmup,
+            *min_score,
+            output_mode,
+        ),
+        BenchmarkAction::Quality { file, k, detail } => {
+            quality::run_quality_benchmark(conn, file, *k, *detail, output_mode)
+        }
+    }
+}

--- a/src/commands/benchmark/perf.rs
+++ b/src/commands/benchmark/perf.rs
@@ -192,7 +192,7 @@ fn calculate_results(
     }
 }
 
-fn percentile(sorted_values: &[f64], p: f64) -> f64 {
+pub(super) fn percentile(sorted_values: &[f64], p: f64) -> f64 {
     if sorted_values.is_empty() {
         return 0.0;
     }

--- a/src/commands/benchmark/perf.rs
+++ b/src/commands/benchmark/perf.rs
@@ -1,17 +1,12 @@
-//! Benchmark command: measure semantic search performance.
+//! Semantic search performance benchmark: latency and throughput.
 
-use std::collections::HashSet;
-use std::fs;
-use std::path::Path;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use rand::prelude::*;
 use rusqlite::Connection;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-use crate::cli::args::BenchmarkAction;
-use crate::embed;
 use crate::embed::search::cosine_similarity;
 use crate::embed::store::load_all_vectors;
 use crate::output::format::OutputMode;
@@ -42,30 +37,7 @@ pub struct BenchmarkResults {
     pub total_time_ms: f64,
 }
 
-pub fn run(conn: &Connection, action: &BenchmarkAction, output_mode: OutputMode) -> Result<()> {
-    match action {
-        BenchmarkAction::SemanticSearch {
-            queries,
-            synthetic,
-            vectors,
-            warmup,
-            min_score,
-        } => run_semantic_search_benchmark(
-            conn,
-            *queries,
-            *synthetic,
-            *vectors,
-            *warmup,
-            *min_score,
-            output_mode,
-        ),
-        BenchmarkAction::Quality { file, k, detail } => {
-            run_quality_benchmark(conn, file, *k, *detail, output_mode)
-        }
-    }
-}
-
-fn run_semantic_search_benchmark(
+pub(super) fn run_semantic_search_benchmark(
     conn: &Connection,
     query_count: usize,
     synthetic: bool,
@@ -323,200 +295,6 @@ fn format_number(n: usize) -> String {
         result.push(c);
     }
     result.chars().rev().collect()
-}
-
-// === Quality Benchmark ===
-
-/// A single test query from the benchmark file
-#[derive(Debug, Deserialize)]
-struct BenchmarkQuery {
-    query: String,
-    relevant_meetings: Vec<String>,
-    #[allow(dead_code)]
-    rationale: String,
-}
-
-/// The benchmark file format
-#[derive(Debug, Deserialize)]
-struct BenchmarkFile {
-    #[allow(dead_code)]
-    description: String,
-    queries: Vec<BenchmarkQuery>,
-}
-
-/// Results for a single query
-#[derive(Debug, Serialize)]
-struct QueryResult {
-    query: String,
-    expected: Vec<String>,
-    found: Vec<String>,
-    found_in_top_k: bool,
-    best_rank: Option<usize>,
-    best_score: Option<f32>,
-}
-
-/// Overall quality benchmark results
-#[derive(Debug, Serialize)]
-struct QualityResults {
-    total_queries: usize,
-    queries_with_match: usize,
-    precision_at_k: f64,
-    mean_reciprocal_rank: f64,
-    k: usize,
-    query_results: Vec<QueryResult>,
-}
-
-fn run_quality_benchmark(
-    conn: &Connection,
-    file: &Path,
-    k: usize,
-    detail: bool,
-    output_mode: OutputMode,
-) -> Result<()> {
-    // Load benchmark file
-    let content = fs::read_to_string(file)
-        .with_context(|| format!("Failed to read benchmark file: {}", file.display()))?;
-    let benchmark: BenchmarkFile = serde_json::from_str(&content)
-        .with_context(|| "Failed to parse benchmark JSON")?;
-
-    if benchmark.queries.is_empty() {
-        bail!("Benchmark file contains no queries");
-    }
-
-    // Build a map of meeting titles for lookup
-    let title_map = build_title_map(conn)?;
-
-    let mut query_results = Vec::new();
-    let mut total_reciprocal_rank = 0.0;
-
-    for bq in &benchmark.queries {
-        // Run semantic search
-        let (results, _total) = embed::semantic_search(conn, &bq.query, None, k, None, false)?;
-
-        // Get result titles
-        let result_titles: Vec<String> = results
-            .iter()
-            .filter_map(|r| title_map.get(&r.document_id).cloned())
-            .collect();
-
-        // Check if any expected meeting is in results
-        let expected_set: HashSet<&str> = bq.relevant_meetings.iter().map(|s| s.as_str()).collect();
-
-        let mut best_rank: Option<usize> = None;
-        let mut best_score: Option<f32> = None;
-
-        for (i, result) in results.iter().enumerate() {
-            if let Some(title) = title_map.get(&result.document_id) {
-                if expected_set.contains(title.as_str()) {
-                    if best_rank.is_none() {
-                        best_rank = Some(i + 1);
-                        best_score = Some(result.score);
-                    }
-                }
-            }
-        }
-
-        let found_in_top_k = best_rank.is_some();
-
-        // Calculate reciprocal rank (1/rank if found, 0 if not)
-        if let Some(rank) = best_rank {
-            total_reciprocal_rank += 1.0 / rank as f64;
-        }
-
-        query_results.push(QueryResult {
-            query: bq.query.clone(),
-            expected: bq.relevant_meetings.clone(),
-            found: result_titles,
-            found_in_top_k,
-            best_rank,
-            best_score,
-        });
-    }
-
-    let queries_with_match = query_results.iter().filter(|r| r.found_in_top_k).count();
-    let precision_at_k = queries_with_match as f64 / query_results.len() as f64;
-    let mean_reciprocal_rank = total_reciprocal_rank / query_results.len() as f64;
-
-    let results = QualityResults {
-        total_queries: query_results.len(),
-        queries_with_match,
-        precision_at_k,
-        mean_reciprocal_rank,
-        k,
-        query_results,
-    };
-
-    match output_mode {
-        OutputMode::Json => print_quality_json(&results)?,
-        OutputMode::Tty => print_quality_tty(&results, detail),
-    }
-
-    Ok(())
-}
-
-fn build_title_map(conn: &Connection) -> Result<std::collections::HashMap<String, String>> {
-    let mut stmt = conn.prepare("SELECT id, title FROM documents")?;
-    let rows = stmt.query_map([], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-    })?;
-
-    let mut map = std::collections::HashMap::new();
-    for row in rows {
-        let (id, title) = row?;
-        map.insert(id, title);
-    }
-    Ok(map)
-}
-
-fn print_quality_json(results: &QualityResults) -> Result<()> {
-    println!("{}", serde_json::to_string_pretty(results)?);
-    Ok(())
-}
-
-fn print_quality_tty(results: &QualityResults, detail: bool) {
-    use colored::Colorize;
-
-    println!("{}", "Semantic Search Quality Benchmark".bold().cyan());
-    println!("{}", "=".repeat(35).cyan());
-    println!();
-    println!("{:24} {:>10}", "Total queries:".bold(), results.total_queries);
-    println!("{:24} {:>10}", "Matches in top k:".bold(), results.queries_with_match);
-    println!("{:24} {:>10}", "k:".bold(), results.k);
-    println!();
-    println!(
-        "{:24} {:>10.1}%",
-        "Precision@k:".bold().green(),
-        results.precision_at_k * 100.0
-    );
-    println!(
-        "{:24} {:>10.3}",
-        "Mean Reciprocal Rank:".bold().green(),
-        results.mean_reciprocal_rank
-    );
-
-    if detail {
-        println!();
-        println!("{}", "Query Details".bold().yellow());
-        println!("{}", "-".repeat(13).yellow());
-
-        for qr in &results.query_results {
-            let status = if qr.found_in_top_k {
-                "PASS".green()
-            } else {
-                "MISS".red()
-            };
-
-            println!();
-            println!("[{}] {}", status, qr.query.bold());
-            println!("  Expected: {}", qr.expected.join(", "));
-            if let (Some(rank), Some(score)) = (qr.best_rank, qr.best_score) {
-                println!("  Found at rank {} (score: {:.3})", rank, score);
-            } else {
-                println!("  Not found in top {}", results.k);
-                println!("  Got: {}", qr.found.first().unwrap_or(&"(no results)".to_string()));
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -1,0 +1,200 @@
+//! Search quality benchmark: score search results against a labeled golden set.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+
+use crate::embed;
+use crate::output::format::OutputMode;
+
+/// A single test query from the benchmark file
+#[derive(Debug, Deserialize)]
+struct BenchmarkQuery {
+    query: String,
+    relevant_meetings: Vec<String>,
+}
+
+/// The benchmark file format
+#[derive(Debug, Deserialize)]
+struct BenchmarkFile {
+    queries: Vec<BenchmarkQuery>,
+}
+
+/// Results for a single query
+#[derive(Debug, Serialize)]
+struct QueryResult {
+    query: String,
+    expected: Vec<String>,
+    found: Vec<String>,
+    found_in_top_k: bool,
+    best_rank: Option<usize>,
+    best_score: Option<f32>,
+}
+
+/// Overall quality benchmark results
+#[derive(Debug, Serialize)]
+struct QualityResults {
+    total_queries: usize,
+    queries_with_match: usize,
+    precision_at_k: f64,
+    mean_reciprocal_rank: f64,
+    k: usize,
+    query_results: Vec<QueryResult>,
+}
+
+pub fn run_quality_benchmark(
+    conn: &Connection,
+    file: &Path,
+    k: usize,
+    detail: bool,
+    output_mode: OutputMode,
+) -> Result<()> {
+    // Load benchmark file
+    let content = fs::read_to_string(file)
+        .with_context(|| format!("Failed to read benchmark file: {}", file.display()))?;
+    let benchmark: BenchmarkFile = serde_json::from_str(&content)
+        .with_context(|| "Failed to parse benchmark JSON")?;
+
+    if benchmark.queries.is_empty() {
+        bail!("Benchmark file contains no queries");
+    }
+
+    // Build a map of meeting titles for lookup
+    let title_map = build_title_map(conn)?;
+
+    let mut query_results = Vec::new();
+    let mut total_reciprocal_rank = 0.0;
+
+    for bq in &benchmark.queries {
+        // Run semantic search
+        let (results, _total) = embed::semantic_search(conn, &bq.query, None, k, None, false)?;
+
+        // Get result titles
+        let result_titles: Vec<String> = results
+            .iter()
+            .filter_map(|r| title_map.get(&r.document_id).cloned())
+            .collect();
+
+        // Check if any expected meeting is in results
+        let expected_set: HashSet<&str> = bq.relevant_meetings.iter().map(|s| s.as_str()).collect();
+
+        let mut best_rank: Option<usize> = None;
+        let mut best_score: Option<f32> = None;
+
+        for (i, result) in results.iter().enumerate() {
+            if let Some(title) = title_map.get(&result.document_id) {
+                if expected_set.contains(title.as_str()) {
+                    if best_rank.is_none() {
+                        best_rank = Some(i + 1);
+                        best_score = Some(result.score);
+                    }
+                }
+            }
+        }
+
+        let found_in_top_k = best_rank.is_some();
+
+        // Calculate reciprocal rank (1/rank if found, 0 if not)
+        if let Some(rank) = best_rank {
+            total_reciprocal_rank += 1.0 / rank as f64;
+        }
+
+        query_results.push(QueryResult {
+            query: bq.query.clone(),
+            expected: bq.relevant_meetings.clone(),
+            found: result_titles,
+            found_in_top_k,
+            best_rank,
+            best_score,
+        });
+    }
+
+    let queries_with_match = query_results.iter().filter(|r| r.found_in_top_k).count();
+    let precision_at_k = queries_with_match as f64 / query_results.len() as f64;
+    let mean_reciprocal_rank = total_reciprocal_rank / query_results.len() as f64;
+
+    let results = QualityResults {
+        total_queries: query_results.len(),
+        queries_with_match,
+        precision_at_k,
+        mean_reciprocal_rank,
+        k,
+        query_results,
+    };
+
+    match output_mode {
+        OutputMode::Json => print_quality_json(&results)?,
+        OutputMode::Tty => print_quality_tty(&results, detail),
+    }
+
+    Ok(())
+}
+
+fn build_title_map(conn: &Connection) -> Result<std::collections::HashMap<String, String>> {
+    let mut stmt = conn.prepare("SELECT id, title FROM documents")?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+
+    let mut map = std::collections::HashMap::new();
+    for row in rows {
+        let (id, title) = row?;
+        map.insert(id, title);
+    }
+    Ok(map)
+}
+
+fn print_quality_json(results: &QualityResults) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(results)?);
+    Ok(())
+}
+
+fn print_quality_tty(results: &QualityResults, detail: bool) {
+    use colored::Colorize;
+
+    println!("{}", "Semantic Search Quality Benchmark".bold().cyan());
+    println!("{}", "=".repeat(35).cyan());
+    println!();
+    println!("{:24} {:>10}", "Total queries:".bold(), results.total_queries);
+    println!("{:24} {:>10}", "Matches in top k:".bold(), results.queries_with_match);
+    println!("{:24} {:>10}", "k:".bold(), results.k);
+    println!();
+    println!(
+        "{:24} {:>10.1}%",
+        "Precision@k:".bold().green(),
+        results.precision_at_k * 100.0
+    );
+    println!(
+        "{:24} {:>10.3}",
+        "Mean Reciprocal Rank:".bold().green(),
+        results.mean_reciprocal_rank
+    );
+
+    if detail {
+        println!();
+        println!("{}", "Query Details".bold().yellow());
+        println!("{}", "-".repeat(13).yellow());
+
+        for qr in &results.query_results {
+            let status = if qr.found_in_top_k {
+                "PASS".green()
+            } else {
+                "MISS".red()
+            };
+
+            println!();
+            println!("[{}] {}", status, qr.query.bold());
+            println!("  Expected: {}", qr.expected.join(", "));
+            if let (Some(rank), Some(score)) = (qr.best_rank, qr.best_score) {
+                println!("  Found at rank {} (score: {:.3})", rank, score);
+            } else {
+                println!("  Not found in top {}", results.k);
+                println!("  Got: {}", qr.found.first().unwrap_or(&"(no results)".to_string()));
+            }
+        }
+    }
+}

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -1,146 +1,324 @@
-//! Search quality benchmark: score search results against a labeled golden set.
+//! Search quality benchmark: score retrieval modes against a labeled golden set.
+//!
+//! The golden-set file provides labeled queries; each requested mode retrieves
+//! a ranked document list per query, which metrics.rs scores. Labels match by
+//! document ID when the file provides `relevant_meeting_ids`, falling back to
+//! exact title for older files that only carry `relevant_meetings`.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::Path;
+use std::time::Instant;
 
 use anyhow::{bail, Context, Result};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
-use crate::embed;
+use super::metrics::{self, AggregateMetrics, LabelMatcher, QueryScore, RankedDoc, WinLossTie};
+use super::perf::percentile;
+use super::retriever::Retriever;
+use crate::cli::args::QualityMode;
 use crate::output::format::OutputMode;
 
-/// A single test query from the benchmark file
+/// CLI arguments for the quality benchmark.
+pub struct QualityArgs<'a> {
+    pub file: &'a Path,
+    pub k: usize,
+    pub mode: QualityMode,
+    pub compare: &'a [QualityMode],
+    pub detail: bool,
+}
+
+/// A single test query from the benchmark file.
 #[derive(Debug, Deserialize)]
 struct BenchmarkQuery {
     query: String,
+    #[serde(default)]
+    query_type: Option<String>,
+    #[serde(default)]
     relevant_meetings: Vec<String>,
+    #[serde(default)]
+    relevant_meeting_ids: Vec<String>,
 }
 
-/// The benchmark file format
+impl BenchmarkQuery {
+    /// ID matching when the file provides document IDs, title matching
+    /// otherwise (v1 golden set).
+    fn matcher<'a>(&'a self, title_map: &'a HashMap<String, String>) -> LabelMatcher<'a> {
+        if self.relevant_meeting_ids.is_empty() {
+            LabelMatcher::Titles {
+                titles: self.relevant_meetings.iter().map(String::as_str).collect(),
+                title_map,
+            }
+        } else {
+            LabelMatcher::Ids(
+                self.relevant_meeting_ids
+                    .iter()
+                    .map(String::as_str)
+                    .collect(),
+            )
+        }
+    }
+
+    /// Human-readable labels for output: titles when the file has them,
+    /// document IDs otherwise.
+    fn expected_display(&self) -> &[String] {
+        if self.relevant_meetings.is_empty() {
+            &self.relevant_meeting_ids
+        } else {
+            &self.relevant_meetings
+        }
+    }
+}
+
+/// The benchmark file format.
 #[derive(Debug, Deserialize)]
 struct BenchmarkFile {
     queries: Vec<BenchmarkQuery>,
 }
 
-/// Results for a single query
+/// A single result document in a query's top k, for the per-query output.
 #[derive(Debug, Serialize)]
-struct QueryResult {
+struct TopHit {
+    rank: usize,
+    document_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    score: Option<f32>,
+}
+
+/// Full scored outcome for one query in one mode.
+#[derive(Debug, Serialize)]
+struct QueryOutcome {
     query: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    query_type: Option<String>,
+    matching: &'static str,
     expected: Vec<String>,
-    found: Vec<String>,
-    found_in_top_k: bool,
-    best_rank: Option<usize>,
-    best_score: Option<f32>,
+    #[serde(flatten)]
+    score: QueryScore,
+    latency_ms: f64,
+    top_k: Vec<TopHit>,
 }
 
-/// Overall quality benchmark results
 #[derive(Debug, Serialize)]
-struct QualityResults {
-    total_queries: usize,
-    queries_with_match: usize,
-    precision_at_k: f64,
-    mean_reciprocal_rank: f64,
-    k: usize,
-    query_results: Vec<QueryResult>,
+pub struct LatencyStats {
+    pub avg_ms: f64,
+    pub p50_ms: f64,
 }
 
-pub fn run_quality_benchmark(
+/// One mode's complete benchmark run over the golden set.
+#[derive(Debug, Serialize)]
+pub struct ModeRun {
+    pub mode: &'static str,
+    /// "id", "title", or "mixed" across the file's queries.
+    pub matching: &'static str,
+    pub k: usize,
+    pub overall: AggregateMetrics,
+    /// Empty when no query carries a `query_type` label (v1 golden set).
+    pub strata: BTreeMap<String, AggregateMetrics>,
+    pub latency: LatencyStats,
+    query_results: Vec<QueryOutcome>,
+}
+
+impl ModeRun {
+    fn best_ranks(&self) -> Vec<Option<usize>> {
+        self.query_results.iter().map(|o| o.score.best_rank).collect()
+    }
+}
+
+/// Pairwise win/loss/tie between two modes, on per-query best rank.
+#[derive(Debug, Serialize)]
+pub struct PairwiseComparison {
+    pub mode_a: &'static str,
+    pub mode_b: &'static str,
+    #[serde(flatten)]
+    pub result: WinLossTie,
+}
+
+pub(super) fn run_quality_benchmark(
     conn: &Connection,
-    file: &Path,
-    k: usize,
-    detail: bool,
+    args: &QualityArgs,
     output_mode: OutputMode,
 ) -> Result<()> {
-    // Load benchmark file
-    let content = fs::read_to_string(file)
-        .with_context(|| format!("Failed to read benchmark file: {}", file.display()))?;
-    let benchmark: BenchmarkFile = serde_json::from_str(&content)
-        .with_context(|| "Failed to parse benchmark JSON")?;
-
-    if benchmark.queries.is_empty() {
-        bail!("Benchmark file contains no queries");
-    }
-
-    // Build a map of meeting titles for lookup
+    let content = fs::read_to_string(args.file)
+        .with_context(|| format!("Failed to read benchmark file: {}", args.file.display()))?;
+    let queries = parse_benchmark(&content)?;
     let title_map = build_title_map(conn)?;
 
-    let mut query_results = Vec::new();
-    let mut total_reciprocal_rank = 0.0;
-
-    for bq in &benchmark.queries {
-        // Run semantic search
-        let (results, _total) = embed::semantic_search(conn, &bq.query, None, k, None, false)?;
-
-        // Get result titles
-        let result_titles: Vec<String> = results
-            .iter()
-            .filter_map(|r| title_map.get(&r.document_id).cloned())
-            .collect();
-
-        // Check if any expected meeting is in results
-        let expected_set: HashSet<&str> = bq.relevant_meetings.iter().map(|s| s.as_str()).collect();
-
-        let mut best_rank: Option<usize> = None;
-        let mut best_score: Option<f32> = None;
-
-        for (i, result) in results.iter().enumerate() {
-            if let Some(title) = title_map.get(&result.document_id) {
-                if expected_set.contains(title.as_str()) {
-                    if best_rank.is_none() {
-                        best_rank = Some(i + 1);
-                        best_score = Some(result.score);
-                    }
-                }
-            }
-        }
-
-        let found_in_top_k = best_rank.is_some();
-
-        // Calculate reciprocal rank (1/rank if found, 0 if not)
-        if let Some(rank) = best_rank {
-            total_reciprocal_rank += 1.0 / rank as f64;
-        }
-
-        query_results.push(QueryResult {
-            query: bq.query.clone(),
-            expected: bq.relevant_meetings.clone(),
-            found: result_titles,
-            found_in_top_k,
-            best_rank,
-            best_score,
-        });
-    }
-
-    let queries_with_match = query_results.iter().filter(|r| r.found_in_top_k).count();
-    let precision_at_k = queries_with_match as f64 / query_results.len() as f64;
-    let mean_reciprocal_rank = total_reciprocal_rank / query_results.len() as f64;
-
-    let results = QualityResults {
-        total_queries: query_results.len(),
-        queries_with_match,
-        precision_at_k,
-        mean_reciprocal_rank,
-        k,
-        query_results,
+    let modes: Vec<QualityMode> = if args.compare.is_empty() {
+        vec![args.mode]
+    } else {
+        args.compare.to_vec()
     };
 
+    let mut runs = Vec::with_capacity(modes.len());
+    for mode in modes {
+        let retriever = Retriever::build(mode, conn)?;
+        runs.push(run_queries(
+            |q| retriever.retrieve(q),
+            &queries,
+            &title_map,
+            mode,
+            args.k,
+        )?);
+    }
+
+    let comparisons = pairwise_comparisons(&runs);
+
     match output_mode {
-        OutputMode::Json => print_quality_json(&results)?,
-        OutputMode::Tty => print_quality_tty(&results, detail),
+        OutputMode::Json => print_json(&runs, &comparisons)?,
+        OutputMode::Tty => print_tty(&runs, &comparisons, args.detail),
     }
 
     Ok(())
 }
 
-fn build_title_map(conn: &Connection) -> Result<std::collections::HashMap<String, String>> {
+/// Parse and validate a benchmark file's contents.
+fn parse_benchmark(content: &str) -> Result<Vec<BenchmarkQuery>> {
+    let file: BenchmarkFile =
+        serde_json::from_str(content).with_context(|| "Failed to parse benchmark JSON")?;
+
+    if file.queries.is_empty() {
+        bail!("Benchmark file contains no queries");
+    }
+    for (i, q) in file.queries.iter().enumerate() {
+        if q.query.trim().is_empty() {
+            bail!("Benchmark query {} has an empty query string", i + 1);
+        }
+        if q.relevant_meetings.is_empty() && q.relevant_meeting_ids.is_empty() {
+            bail!("Benchmark query {} ({:?}) has no relevance labels", i + 1, q.query);
+        }
+    }
+
+    Ok(file.queries)
+}
+
+/// Run every query through one retrieval function and score the results.
+fn run_queries<F>(
+    retrieve: F,
+    queries: &[BenchmarkQuery],
+    title_map: &HashMap<String, String>,
+    mode: QualityMode,
+    k: usize,
+) -> Result<ModeRun>
+where
+    F: Fn(&str) -> Result<Vec<RankedDoc>>,
+{
+    let mut outcomes = Vec::with_capacity(queries.len());
+    for bq in queries {
+        let start = Instant::now();
+        let ranked = retrieve(&bq.query)?;
+        let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+        let matcher = bq.matcher(title_map);
+        let score = metrics::score_query(&ranked, &matcher, k);
+        outcomes.push(build_outcome(bq, &ranked, matcher.method(), score, latency_ms, title_map, k));
+    }
+
+    let overall = metrics::aggregate(outcomes.iter().map(|o| &o.score));
+    let strata = build_strata(&outcomes);
+    let latency = latency_stats(&outcomes);
+    let methods: Vec<&'static str> = outcomes.iter().map(|o| o.matching).collect();
+
+    Ok(ModeRun {
+        mode: mode.as_str(),
+        matching: matching_summary(&methods),
+        k,
+        overall,
+        strata,
+        latency,
+        query_results: outcomes,
+    })
+}
+
+fn build_outcome(
+    bq: &BenchmarkQuery,
+    ranked: &[RankedDoc],
+    matching: &'static str,
+    score: QueryScore,
+    latency_ms: f64,
+    title_map: &HashMap<String, String>,
+    k: usize,
+) -> QueryOutcome {
+    let top_k = ranked
+        .iter()
+        .take(k)
+        .enumerate()
+        .map(|(i, doc)| TopHit {
+            rank: i + 1,
+            document_id: doc.document_id.clone(),
+            title: title_map.get(&doc.document_id).cloned(),
+            score: doc.score,
+        })
+        .collect();
+
+    QueryOutcome {
+        query: bq.query.clone(),
+        query_type: bq.query_type.clone(),
+        matching,
+        expected: bq.expected_display().to_vec(),
+        score,
+        latency_ms,
+        top_k,
+    }
+}
+
+/// Per-stratum aggregation, keyed by `query_type`. Empty when no query in
+/// the file carries a stratum label; queries missing one in a labeled file
+/// land in "unlabeled".
+fn build_strata(outcomes: &[QueryOutcome]) -> BTreeMap<String, AggregateMetrics> {
+    if outcomes.iter().all(|o| o.query_type.is_none()) {
+        return BTreeMap::new();
+    }
+    let pairs: Vec<(&str, &QueryScore)> = outcomes
+        .iter()
+        .map(|o| (o.query_type.as_deref().unwrap_or("unlabeled"), &o.score))
+        .collect();
+    metrics::aggregate_by_stratum(&pairs)
+}
+
+fn latency_stats(outcomes: &[QueryOutcome]) -> LatencyStats {
+    let mut latencies: Vec<f64> = outcomes.iter().map(|o| o.latency_ms).collect();
+    latencies.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    LatencyStats {
+        avg_ms: latencies.iter().sum::<f64>() / latencies.len() as f64,
+        p50_ms: percentile(&latencies, 50.0),
+    }
+}
+
+/// Run-level matching method: "id" or "title" when uniform, "mixed" otherwise.
+fn matching_summary(methods: &[&'static str]) -> &'static str {
+    match methods.first() {
+        Some(first) if methods.iter().all(|m| m == first) => first,
+        Some(_) => "mixed",
+        None => "mixed",
+    }
+}
+
+/// Win/loss/tie for every ordered pair of runs (earlier mode as A).
+fn pairwise_comparisons(runs: &[ModeRun]) -> Vec<PairwiseComparison> {
+    let mut comparisons = Vec::new();
+    for (i, a) in runs.iter().enumerate() {
+        for b in &runs[i + 1..] {
+            comparisons.push(PairwiseComparison {
+                mode_a: a.mode,
+                mode_b: b.mode,
+                result: metrics::compare_ranks(&a.best_ranks(), &b.best_ranks()),
+            });
+        }
+    }
+    comparisons
+}
+
+fn build_title_map(conn: &Connection) -> Result<HashMap<String, String>> {
     let mut stmt = conn.prepare("SELECT id, title FROM documents")?;
     let rows = stmt.query_map([], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
 
-    let mut map = std::collections::HashMap::new();
+    let mut map = HashMap::new();
     for row in rows {
         let (id, title) = row?;
         map.insert(id, title);
@@ -148,53 +326,383 @@ fn build_title_map(conn: &Connection) -> Result<std::collections::HashMap<String
     Ok(map)
 }
 
-fn print_quality_json(results: &QualityResults) -> Result<()> {
-    println!("{}", serde_json::to_string_pretty(results)?);
+// === Output ===
+
+fn print_json(runs: &[ModeRun], comparisons: &[PairwiseComparison]) -> Result<()> {
+    if runs.len() == 1 {
+        println!("{}", serde_json::to_string_pretty(&runs[0])?);
+    } else {
+        let combined = serde_json::json!({
+            "runs": runs,
+            "comparisons": comparisons,
+        });
+        println!("{}", serde_json::to_string_pretty(&combined)?);
+    }
     Ok(())
 }
 
-fn print_quality_tty(results: &QualityResults, detail: bool) {
+fn print_tty(runs: &[ModeRun], comparisons: &[PairwiseComparison], detail: bool) {
+    for run in runs {
+        print_run_tty(run, detail);
+        println!();
+    }
+    if runs.len() > 1 {
+        print_compare_tty(runs, comparisons);
+    }
+}
+
+fn print_run_tty(run: &ModeRun, detail: bool) {
     use colored::Colorize;
 
-    println!("{}", "Semantic Search Quality Benchmark".bold().cyan());
-    println!("{}", "=".repeat(35).cyan());
+    let heading = format!("Search Quality Benchmark ({})", run.mode);
+    println!("{}", heading.bold().cyan());
+    println!("{}", "=".repeat(heading.len()).cyan());
     println!();
-    println!("{:24} {:>10}", "Total queries:".bold(), results.total_queries);
-    println!("{:24} {:>10}", "Matches in top k:".bold(), results.queries_with_match);
-    println!("{:24} {:>10}", "k:".bold(), results.k);
+    println!("{:24} {:>10}", "Queries:".bold(), run.overall.n);
+    println!("{:24} {:>10}", "k:".bold(), run.k);
+    println!("{:24} {:>10}", "Matching:".bold(), run.matching);
+    println!(
+        "{:24} {:>10}",
+        "Matches in top k:".bold(),
+        run.overall.queries_with_match
+    );
     println!();
     println!(
         "{:24} {:>10.1}%",
-        "Precision@k:".bold().green(),
-        results.precision_at_k * 100.0
+        format!("hit-rate@{}:", run.k).bold().green(),
+        run.overall.hit_rate_at_k * 100.0
+    );
+    println!(
+        "{:24} {:>10.1}%",
+        format!("recall@{}:", run.k).bold().green(),
+        run.overall.recall_at_k * 100.0
     );
     println!(
         "{:24} {:>10.3}",
-        "Mean Reciprocal Rank:".bold().green(),
-        results.mean_reciprocal_rank
+        format!("MRR@{}:", run.k).bold().green(),
+        run.overall.mrr
+    );
+    println!(
+        "{:24} {:>10}",
+        "Latency (avg / p50):".bold(),
+        format!("{:.1} / {:.1} ms", run.latency.avg_ms, run.latency.p50_ms)
     );
 
-    if detail {
+    if !run.strata.is_empty() {
         println!();
-        println!("{}", "Query Details".bold().yellow());
-        println!("{}", "-".repeat(13).yellow());
+        println!(
+            "{:<12} {:>4} {:>10} {:>10} {:>8}",
+            "Stratum".bold().yellow(),
+            "n",
+            "hit-rate",
+            "recall",
+            "MRR"
+        );
+        for (stratum, agg) in &run.strata {
+            println!(
+                "{:<12} {:>4} {:>9.1}% {:>9.1}% {:>8.3}",
+                stratum,
+                agg.n,
+                agg.hit_rate_at_k * 100.0,
+                agg.recall_at_k * 100.0,
+                agg.mrr
+            );
+        }
+    }
 
-        for qr in &results.query_results {
-            let status = if qr.found_in_top_k {
-                "PASS".green()
-            } else {
-                "MISS".red()
-            };
+    if detail {
+        print_detail_tty(run);
+    }
+}
 
-            println!();
-            println!("[{}] {}", status, qr.query.bold());
-            println!("  Expected: {}", qr.expected.join(", "));
-            if let (Some(rank), Some(score)) = (qr.best_rank, qr.best_score) {
-                println!("  Found at rank {} (score: {:.3})", rank, score);
-            } else {
-                println!("  Not found in top {}", results.k);
-                println!("  Got: {}", qr.found.first().unwrap_or(&"(no results)".to_string()));
+fn print_detail_tty(run: &ModeRun) {
+    use colored::Colorize;
+
+    println!();
+    println!("{}", "Query Details".bold().yellow());
+    println!("{}", "-".repeat(13).yellow());
+
+    for qr in &run.query_results {
+        let status = if qr.score.found_in_top_k {
+            "PASS".green()
+        } else {
+            "MISS".red()
+        };
+
+        println!();
+        println!("[{}] {}", status, qr.query.bold());
+        println!("  Expected: {}", qr.expected.join(", "));
+        match qr.score.best_rank {
+            Some(rank) => {
+                let score_note = qr
+                    .score
+                    .best_score
+                    .map(|s| format!(" (score: {:.3})", s))
+                    .unwrap_or_default();
+                println!("  First relevant at rank {}{}", rank, score_note);
+            }
+            None => {
+                println!("  Not found");
+                let got = qr
+                    .top_k
+                    .first()
+                    .and_then(|h| h.title.as_deref())
+                    .unwrap_or("(no results)");
+                println!("  Got: {}", got);
             }
         }
+    }
+}
+
+fn print_compare_tty(runs: &[ModeRun], comparisons: &[PairwiseComparison]) {
+    use colored::Colorize;
+
+    println!("{}", "Per-query rank of first relevant".bold().cyan());
+    println!("{}", "-".repeat(32).cyan());
+    for run in runs {
+        print!("{:>10}", run.mode);
+    }
+    println!("  query");
+
+    let n = runs[0].query_results.len();
+    for i in 0..n {
+        for run in runs {
+            let cell = run.query_results[i]
+                .score
+                .best_rank
+                .map(|r| r.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            print!("{:>10}", cell);
+        }
+        let query = &runs[0].query_results[i].query;
+        let truncated: String = query.chars().take(60).collect();
+        println!("  {}", truncated);
+    }
+
+    println!();
+    for cmp in comparisons {
+        println!(
+            "{}: {} wins / {} losses / {} ties (on best rank)",
+            format!("{} vs {}", cmp.mode_a, cmp.mode_b).bold(),
+            cmp.result.wins,
+            cmp.result.losses,
+            cmp.result.ties
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const V2_JSON: &str = r#"{
+        "description": "test set",
+        "created": "2026-07-10",
+        "queries": [
+            {
+                "query": "quarterly budget review",
+                "query_type": "exact-term",
+                "provenance": "v2",
+                "relevant_meetings": ["Budget Review"],
+                "relevant_meeting_ids": ["doc-a"],
+                "rationale": "test"
+            },
+            {
+                "query": "planning the offsite",
+                "query_type": "paraphrase",
+                "provenance": "v2",
+                "relevant_meetings": ["Offsite Planning"],
+                "relevant_meeting_ids": ["doc-b", "doc-c"],
+                "rationale": "test"
+            }
+        ]
+    }"#;
+
+    const V1_JSON: &str = r#"{
+        "description": "test set",
+        "queries": [
+            {
+                "query": "quarterly budget review",
+                "relevant_meetings": ["Budget Review"],
+                "rationale": "test"
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn parse_v2_file_prefers_id_matching() {
+        let queries = parse_benchmark(V2_JSON).unwrap();
+        assert_eq!(queries.len(), 2);
+        assert_eq!(queries[0].query_type.as_deref(), Some("exact-term"));
+        assert_eq!(queries[0].relevant_meeting_ids, vec!["doc-a"]);
+
+        let title_map = HashMap::new();
+        let matcher = queries[0].matcher(&title_map);
+        assert_eq!(matcher.method(), "id");
+        assert_eq!(matcher.label_count(), 1);
+    }
+
+    #[test]
+    fn parse_v1_file_falls_back_to_title_matching() {
+        let queries = parse_benchmark(V1_JSON).unwrap();
+        assert_eq!(queries.len(), 1);
+        assert!(queries[0].query_type.is_none());
+
+        let title_map = HashMap::new();
+        let matcher = queries[0].matcher(&title_map);
+        assert_eq!(matcher.method(), "title");
+    }
+
+    #[test]
+    fn parse_rejects_query_without_labels() {
+        let json = r#"{"queries": [{"query": "anything", "rationale": "x"}]}"#;
+        let err = parse_benchmark(json).unwrap_err();
+        assert!(err.to_string().contains("no relevance labels"));
+    }
+
+    #[test]
+    fn parse_rejects_empty_file() {
+        let json = r#"{"queries": []}"#;
+        assert!(parse_benchmark(json).is_err());
+    }
+
+    #[test]
+    fn matching_summary_uniform_and_mixed() {
+        assert_eq!(matching_summary(&["id", "id"]), "id");
+        assert_eq!(matching_summary(&["title"]), "title");
+        assert_eq!(matching_summary(&["id", "title"]), "mixed");
+    }
+
+    fn stub_ranked(ids: &[&str]) -> Vec<RankedDoc> {
+        ids.iter()
+            .map(|id| RankedDoc {
+                document_id: id.to_string(),
+                score: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn run_queries_scores_and_aggregates() {
+        let queries = parse_benchmark(V2_JSON).unwrap();
+        let title_map = HashMap::new();
+
+        // First query: doc-a at rank 1. Second query: no relevant doc found.
+        let run = run_queries(
+            |q| {
+                Ok(if q.starts_with("quarterly") {
+                    stub_ranked(&["doc-a", "doc-x"])
+                } else {
+                    stub_ranked(&["doc-x", "doc-y"])
+                })
+            },
+            &queries,
+            &title_map,
+            QualityMode::Fts,
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(run.mode, "fts");
+        assert_eq!(run.matching, "id");
+        assert_eq!(run.k, 10);
+        assert_eq!(run.overall.n, 2);
+        assert_eq!(run.overall.queries_with_match, 1);
+        assert!((run.overall.hit_rate_at_k - 0.5).abs() < 1e-9);
+        assert!((run.overall.mrr - 0.5).abs() < 1e-9);
+
+        assert_eq!(run.strata.len(), 2);
+        assert_eq!(run.strata["exact-term"].n, 1);
+        assert_eq!(run.strata["exact-term"].queries_with_match, 1);
+        assert_eq!(run.strata["paraphrase"].queries_with_match, 0);
+
+        assert_eq!(run.query_results.len(), 2);
+        assert_eq!(run.query_results[0].score.best_rank, Some(1));
+        assert_eq!(run.query_results[0].top_k.len(), 2);
+        assert!(run.query_results[0].latency_ms >= 0.0);
+    }
+
+    #[test]
+    fn run_queries_v1_has_no_strata() {
+        let queries = parse_benchmark(V1_JSON).unwrap();
+        let title_map: HashMap<String, String> =
+            [("doc-a".to_string(), "Budget Review".to_string())].into();
+
+        let run = run_queries(
+            |_| Ok(stub_ranked(&["doc-a"])),
+            &queries,
+            &title_map,
+            QualityMode::Semantic,
+            10,
+        )
+        .unwrap();
+
+        assert_eq!(run.matching, "title");
+        assert!(run.strata.is_empty());
+        assert_eq!(run.overall.queries_with_match, 1);
+    }
+
+    #[test]
+    fn pairwise_comparisons_use_best_ranks() {
+        let queries = parse_benchmark(V2_JSON).unwrap();
+        let title_map = HashMap::new();
+
+        // Mode A: hits query 1 at rank 1, misses query 2.
+        let run_a = run_queries(
+            |q| {
+                Ok(if q.starts_with("quarterly") {
+                    stub_ranked(&["doc-a"])
+                } else {
+                    stub_ranked(&["doc-x"])
+                })
+            },
+            &queries,
+            &title_map,
+            QualityMode::Fts,
+            10,
+        )
+        .unwrap();
+
+        // Mode B: hits query 1 at rank 2, hits query 2 at rank 1.
+        let run_b = run_queries(
+            |q| {
+                Ok(if q.starts_with("quarterly") {
+                    stub_ranked(&["doc-x", "doc-a"])
+                } else {
+                    stub_ranked(&["doc-b"])
+                })
+            },
+            &queries,
+            &title_map,
+            QualityMode::Semantic,
+            10,
+        )
+        .unwrap();
+
+        let comparisons = pairwise_comparisons(&[run_a, run_b]);
+
+        assert_eq!(comparisons.len(), 1);
+        let cmp = &comparisons[0];
+        assert_eq!(cmp.mode_a, "fts");
+        assert_eq!(cmp.mode_b, "semantic");
+        assert_eq!(cmp.result.wins, 1);
+        assert_eq!(cmp.result.losses, 1);
+        assert_eq!(cmp.result.ties, 0);
+    }
+
+    #[test]
+    fn single_run_has_no_comparisons() {
+        let queries = parse_benchmark(V1_JSON).unwrap();
+        let title_map = HashMap::new();
+        let run = run_queries(
+            |_| Ok(vec![]),
+            &queries,
+            &title_map,
+            QualityMode::Fts,
+            10,
+        )
+        .unwrap();
+
+        assert!(pairwise_comparisons(&[run]).is_empty());
     }
 }

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -150,12 +150,7 @@ pub(super) fn run_quality_benchmark(
         .with_context(|| format!("Failed to read benchmark file: {}", args.file.display()))?;
     let queries = parse_benchmark(&content)?;
     let title_map = build_title_map(conn)?;
-
-    let modes: Vec<QualityMode> = if args.compare.is_empty() {
-        vec![args.mode]
-    } else {
-        args.compare.to_vec()
-    };
+    let modes = resolve_modes(args.mode, args.compare)?;
 
     let mut runs = Vec::with_capacity(modes.len());
     for mode in modes {
@@ -329,6 +324,23 @@ fn latency_stats(outcomes: &[QueryOutcome]) -> LatencyStats {
         avg_ms: latencies.iter().sum::<f64>() / latencies.len() as f64,
         p50_ms: percentile(&latencies, 50.0),
     }
+}
+
+/// The modes to run: the --compare list when given (validated), else the
+/// single --mode.
+fn resolve_modes(mode: QualityMode, compare: &[QualityMode]) -> Result<Vec<QualityMode>> {
+    if compare.is_empty() {
+        return Ok(vec![mode]);
+    }
+    if compare.len() < 2 {
+        bail!("--compare needs at least two modes, e.g. --compare fts,semantic");
+    }
+    for (i, m) in compare.iter().enumerate() {
+        if compare[..i].contains(m) {
+            bail!("--compare has a duplicate mode: {}", m.as_str());
+        }
+    }
+    Ok(compare.to_vec())
 }
 
 /// Run-level matching method: "id" or "title" when uniform, "mixed" otherwise.
@@ -614,6 +626,38 @@ mod tests {
         assert_eq!(matching_summary(&["id", "id"]), "id");
         assert_eq!(matching_summary(&["title"]), "title");
         assert_eq!(matching_summary(&["id", "title"]), "mixed");
+    }
+
+    #[test]
+    fn resolve_modes_defaults_to_single_mode() {
+        let modes = resolve_modes(QualityMode::Semantic, &[]).unwrap();
+        assert_eq!(modes, vec![QualityMode::Semantic]);
+    }
+
+    #[test]
+    fn resolve_modes_uses_compare_list() {
+        let modes = resolve_modes(
+            QualityMode::Semantic,
+            &[QualityMode::Fts, QualityMode::Semantic],
+        )
+        .unwrap();
+        assert_eq!(modes, vec![QualityMode::Fts, QualityMode::Semantic]);
+    }
+
+    #[test]
+    fn resolve_modes_rejects_single_compare_mode() {
+        let err = resolve_modes(QualityMode::Semantic, &[QualityMode::Fts]).unwrap_err();
+        assert!(err.to_string().contains("at least two"));
+    }
+
+    #[test]
+    fn resolve_modes_rejects_duplicate_compare_modes() {
+        let err = resolve_modes(
+            QualityMode::Semantic,
+            &[QualityMode::Fts, QualityMode::Fts],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("duplicate"));
     }
 
     fn stub_ranked(ids: &[&str]) -> Vec<RankedDoc> {

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -27,6 +27,10 @@ pub struct QualityArgs<'a> {
     pub mode: QualityMode,
     pub compare: &'a [QualityMode],
     pub detail: bool,
+    pub record: bool,
+    pub note: Option<&'a str>,
+    /// --db override, when given; the default database path otherwise applies.
+    pub db: Option<&'a Path>,
 }
 
 /// A single test query from the benchmark file.
@@ -90,7 +94,7 @@ struct TopHit {
 
 /// Full scored outcome for one query in one mode.
 #[derive(Debug, Serialize)]
-struct QueryOutcome {
+pub(super) struct QueryOutcome {
     query: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     query_type: Option<String>,
@@ -119,7 +123,7 @@ pub struct ModeRun {
     /// Empty when no query carries a `query_type` label (v1 golden set).
     pub strata: BTreeMap<String, AggregateMetrics>,
     pub latency: LatencyStats,
-    query_results: Vec<QueryOutcome>,
+    pub(super) query_results: Vec<QueryOutcome>,
 }
 
 impl ModeRun {
@@ -172,6 +176,45 @@ pub(super) fn run_quality_benchmark(
         OutputMode::Tty => print_tty(&runs, &comparisons, args.detail),
     }
 
+    if args.record {
+        record_runs(&runs, args)?;
+    }
+
+    Ok(())
+}
+
+/// Persist every run to the results ledger in the benchmarks directory.
+/// Confirmation goes to stderr so --json stdout stays parseable.
+fn record_runs(runs: &[ModeRun], args: &QualityArgs) -> Result<()> {
+    let benchmarks_dir = crate::platform::data_dir()?.join("benchmarks");
+    let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let set = args
+        .file
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| args.file.display().to_string());
+    let binary = format!("grans {}", env!("GRANS_VERSION"));
+    let db = match args.db {
+        Some(path) => path.display().to_string(),
+        None => crate::db::connection::default_db_path()?.display().to_string(),
+    };
+
+    let ctx = super::ledger::RecordContext {
+        benchmarks_dir: &benchmarks_dir,
+        date: &date,
+        set: &set,
+        binary: &binary,
+        db: &db,
+        note: args.note,
+    };
+    for run in runs {
+        let run_path = super::ledger::record_run(&ctx, run)?;
+        eprintln!("Recorded {} run: {}", run.mode, run_path.display());
+    }
+    eprintln!(
+        "Ledger updated: {}",
+        benchmarks_dir.join("ledger.jsonl").display()
+    );
     Ok(())
 }
 

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -83,27 +83,27 @@ struct BenchmarkFile {
 
 /// A single result document in a query's top k, for the per-query output.
 #[derive(Debug, Serialize)]
-struct TopHit {
-    rank: usize,
-    document_id: String,
+pub(super) struct TopHit {
+    pub(super) rank: usize,
+    pub(super) document_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    title: Option<String>,
+    pub(super) title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    score: Option<f32>,
+    pub(super) score: Option<f32>,
 }
 
 /// Full scored outcome for one query in one mode.
 #[derive(Debug, Serialize)]
 pub(super) struct QueryOutcome {
-    query: String,
+    pub(super) query: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    query_type: Option<String>,
-    matching: &'static str,
-    expected: Vec<String>,
+    pub(super) query_type: Option<String>,
+    pub(super) matching: &'static str,
+    pub(super) expected: Vec<String>,
     #[serde(flatten)]
-    score: QueryScore,
-    latency_ms: f64,
-    top_k: Vec<TopHit>,
+    pub(super) score: QueryScore,
+    pub(super) latency_ms: f64,
+    pub(super) top_k: Vec<TopHit>,
 }
 
 #[derive(Debug, Serialize)]
@@ -167,8 +167,8 @@ pub(super) fn run_quality_benchmark(
     let comparisons = pairwise_comparisons(&runs);
 
     match output_mode {
-        OutputMode::Json => print_json(&runs, &comparisons)?,
-        OutputMode::Tty => print_tty(&runs, &comparisons, args.detail),
+        OutputMode::Json => super::report::print_json(&runs, &comparisons)?,
+        OutputMode::Tty => super::report::print_tty(&runs, &comparisons, args.detail),
     }
 
     if args.record {
@@ -379,171 +379,6 @@ fn build_title_map(conn: &Connection) -> Result<HashMap<String, String>> {
         map.insert(id, title);
     }
     Ok(map)
-}
-
-// === Output ===
-
-fn print_json(runs: &[ModeRun], comparisons: &[PairwiseComparison]) -> Result<()> {
-    if runs.len() == 1 {
-        println!("{}", serde_json::to_string_pretty(&runs[0])?);
-    } else {
-        let combined = serde_json::json!({
-            "runs": runs,
-            "comparisons": comparisons,
-        });
-        println!("{}", serde_json::to_string_pretty(&combined)?);
-    }
-    Ok(())
-}
-
-fn print_tty(runs: &[ModeRun], comparisons: &[PairwiseComparison], detail: bool) {
-    for run in runs {
-        print_run_tty(run, detail);
-        println!();
-    }
-    if runs.len() > 1 {
-        print_compare_tty(runs, comparisons);
-    }
-}
-
-fn print_run_tty(run: &ModeRun, detail: bool) {
-    use colored::Colorize;
-
-    let heading = format!("Search Quality Benchmark ({})", run.mode);
-    println!("{}", heading.bold().cyan());
-    println!("{}", "=".repeat(heading.len()).cyan());
-    println!();
-    println!("{:24} {:>10}", "Queries:".bold(), run.overall.n);
-    println!("{:24} {:>10}", "k:".bold(), run.k);
-    println!("{:24} {:>10}", "Matching:".bold(), run.matching);
-    println!(
-        "{:24} {:>10}",
-        "Matches in top k:".bold(),
-        run.overall.queries_with_match
-    );
-    println!();
-    println!(
-        "{:24} {:>10.1}%",
-        format!("hit-rate@{}:", run.k).bold().green(),
-        run.overall.hit_rate_at_k * 100.0
-    );
-    println!(
-        "{:24} {:>10.1}%",
-        format!("recall@{}:", run.k).bold().green(),
-        run.overall.recall_at_k * 100.0
-    );
-    println!(
-        "{:24} {:>10.3}",
-        format!("MRR@{}:", run.k).bold().green(),
-        run.overall.mrr
-    );
-    println!(
-        "{:24} {:>10}",
-        "Latency (avg / p50):".bold(),
-        format!("{:.1} / {:.1} ms", run.latency.avg_ms, run.latency.p50_ms)
-    );
-
-    if !run.strata.is_empty() {
-        println!();
-        println!(
-            "{:<12} {:>4} {:>10} {:>10} {:>8}",
-            "Stratum".bold().yellow(),
-            "n",
-            "hit-rate",
-            "recall",
-            "MRR"
-        );
-        for (stratum, agg) in &run.strata {
-            println!(
-                "{:<12} {:>4} {:>9.1}% {:>9.1}% {:>8.3}",
-                stratum,
-                agg.n,
-                agg.hit_rate_at_k * 100.0,
-                agg.recall_at_k * 100.0,
-                agg.mrr
-            );
-        }
-    }
-
-    if detail {
-        print_detail_tty(run);
-    }
-}
-
-fn print_detail_tty(run: &ModeRun) {
-    use colored::Colorize;
-
-    println!();
-    println!("{}", "Query Details".bold().yellow());
-    println!("{}", "-".repeat(13).yellow());
-
-    for qr in &run.query_results {
-        let status = if qr.score.found_in_top_k {
-            "PASS".green()
-        } else {
-            "MISS".red()
-        };
-
-        println!();
-        println!("[{}] {}", status, qr.query.bold());
-        println!("  Expected: {}", qr.expected.join(", "));
-        match qr.score.best_rank {
-            Some(rank) => {
-                let score_note = qr
-                    .score
-                    .best_score
-                    .map(|s| format!(" (score: {:.3})", s))
-                    .unwrap_or_default();
-                println!("  First relevant at rank {}{}", rank, score_note);
-            }
-            None => {
-                println!("  Not found");
-                let got = qr
-                    .top_k
-                    .first()
-                    .and_then(|h| h.title.as_deref())
-                    .unwrap_or("(no results)");
-                println!("  Got: {}", got);
-            }
-        }
-    }
-}
-
-fn print_compare_tty(runs: &[ModeRun], comparisons: &[PairwiseComparison]) {
-    use colored::Colorize;
-
-    println!("{}", "Per-query rank of first relevant".bold().cyan());
-    println!("{}", "-".repeat(32).cyan());
-    for run in runs {
-        print!("{:>10}", run.mode);
-    }
-    println!("  query");
-
-    let n = runs[0].query_results.len();
-    for i in 0..n {
-        for run in runs {
-            let cell = run.query_results[i]
-                .score
-                .best_rank
-                .map(|r| r.to_string())
-                .unwrap_or_else(|| "-".to_string());
-            print!("{:>10}", cell);
-        }
-        let query = &runs[0].query_results[i].query;
-        let truncated: String = query.chars().take(60).collect();
-        println!("  {}", truncated);
-    }
-
-    println!();
-    for cmp in comparisons {
-        println!(
-            "{}: {} wins / {} losses / {} ties (on best rank)",
-            format!("{} vs {}", cmp.mode_a, cmp.mode_b).bold(),
-            cmp.result.wins,
-            cmp.result.losses,
-            cmp.result.ties
-        );
-    }
 }
 
 #[cfg(test)]

--- a/src/commands/benchmark/report.rs
+++ b/src/commands/benchmark/report.rs
@@ -1,0 +1,168 @@
+//! Terminal and JSON rendering for quality benchmark results.
+
+use anyhow::Result;
+
+use super::quality::{ModeRun, PairwiseComparison};
+
+pub(super) fn print_json(runs: &[ModeRun], comparisons: &[PairwiseComparison]) -> Result<()> {
+    if runs.len() == 1 {
+        println!("{}", serde_json::to_string_pretty(&runs[0])?);
+    } else {
+        let combined = serde_json::json!({
+            "runs": runs,
+            "comparisons": comparisons,
+        });
+        println!("{}", serde_json::to_string_pretty(&combined)?);
+    }
+    Ok(())
+}
+
+pub(super) fn print_tty(runs: &[ModeRun], comparisons: &[PairwiseComparison], detail: bool) {
+    for run in runs {
+        print_run_tty(run, detail);
+        println!();
+    }
+    if runs.len() > 1 {
+        print_compare_tty(runs, comparisons);
+    }
+}
+
+fn print_run_tty(run: &ModeRun, detail: bool) {
+    use colored::Colorize;
+
+    let heading = format!("Search Quality Benchmark ({})", run.mode);
+    println!("{}", heading.bold().cyan());
+    println!("{}", "=".repeat(heading.len()).cyan());
+    println!();
+    println!("{:24} {:>10}", "Queries:".bold(), run.overall.n);
+    println!("{:24} {:>10}", "k:".bold(), run.k);
+    println!("{:24} {:>10}", "Matching:".bold(), run.matching);
+    println!(
+        "{:24} {:>10}",
+        "Matches in top k:".bold(),
+        run.overall.queries_with_match
+    );
+    println!();
+    println!(
+        "{:24} {:>10.1}%",
+        format!("hit-rate@{}:", run.k).bold().green(),
+        run.overall.hit_rate_at_k * 100.0
+    );
+    println!(
+        "{:24} {:>10.1}%",
+        format!("recall@{}:", run.k).bold().green(),
+        run.overall.recall_at_k * 100.0
+    );
+    println!(
+        "{:24} {:>10.3}",
+        format!("MRR@{}:", run.k).bold().green(),
+        run.overall.mrr
+    );
+    println!(
+        "{:24} {:>10}",
+        "Latency (avg / p50):".bold(),
+        format!("{:.1} / {:.1} ms", run.latency.avg_ms, run.latency.p50_ms)
+    );
+
+    if !run.strata.is_empty() {
+        println!();
+        println!(
+            "{:<12} {:>4} {:>10} {:>10} {:>8}",
+            "Stratum".bold().yellow(),
+            "n",
+            "hit-rate",
+            "recall",
+            "MRR"
+        );
+        for (stratum, agg) in &run.strata {
+            println!(
+                "{:<12} {:>4} {:>9.1}% {:>9.1}% {:>8.3}",
+                stratum,
+                agg.n,
+                agg.hit_rate_at_k * 100.0,
+                agg.recall_at_k * 100.0,
+                agg.mrr
+            );
+        }
+    }
+
+    if detail {
+        print_detail_tty(run);
+    }
+}
+
+fn print_detail_tty(run: &ModeRun) {
+    use colored::Colorize;
+
+    println!();
+    println!("{}", "Query Details".bold().yellow());
+    println!("{}", "-".repeat(13).yellow());
+
+    for qr in &run.query_results {
+        let status = if qr.score.found_in_top_k {
+            "PASS".green()
+        } else {
+            "MISS".red()
+        };
+
+        println!();
+        println!("[{}] {}", status, qr.query.bold());
+        println!("  Expected: {}", qr.expected.join(", "));
+        match qr.score.best_rank {
+            Some(rank) => {
+                let score_note = qr
+                    .score
+                    .best_score
+                    .map(|s| format!(" (score: {:.3})", s))
+                    .unwrap_or_default();
+                println!("  First relevant at rank {}{}", rank, score_note);
+            }
+            None => {
+                println!("  Not found");
+                let got = qr
+                    .top_k
+                    .first()
+                    .and_then(|h| h.title.as_deref())
+                    .unwrap_or("(no results)");
+                println!("  Got: {}", got);
+            }
+        }
+    }
+}
+
+fn print_compare_tty(runs: &[ModeRun], comparisons: &[PairwiseComparison]) {
+    use colored::Colorize;
+
+    println!("{}", "Per-query rank of first relevant".bold().cyan());
+    println!("{}", "-".repeat(32).cyan());
+    for run in runs {
+        print!("{:>10}", run.mode);
+    }
+    println!("  query");
+
+    let n = runs[0].query_results.len();
+    for i in 0..n {
+        for run in runs {
+            let cell = run.query_results[i]
+                .score
+                .best_rank
+                .map(|r| r.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            print!("{:>10}", cell);
+        }
+        let query = &runs[0].query_results[i].query;
+        let truncated: String = query.chars().take(60).collect();
+        println!("  {}", truncated);
+    }
+
+    println!();
+    for cmp in comparisons {
+        println!(
+            "{}: {} wins / {} losses / {} ties (on best rank)",
+            format!("{} vs {}", cmp.mode_a, cmp.mode_b).bold(),
+            cmp.result.wins,
+            cmp.result.losses,
+            cmp.result.ties
+        );
+    }
+}

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -1,0 +1,140 @@
+//! Retrieval backends for the quality benchmark.
+//!
+//! Each mode returns the full document-level ranked list for a query;
+//! scoring (metrics.rs) applies k. Lists reflect current production
+//! behavior for the mode: FTS has no relevance ranking yet (Phase 1),
+//! semantic is ranked by best-chunk cosine score.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::metrics::RankedDoc;
+use crate::cli::args::QualityMode;
+use crate::embed::model::{Embedder, FastEmbedModel};
+use crate::embed::search::SemanticSearchResult;
+use crate::embed::{ensure_embeddings, EmbeddingIndex, DEFAULT_BATCH_SIZE};
+
+pub enum Retriever<'a> {
+    Fts {
+        conn: &'a Connection,
+    },
+    Semantic {
+        embedder: FastEmbedModel,
+        index: EmbeddingIndex,
+    },
+}
+
+impl<'a> Retriever<'a> {
+    /// Build the retriever for a mode. For semantic, the embedding model and
+    /// index are loaded once here so per-query latency measures search, not
+    /// one-time setup.
+    pub fn build(mode: QualityMode, conn: &'a Connection) -> Result<Self> {
+        match mode {
+            QualityMode::Fts => Ok(Retriever::Fts { conn }),
+            QualityMode::Semantic => {
+                let embedder = FastEmbedModel::new()?;
+                let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE)?;
+                Ok(Retriever::Semantic { embedder, index })
+            }
+        }
+    }
+
+    /// Run one query, returning the full ranked document list.
+    pub fn retrieve(&self, query: &str) -> Result<Vec<RankedDoc>> {
+        match self {
+            Retriever::Fts { conn } => retrieve_fts(conn, query),
+            Retriever::Semantic { embedder, index } => {
+                let query_vec = embedder.embed_query(query)?;
+                Ok(to_ranked(index.search(&query_vec, 0.0, None)))
+            }
+        }
+    }
+}
+
+/// FTS keyword search over the same targets `grans search` uses by default
+/// (titles, transcripts, notes, panels), in production result order
+/// (created_at DESC).
+fn retrieve_fts(conn: &Connection, query: &str) -> Result<Vec<RankedDoc>> {
+    let docs =
+        crate::db::meetings::search_meetings(conn, query, true, true, true, true, None, false)?;
+    Ok(docs
+        .into_iter()
+        .filter_map(|d| d.id)
+        .map(|id| RankedDoc {
+            document_id: id,
+            score: None,
+        })
+        .collect())
+}
+
+/// Map document-level semantic results (already deduped and sorted by score
+/// descending) to the scoring input type.
+fn to_ranked(results: Vec<SemanticSearchResult>) -> Vec<RankedDoc> {
+    results
+        .into_iter()
+        .map(|r| RankedDoc {
+            document_id: r.document_id,
+            score: Some(r.score),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_fixtures::{build_test_db, meetings_state};
+
+    #[test]
+    fn fts_retriever_returns_matching_documents() {
+        let conn = build_test_db(&meetings_state());
+        let retriever = Retriever::Fts { conn: &conn };
+
+        let ranked = retriever.retrieve("machine learning").unwrap();
+
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].document_id, "doc-1");
+        assert_eq!(ranked[0].score, None);
+    }
+
+    #[test]
+    fn fts_retriever_empty_for_no_match() {
+        let conn = build_test_db(&meetings_state());
+        let retriever = Retriever::Fts { conn: &conn };
+
+        let ranked = retriever.retrieve("zebra xylophone").unwrap();
+
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn to_ranked_preserves_order_and_scores() {
+        let results = vec![
+            SemanticSearchResult {
+                document_id: "d1".into(),
+                score: 0.9,
+                source_type: "transcript".into(),
+                matched_text: String::new(),
+                window_start_idx: None,
+                window_end_idx: None,
+                match_context: None,
+            },
+            SemanticSearchResult {
+                document_id: "d2".into(),
+                score: 0.7,
+                source_type: "notes".into(),
+                matched_text: String::new(),
+                window_start_idx: None,
+                window_end_idx: None,
+                match_context: None,
+            },
+        ];
+
+        let ranked = to_ranked(results);
+
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].document_id, "d1");
+        assert_eq!(ranked[0].score, Some(0.9));
+        assert_eq!(ranked[1].document_id, "d2");
+        assert_eq!(ranked[1].score, Some(0.7));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<()> {
     // Benchmark command
     if let Commands::Benchmark { action } = &cli.command {
         let conn = get_connection(cli.db.as_deref())?;
-        commands::benchmark::run(&conn, action, ctx.output_mode)?;
+        commands::benchmark::run(&conn, action, cli.db.as_deref(), ctx.output_mode)?;
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary

Phase 0 of the search roadmap (#37): make `benchmark quality` retriever-agnostic so every later phase can be gated on before/after numbers. No search behavior changes; only the harness (plus docs).

- `--mode fts|semantic` scores any retrieval mode (semantic stays the default); further modes appear as later phases land
- `--compare fts,semantic` runs several modes with a per-query rank-of-first-relevant table and a pairwise win/loss/tie summary
- Results match labels by document ID (`relevant_meeting_ids`). Exact-title matching remains only as the fallback for the v1 file; titles are heavily duplicated across recurring meetings (329 unique titles across 872 documents), so title matching over-credits recurring series. Each run reports which method applied.
- Metrics: the reported precision@k is renamed hit-rate@k (that is what it computed), recall@k over each query's full label list is added, MRR stays (counted at k), and per-mode query latency is recorded (retriever setup such as model load happens once, outside the timed loop)
- `--record` appends one line per mode to `ledger.jsonl` in the benchmarks directory (date, binary version, mode, matching method, k, metrics with per-stratum breakdown, latency, db path, optional `--note`) and writes the full per-query output under `runs/`
- `src/commands/benchmark.rs` split into `benchmark/{mod,perf,quality,metrics,retriever,report,ledger}.rs`
- Fixes a clap quirk found while recording baselines: `num_args = 2..` counts raw values before delimiter splitting, so the documented `--compare fts,semantic` form was rejected; validation moved into code with parse regression tests

## Baselines (gate)

Recorded on the v2 golden set (93 stratified queries, ID matching, k=10, `grans 2026.7.10 (046d6d6)`, db unchanged since 2026-07-09: 872 docs / 33,510 chunks). Ledger and per-query outputs live in the benchmarks directory outside this repo.

Before (old harness: semantic only, title matching): hit-rate@10 0.839, MRR 0.700.

After (new harness, ID matching):

| Mode | hit-rate@10 | recall@10 | MRR@10 | avg / p50 latency |
|---|---|---|---|---|
| fts | 0.054 | 0.030 | 0.039 | 4.7 / 4.6 ms |
| semantic | 0.860 | 0.759 | 0.721 | 57.6 / 57.1 ms |

Semantic per stratum (hit-rate / recall / MRR): exact-term 0.917 / 0.858 / 0.808; mixed 0.860 / 0.793 / 0.768; paraphrase 0.842 / 0.689 / 0.639.

FTS vs semantic on best rank: 1 win / 90 losses / 2 ties. The FTS collapse outside exact-term is the known phrase-quoting behavior plus recency-only ordering; fixing that is Phase 1 (#39), not this PR.

Title-matched and ID-matched numbers are not comparable; the ledger keeps both eras and the new entries carry a note saying so.

## Testing

- 655 tests pass (`cargo test`), including new TDD units for scoring, matching fallback, strata aggregation, win/loss/tie, retrievers, file parsing/validation, ledger append/collision behavior, and CLI parse regressions
- End-to-end: FTS run, `--compare` run, and `--record` run executed against the real v2 set; ledger and `runs/` output verified

Closes #38.