### PR TITLE
#39: bm25 ranking and implicit-AND query semantics for keyword search

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ grans search "budget" --include-deleted
 grans search "old project" --semantic --include-deleted
 ```
 
+Keyword search matches every word in the query, in any order: `grans search "budget review"` finds meetings that mention both words. To require an exact phrase, quote it inside the query (e.g. `grans search '"budget review"'`). Results are ranked by relevance: meetings whose title contains the query come first, then content matches ranked by BM25, with newer meetings breaking ties.
+
 Semantic search uses a local embedding model (`nomic-embed-text-v1.5`) to find meetings by meaning rather than exact keywords. On first use, the model is downloaded automatically (~270MB). Embeddings are built from transcripts, AI-generated panel sections, and your notes, and are stored in the main database. Use `--in` to restrict which sources are searched (e.g. `--in panels` to only search AI notes).
 
 When an upgrade changes the embedding model, existing embeddings are detected as stale and rebuilt automatically on the next embed or semantic search. This full rebuild is a one-time cost and can take a while on large databases; run `grans embed -y` to do it at a time of your choosing.

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -4,7 +4,7 @@ A staged plan to evolve `grans search` from two separate modes (FTS5 keyword, se
 
 ## Current state (2026-07)
 
-- **Keyword search**: FTS5 `MATCH` used as a boolean filter; results ordered by `created_at DESC`. No relevance ranking. Additionally, `sanitize_fts_query` wraps the whole query in double quotes, which FTS5 interprets as a phrase query: multi-word searches only match the words adjacent and in order, not AND semantics.
+- **Keyword search** (Phase 1, #39): FTS5 `MATCH` with implicit-AND semantics (each term quoted individually; user-supplied quotes force phrase matching), ranked by `bm25()` with recency as tiebreak. Title substring matches rank as a tier above content matches; weighting them properly is Phase 5. Applies to the combined search and the standalone transcript/notes/panel searches.
 - **Semantic search** (`--semantic`): nomic-embed-text-v1.5 (768d) via fastembed, brute-force cosine over in-memory vectors, `min_score` cutoff. Chunkers for transcripts (adaptive window), panels (section), notes (paragraph).
 - The two modes are mutually exclusive; `commands/search.rs` dispatches to one or the other.
 - **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. Implemented in `commands/benchmark/`.

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -55,14 +55,24 @@ Phase 0 baselines on v2 (2026-07-10, k=10, **ID matching**, commit 046d6d6):
 | fts | 0.05 | 0.03 | 0.04 | ~5 ms |
 | semantic | 0.86 | 0.76 | 0.72 | ~58 ms |
 
-Semantic per stratum (hit-rate / MRR): exact-term 0.92 / 0.81, mixed 0.86 / 0.77, paraphrase 0.84 / 0.64. FTS beats semantic on best rank for 1 of 93 queries (90 losses, 2 ties); its collapse outside exact-term is the phrase-quoting bug plus recency-only ordering, which Phase 1 addresses. Full per-stratum metrics for both modes are in the ledger.
+Semantic per stratum (hit-rate / MRR): exact-term 0.92 / 0.81, mixed 0.86 / 0.77, paraphrase 0.84 / 0.64. FTS beats semantic on best rank for 1 of 93 queries (90 losses, 2 ties); its collapse outside exact-term was the phrase-quoting bug plus recency-only ordering, which Phase 1 fixed. Full per-stratum metrics for both modes are in the ledger.
+
+Phase 1 results (2026-07-10, k=10, ID matching, same snapshot):
+
+| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
+|---|---|---|---|---|
+| fts (Phase 0) | 0.05 | 0.03 | 0.04 | ~5 ms |
+| fts (Phase 1) | 0.17 | 0.09 | 0.14 | ~5 ms |
+| semantic (unchanged) | 0.86 | 0.76 | 0.72 | ~58 ms |
+
+Per query, 11 flipped miss-to-hit, none hit-to-miss, worst rank change 7 to 9; FTS vs semantic on best rank moved from 1/90/2 to 2/82/9 (W/L/T). Under the re-audited strata (below), FTS scores hit-rate 0.94 / MRR 0.76 on exact-term (n=17) and zero on mixed and paraphrase; semantic scores 1.00 / 0.92 on exact-term. Note the implicit-AND granularity: all terms must co-occur within one FTS row (a single utterance, panel, or notes document), so multi-term queries whose terms are scattered across a transcript still miss.
 
 (v1-file baseline for reference: hit-rate@10 ~73%, MRR ~0.55, title matching.)
 
 Caveats a maintainer must know:
 
 - Ledger entries recorded before 2026-07-10 used title matching, which over-credits recurring-title meetings; do not compare them against ID-matched numbers.
-- `query_type` labels were assigned relative to the current phrase-matching keyword behavior: several queries were demoted from exact-term to mixed only because the full query fails as a phrase. After Phase 1 lands implicit-AND semantics, re-audit the strata; the exact-term stratum (n=12) is currently thin and noisy.
+- `query_type` strata were re-audited on 2026-07-10 after Phase 1 landed: 9 queries demoted to mixed only for the old phrase-match failure were promoted back to exact-term, and 4 exact-term labels that fail the operational test (all terms verbatim within one utterance/panel/notes row of a labeled doc) were demoted to mixed. Exact-term is now n=17, mixed n=38, paraphrase n=38. Ledger entries recorded before the re-audit used the old strata; their per-stratum numbers are not comparable to later entries (overall metrics are unaffected).
 - For stable numbers across syncs, benchmark against the frozen snapshot rather than the live database: `grans --db <benchmarks-dir>/grans-snapshot-2026-07-09.db benchmark quality ...`. The snapshot is byte-identical to the state the Phase 0 baselines were recorded against (872 docs, 33,510 chunks); the live database drifts with every `grans sync`, which invalidates per-query comparison against earlier ledger entries.
 - Open review items: the 11 v1 queries' `query_type` values were hand-assigned and unreviewed, and two v1 queries ("AI phone agent...", "changing an intermittent caregiving leave...") had their ID labels expanded across recurring-title instances that may over-include.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -43,7 +43,7 @@ pub enum Commands {
     /// Search meetings, transcripts, and notes
     #[command(visible_alias = "s")]
     Search {
-        /// Search query
+        /// Search query; words match in any order, "quoted phrases" must match exactly
         query: String,
 
         /// Search targets: titles, transcripts, notes, panels (comma-separated)

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -53,7 +53,7 @@ impl<'a> Retriever<'a> {
 
 /// FTS keyword search over the same targets `grans search` uses by default
 /// (titles, transcripts, notes, panels), in production result order
-/// (created_at DESC).
+/// (bm25 relevance, recency tiebreak).
 fn retrieve_fts(conn: &Connection, query: &str) -> Result<Vec<RankedDoc>> {
     let docs =
         crate::db::meetings::search_meetings(conn, query, true, true, true, true, None, false)?;

--- a/src/db/meetings.rs
+++ b/src/db/meetings.rs
@@ -231,69 +231,67 @@ pub fn search_meetings(
     date_range: Option<&DateRange>,
     include_deleted: bool,
 ) -> Result<Vec<Document>> {
-    let title_pattern = format!("%{}%", query);
-    let fts_query = sanitize_fts_query(query);
-    let doc_filter = if include_deleted { "" } else { " AND deleted_at IS NULL" };
-    let d_doc_filter = if include_deleted { "" } else { " AND d.deleted_at IS NULL" };
-
-    // Build UNION of matching document IDs from requested search types
-    let mut union_parts: Vec<String> = Vec::new();
+    // Each enabled source contributes (doc_id, title_hit, score) rows; a
+    // document's rank is its best (lowest) bm25 score across sources.
+    let mut union_parts: Vec<&str> = Vec::new();
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-    let mut param_idx = 1;
 
     if search_titles {
-        let mut sub = format!(
-            "SELECT id FROM documents WHERE 1=1{} AND title LIKE ?{} COLLATE NOCASE",
-            doc_filter, param_idx
+        union_parts.push(
+            "SELECT id AS doc_id, 1 AS title_hit, NULL AS score FROM documents WHERE title LIKE ? COLLATE NOCASE",
         );
-        params.push(Box::new(title_pattern));
-        param_idx += 1;
-        append_date_filter(&mut sub, &mut params, &mut param_idx, date_range, "created_at");
-        union_parts.push(sub);
+        params.push(Box::new(format!("%{}%", query)));
     }
 
+    let fts_query = sanitize_fts_query(query);
+
     if search_notes {
-        let mut sub = format!(
-            "SELECT d.id FROM notes_fts JOIN documents d ON notes_fts.rowid = d.rowid WHERE 1=1{} AND notes_fts MATCH ?{}",
-            d_doc_filter, param_idx
+        union_parts.push(
+            "SELECT d.id AS doc_id, 0 AS title_hit, bm25(notes_fts) AS score FROM notes_fts JOIN documents d ON notes_fts.rowid = d.rowid WHERE notes_fts MATCH ?",
         );
         params.push(Box::new(fts_query.clone()));
-        param_idx += 1;
-        append_date_filter(&mut sub, &mut params, &mut param_idx, date_range, "d.created_at");
-        union_parts.push(sub);
     }
 
     if search_transcripts {
-        let mut sub = format!(
-            "SELECT DISTINCT tu.document_id FROM transcript_fts JOIN transcript_utterances tu ON transcript_fts.rowid = tu.rowid JOIN documents d ON tu.document_id = d.id WHERE 1=1{} AND transcript_fts MATCH ?{}",
-            d_doc_filter, param_idx
+        union_parts.push(
+            "SELECT tu.document_id AS doc_id, 0 AS title_hit, bm25(transcript_fts) AS score FROM transcript_fts JOIN transcript_utterances tu ON transcript_fts.rowid = tu.rowid WHERE transcript_fts MATCH ?",
         );
         params.push(Box::new(fts_query.clone()));
-        param_idx += 1;
-        append_date_filter(&mut sub, &mut params, &mut param_idx, date_range, "d.created_at");
-        union_parts.push(sub);
     }
 
     if search_panels {
-        let mut sub = format!(
-            "SELECT DISTINCT p.document_id FROM panels_fts JOIN panels p ON panels_fts.rowid = p.rowid JOIN documents d ON p.document_id = d.id WHERE p.deleted_at IS NULL{} AND panels_fts MATCH ?{}",
-            d_doc_filter, param_idx
+        union_parts.push(
+            "SELECT p.document_id AS doc_id, 0 AS title_hit, bm25(panels_fts) AS score FROM panels_fts JOIN panels p ON panels_fts.rowid = p.rowid WHERE p.deleted_at IS NULL AND panels_fts MATCH ?",
         );
         params.push(Box::new(fts_query));
-        param_idx += 1;
-        append_date_filter(&mut sub, &mut params, &mut param_idx, date_range, "d.created_at");
-        union_parts.push(sub);
     }
 
     if union_parts.is_empty() {
         return Ok(Vec::new());
     }
 
-    let union_sql = union_parts.join(" UNION ");
-    let sql = format!(
-        "SELECT id, title, created_at, updated_at, deleted_at, doc_type, notes_plain, notes_markdown, summary, people_json, google_calendar_event_json FROM documents WHERE 1=1{} AND id IN ({}) ORDER BY created_at DESC",
-        doc_filter, union_sql
+    // MATERIALIZED stops the query flattener from pulling bm25() into the
+    // aggregate context, where FTS5 auxiliary functions cannot run.
+    let mut sql = format!(
+        "WITH hits AS MATERIALIZED ({})
+         SELECT d.id, d.title, d.created_at, d.updated_at, d.deleted_at, d.doc_type, d.notes_plain, d.notes_markdown, d.summary, d.people_json, d.google_calendar_event_json
+         FROM documents d
+         JOIN (SELECT doc_id, MAX(title_hit) AS title_hit, MIN(score) AS best_score
+               FROM hits GROUP BY doc_id) m ON d.id = m.doc_id
+         WHERE 1=1",
+        union_parts.join(" UNION ALL ")
     );
+
+    if !include_deleted {
+        sql.push_str(" AND d.deleted_at IS NULL");
+    }
+    append_date_filter(&mut sql, &mut params, date_range, "d.created_at");
+
+    // bm25 is lower-is-better. Title matches carry no bm25 score: a title
+    // hit (the whole query as a substring of the title) outranks content
+    // matches, and within that tier title-only matches sort after scored
+    // ones. Recency breaks remaining ties.
+    sql.push_str(" ORDER BY m.title_hit DESC, m.best_score ASC NULLS LAST, d.created_at DESC");
 
     let mut stmt = conn.prepare(&sql)?;
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
@@ -320,20 +318,17 @@ pub fn search_meetings(
 fn append_date_filter(
     sql: &mut String,
     params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
-    param_idx: &mut usize,
     date_range: Option<&DateRange>,
     column: &str,
 ) {
     if let Some(range) = date_range {
         if let Some(start) = &range.start {
-            sql.push_str(&format!(" AND {} >= ?{}", column, param_idx));
+            sql.push_str(&format!(" AND {} >= ?", column));
             params.push(Box::new(start.to_rfc3339()));
-            *param_idx += 1;
         }
         if let Some(end) = &range.end {
-            sql.push_str(&format!(" AND {} < ?{}", column, param_idx));
+            sql.push_str(&format!(" AND {} < ?", column));
             params.push(Box::new(end.to_rfc3339()));
-            *param_idx += 1;
         }
     }
 }
@@ -520,6 +515,66 @@ mod tests {
             search_meetings(&conn, "neural networks", false, true, false, false, None, false).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-1"));
+    }
+
+    /// Docs where relevance and recency disagree. Filler rows keep the
+    /// matched terms under half the corpus so BM25 IDF stays positive.
+    fn ranking_state() -> serde_json::Value {
+        serde_json::json!({
+            "documents": {
+                "doc-relevant": {"id": "doc-relevant", "title": "Platform Sync", "created_at": "2026-01-10T10:00:00Z"},
+                "doc-mention": {"id": "doc-mention", "title": "Team Catchup", "created_at": "2026-01-20T10:00:00Z"},
+                "doc-titled": {"id": "doc-titled", "title": "Kubernetes Migration", "created_at": "2026-01-05T10:00:00Z"},
+                "doc-tie-old": {"id": "doc-tie-old", "title": "Metrics Review A", "created_at": "2026-01-08T10:00:00Z"},
+                "doc-tie-new": {"id": "doc-tie-new", "title": "Metrics Review B", "created_at": "2026-01-18T10:00:00Z"}
+            },
+            "transcripts": {
+                "doc-relevant": [
+                    {"id": "r1", "document_id": "doc-relevant", "text": "kubernetes migration steps kubernetes cluster upgrades and kubernetes networking"}
+                ],
+                "doc-mention": [
+                    {"id": "m1", "document_id": "doc-mention", "text": "someone mentioned kubernetes briefly while we mostly discussed the quarterly budget review"},
+                    {"id": "m2", "document_id": "doc-mention", "text": "budget planning discussion continued"}
+                ],
+                "doc-tie-old": [
+                    {"id": "t1", "document_id": "doc-tie-old", "text": "prometheus metrics dashboard review"}
+                ],
+                "doc-tie-new": [
+                    {"id": "t2", "document_id": "doc-tie-new", "text": "prometheus metrics dashboard review"}
+                ]
+            }
+        })
+    }
+
+    #[test]
+    fn test_search_meetings_ranks_by_relevance_not_recency() {
+        // Regression: results were ordered by created_at DESC, so a passing
+        // mention in a newer meeting outranked the meeting about the topic.
+        let conn = build_test_db(&ranking_state());
+        let results =
+            search_meetings(&conn, "kubernetes", false, true, false, false, None, false).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id.as_deref(), Some("doc-relevant"));
+        assert_eq!(results[1].id.as_deref(), Some("doc-mention"));
+    }
+
+    #[test]
+    fn test_search_meetings_title_match_ranks_first() {
+        let conn = build_test_db(&ranking_state());
+        let results =
+            search_meetings(&conn, "kubernetes", true, true, false, false, None, false).unwrap();
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].id.as_deref(), Some("doc-titled"));
+    }
+
+    #[test]
+    fn test_search_meetings_equal_relevance_breaks_ties_by_recency() {
+        let conn = build_test_db(&ranking_state());
+        let results =
+            search_meetings(&conn, "prometheus", false, true, false, false, None, false).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].id.as_deref(), Some("doc-tie-new"));
+        assert_eq!(results[1].id.as_deref(), Some("doc-tie-old"));
     }
 
     #[test]

--- a/src/db/meetings.rs
+++ b/src/db/meetings.rs
@@ -5,6 +5,7 @@ use super::common::{DocumentRow, row_to_document};
 use super::transcripts::{TranscriptUtteranceRow, row_to_utterance};
 use crate::models::{Document, TranscriptUtterance};
 use crate::query::dates::DateRange;
+use crate::query::fts::sanitize_fts_query;
 
 pub fn list_meetings(
     conn: &Connection,
@@ -337,10 +338,6 @@ fn append_date_filter(
     }
 }
 
-fn sanitize_fts_query(query: &str) -> String {
-    format!("\"{}\"", query.replace('"', ""))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -523,6 +520,35 @@ mod tests {
             search_meetings(&conn, "neural networks", false, true, false, false, None, false).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-1"));
+    }
+
+    #[test]
+    fn test_search_meetings_multi_word_matches_any_order() {
+        // Regression: the old sanitizer quoted the whole query as one FTS5
+        // phrase, so reversed word order never matched.
+        let conn = build_test_db(&meetings_state());
+        let results =
+            search_meetings(&conn, "networks neural", false, true, false, false, None, false)
+                .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id.as_deref(), Some("doc-1"));
+    }
+
+    #[test]
+    fn test_search_meetings_user_quotes_force_phrase() {
+        let conn = build_test_db(&meetings_state());
+        let results = search_meetings(
+            &conn,
+            "\"networks neural\"",
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(results.is_empty());
     }
 
     #[test]

--- a/src/db/meetings.rs
+++ b/src/db/meetings.rs
@@ -312,7 +312,8 @@ pub fn search_meetings(
         })
     })?;
 
-    Ok(rows.filter_map(|r| r.ok()).map(row_to_document).collect())
+    let rows = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows.into_iter().map(row_to_document).collect())
 }
 
 fn append_date_filter(
@@ -575,6 +576,20 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].id.as_deref(), Some("doc-tie-new"));
         assert_eq!(results[1].id.as_deref(), Some("doc-tie-old"));
+    }
+
+    #[test]
+    fn test_search_meetings_surfaces_row_errors() {
+        // Regression: row-mapping errors were silently dropped, which turned
+        // real failures into empty search results.
+        let conn = build_test_db(&meetings_state());
+        conn.execute(
+            "UPDATE documents SET title = x'DEADBEEF' WHERE id = 'doc-1'",
+            [],
+        )
+        .unwrap();
+        let result = search_meetings(&conn, "neural", false, true, false, false, None, false);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/db/notes.rs
+++ b/src/db/notes.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::query::dates::DateRange;
+use crate::query::fts::sanitize_fts_query;
 use crate::query::search::{build_text_context_windows, TextContextWindow, TextSegment};
 use crate::query::text::split_into_paragraphs;
 
@@ -101,10 +102,6 @@ fn find_matching_note_documents(
     Ok(rows.filter_map(|r| r.ok()).collect())
 }
 
-fn sanitize_fts_query(query: &str) -> String {
-    format!("\"{}\"", query.replace('"', ""))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -142,6 +139,17 @@ mod tests {
         assert!(results[0].2[0].matched.text.contains("roadmap"));
         // Should have context after (the "priorities" paragraph)
         assert_eq!(results[0].2[0].after.len(), 1);
+    }
+
+    #[test]
+    fn test_search_notes_multi_word_matches_any_order() {
+        // Regression: phrase-quoting meant reversed word order never matched.
+        let conn = build_test_db(&notes_state());
+        let results =
+            search_notes_with_context(&conn, "agreed team", None, 0, None, false).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "doc-1");
+        assert!(results[0].2[0].matched.text.contains("team agreed"));
     }
 
     #[test]

--- a/src/db/notes.rs
+++ b/src/db/notes.rs
@@ -100,7 +100,7 @@ fn find_matching_note_documents(
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
 
-    Ok(rows.filter_map(|r| r.ok()).collect())
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
 #[cfg(test)]

--- a/src/db/notes.rs
+++ b/src/db/notes.rs
@@ -64,7 +64,7 @@ fn find_matching_note_documents(
     let deleted_filter = if include_deleted { "" } else { " AND d.deleted_at IS NULL" };
 
     let mut sql = format!(
-        "SELECT DISTINCT d.id, COALESCE(d.title, '(untitled)')
+        "SELECT d.id, COALESCE(d.title, '(untitled)')
          FROM notes_fts
          JOIN documents d ON notes_fts.rowid = d.rowid
          WHERE notes_fts MATCH ?1{}",
@@ -90,7 +90,8 @@ fn find_matching_note_documents(
         }
     }
 
-    sql.push_str(" ORDER BY d.created_at DESC");
+    // bm25 is lower-is-better; recency breaks ties.
+    sql.push_str(" ORDER BY bm25(notes_fts) ASC, d.created_at DESC");
 
     let mut stmt = conn.prepare(&sql)?;
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
@@ -139,6 +140,32 @@ mod tests {
         assert!(results[0].2[0].matched.text.contains("roadmap"));
         // Should have context after (the "priorities" paragraph)
         assert_eq!(results[0].2[0].after.len(), 1);
+    }
+
+    #[test]
+    fn test_search_notes_orders_by_relevance_then_recency() {
+        // Regression: matches were ordered by created_at DESC, so a passing
+        // mention in a newer meeting outranked the meeting about the topic.
+        // Filler docs keep the term under half the corpus so BM25 IDF stays
+        // positive.
+        let conn = build_test_db(&serde_json::json!({
+            "documents": {
+                "doc-relevant": {"id": "doc-relevant", "title": "Relevant", "created_at": "2026-01-10T10:00:00Z",
+                    "notes_plain": "grafana dashboards for grafana alerts and grafana panel layout"},
+                "doc-mention": {"id": "doc-mention", "title": "Mention", "created_at": "2026-01-20T10:00:00Z",
+                    "notes_plain": "we touched on grafana briefly during the quarterly budget review"},
+                "doc-f1": {"id": "doc-f1", "title": "Filler 1", "created_at": "2026-01-11T10:00:00Z",
+                    "notes_plain": "planning notes for the offsite agenda"},
+                "doc-f2": {"id": "doc-f2", "title": "Filler 2", "created_at": "2026-01-12T10:00:00Z",
+                    "notes_plain": "budget discussion carried over from last week"},
+                "doc-f3": {"id": "doc-f3", "title": "Filler 3", "created_at": "2026-01-13T10:00:00Z",
+                    "notes_plain": "team retro action items and follow ups"}
+            }
+        }));
+        let results = search_notes_with_context(&conn, "grafana", None, 0, None, false).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "doc-relevant");
+        assert_eq!(results[1].0, "doc-mention");
     }
 
     #[test]

--- a/src/db/panels.rs
+++ b/src/db/panels.rs
@@ -215,8 +215,12 @@ fn find_matching_panel_documents(
     let fts_query = sanitize_fts_query(query);
     let d_deleted_filter = if include_deleted { "" } else { " AND d.deleted_at IS NULL" };
 
+    // MATERIALIZED stops the query flattener from pulling bm25() into the
+    // aggregate context, where FTS5 auxiliary functions cannot run.
     let mut sql = format!(
-        "SELECT DISTINCT p.document_id, COALESCE(d.title, '(untitled)')
+        "WITH hits AS MATERIALIZED (
+         SELECT p.document_id AS doc_id, COALESCE(d.title, '(untitled)') AS title,
+                d.created_at AS created_at, bm25(panels_fts) AS score
          FROM panels_fts
          JOIN panels p ON panels_fts.rowid = p.rowid
          JOIN documents d ON p.document_id = d.id
@@ -243,7 +247,11 @@ fn find_matching_panel_documents(
         }
     }
 
-    sql.push_str(" ORDER BY d.created_at DESC");
+    // A document's rank is its best-matching panel; bm25 is lower-is-better,
+    // recency breaks ties.
+    sql.push_str(
+        ") SELECT doc_id, title FROM hits GROUP BY doc_id ORDER BY MIN(score) ASC, created_at DESC",
+    );
 
     let mut stmt = conn.prepare(&sql)?;
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
@@ -897,6 +905,41 @@ mod tests {
         let window = &results[0].2[0];
         // "deployment" is in "Action Items" section
         assert_eq!(window.matched.label.as_deref(), Some("Action Items"));
+    }
+
+    #[test]
+    fn test_search_panels_orders_by_relevance_then_recency() {
+        // Regression: matches were ordered by created_at DESC, so a passing
+        // mention in a newer meeting outranked the meeting about the topic.
+        // Filler panels keep the term under half the corpus so BM25 IDF stays
+        // positive.
+        let conn = build_test_db(&serde_json::json!({
+            "documents": {
+                "doc-relevant": {"id": "doc-relevant", "title": "Relevant", "created_at": "2026-01-10T10:00:00Z"},
+                "doc-mention": {"id": "doc-mention", "title": "Mention", "created_at": "2026-01-20T10:00:00Z"},
+                "doc-f1": {"id": "doc-f1", "title": "Filler 1", "created_at": "2026-01-11T10:00:00Z"}
+            },
+            "panels": {
+                "doc-relevant": [
+                    {"id": "p-rel", "document_id": "doc-relevant",
+                     "content_markdown": "terraform modules terraform state management and terraform providers"}
+                ],
+                "doc-mention": [
+                    {"id": "p-men", "document_id": "doc-mention",
+                     "content_markdown": "brief mention of terraform in passing during the standup recap"}
+                ],
+                "doc-f1": [
+                    {"id": "p-f1", "document_id": "doc-f1", "content_markdown": "offsite agenda planning notes"},
+                    {"id": "p-f2", "document_id": "doc-f1", "content_markdown": "quarterly budget review discussion"},
+                    {"id": "p-f3", "document_id": "doc-f1", "content_markdown": "team retro action items"}
+                ]
+            }
+        }));
+        let results =
+            search_panels_with_context(&conn, "terraform", None, 0, None, false).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "doc-relevant");
+        assert_eq!(results[1].0, "doc-mention");
     }
 
     #[test]

--- a/src/db/panels.rs
+++ b/src/db/panels.rs
@@ -260,7 +260,7 @@ fn find_matching_panel_documents(
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
 
-    Ok(rows.filter_map(|r| r.ok()).collect())
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
 // ============================================================================

--- a/src/db/panels.rs
+++ b/src/db/panels.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use crate::api::ApiPanel;
 use crate::models::Panel;
 use crate::query::dates::DateRange;
+use crate::query::fts::sanitize_fts_query;
 use crate::tiptap::{extract_chat_url, tiptap_to_markdown};
 
 // ============================================================================
@@ -252,10 +253,6 @@ fn find_matching_panel_documents(
     })?;
 
     Ok(rows.filter_map(|r| r.ok()).collect())
-}
-
-fn sanitize_fts_query(query: &str) -> String {
-    format!("\"{}\"", query.replace('"', ""))
 }
 
 // ============================================================================
@@ -900,6 +897,17 @@ mod tests {
         let window = &results[0].2[0];
         // "deployment" is in "Action Items" section
         assert_eq!(window.matched.label.as_deref(), Some("Action Items"));
+    }
+
+    #[test]
+    fn test_search_panels_multi_word_matches_any_order() {
+        // Regression: phrase-quoting meant reversed word order never matched.
+        let conn = build_test_db(&panels_state());
+        let results =
+            search_panels_with_context(&conn, "priorities roadmap", None, 0, None, false).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "doc-1");
+        assert!(results[0].2[0].matched.text.contains("roadmap and priorities"));
     }
 
     #[test]

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -71,8 +71,12 @@ fn find_matching_documents(
     let fts_query = sanitize_fts_query(query);
     let deleted_filter = if include_deleted { "" } else { " AND d.deleted_at IS NULL" };
 
+    // MATERIALIZED stops the query flattener from pulling bm25() into the
+    // aggregate context, where FTS5 auxiliary functions cannot run.
     let mut sql = format!(
-        "SELECT DISTINCT tu.document_id, COALESCE(d.title, '(untitled)')
+        "WITH hits AS MATERIALIZED (
+         SELECT tu.document_id AS doc_id, COALESCE(d.title, '(untitled)') AS title,
+                d.created_at AS created_at, bm25(transcript_fts) AS score
          FROM transcript_fts
          JOIN transcript_utterances tu ON transcript_fts.rowid = tu.rowid
          JOIN documents d ON tu.document_id = d.id
@@ -99,7 +103,11 @@ fn find_matching_documents(
         }
     }
 
-    sql.push_str(" ORDER BY d.created_at DESC");
+    // A document's rank is its best-matching utterance; bm25 is
+    // lower-is-better, recency breaks ties.
+    sql.push_str(
+        ") SELECT doc_id, title FROM hits GROUP BY doc_id ORDER BY MIN(score) ASC, created_at DESC",
+    );
 
     let mut stmt = conn.prepare(&sql)?;
     let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
@@ -475,6 +483,34 @@ mod tests {
         );
         assert_eq!(windows[0].after.len(), 1);
         assert_eq!(windows[0].after[0].text.as_deref(), Some("Great idea"));
+    }
+
+    #[test]
+    fn test_search_transcripts_orders_by_relevance_then_recency() {
+        // Regression: matches were ordered by created_at DESC, so a passing
+        // mention in a newer meeting outranked the meeting about the topic.
+        // Filler rows keep the term under half the corpus so BM25 IDF stays
+        // positive.
+        let conn = build_test_db(&serde_json::json!({
+            "documents": {
+                "doc-relevant": {"id": "doc-relevant", "title": "Relevant Meeting", "created_at": "2026-01-10T10:00:00Z"},
+                "doc-mention": {"id": "doc-mention", "title": "Passing Mention", "created_at": "2026-01-20T10:00:00Z"}
+            },
+            "transcripts": {
+                "doc-relevant": [
+                    {"id": "r1", "document_id": "doc-relevant", "text": "kubernetes migration steps kubernetes cluster upgrades and kubernetes networking"}
+                ],
+                "doc-mention": [
+                    {"id": "m1", "document_id": "doc-mention", "text": "someone mentioned kubernetes briefly while we mostly discussed the quarterly budget review"},
+                    {"id": "m2", "document_id": "doc-mention", "text": "budget planning discussion continued"},
+                    {"id": "m3", "document_id": "doc-mention", "text": "then we walked through the offsite agenda"}
+                ]
+            }
+        }));
+        let results = search_transcripts(&conn, "kubernetes", None, 0, None, false).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "Relevant Meeting");
+        assert_eq!(results[1].0, "Passing Mention");
     }
 
     #[test]

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -116,7 +116,7 @@ fn find_matching_documents(
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     })?;
 
-    Ok(rows.filter_map(|r| r.ok()).collect())
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
 /// Load all transcript utterances for a document, ordered by timestamp.

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 use crate::models::TranscriptUtterance;
 use crate::query::dates::DateRange;
+use crate::query::fts::{matches_all_tokens, parse_query, sanitize_fts_query};
 use crate::query::search::ContextWindow;
 
 /// Raw SQLite row for a transcript utterance.
@@ -140,8 +141,7 @@ fn build_context_windows(
     query: &str,
     context_size: usize,
 ) -> Vec<ContextWindow> {
-    use crate::query::search::contains_ignore_case;
-
+    let tokens = parse_query(query);
     let mut results = Vec::new();
 
     for (i, utt) in utterances.iter().enumerate() {
@@ -150,7 +150,7 @@ fn build_context_windows(
             None => continue,
         };
 
-        if !contains_ignore_case(text, query) {
+        if !matches_all_tokens(text, &tokens) {
             continue;
         }
 
@@ -175,10 +175,6 @@ fn build_context_windows(
     }
 
     results
-}
-
-fn sanitize_fts_query(query: &str) -> String {
-    format!("\"{}\"", query.replace('"', ""))
 }
 
 /// Build a context window from semantic search result indices.
@@ -479,6 +475,20 @@ mod tests {
         );
         assert_eq!(windows[0].after.len(), 1);
         assert_eq!(windows[0].after[0].text.as_deref(), Some("Great idea"));
+    }
+
+    #[test]
+    fn test_search_transcripts_multi_word_matches_any_order() {
+        // Regression: phrase-quoting meant reversed word order never matched,
+        // and the context-window filter required the full query as a substring.
+        let conn = build_test_db(&transcripts_state());
+        let results = search_transcripts(&conn, "networks neural", None, 0, None, false).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "AI Meeting");
+        assert_eq!(
+            results[0].1[0].matched.text.as_deref(),
+            Some("Let's talk about neural networks today")
+        );
     }
 
     #[test]

--- a/src/query/fts.rs
+++ b/src/query/fts.rs
@@ -1,0 +1,270 @@
+//! Shared FTS5 query construction and term matching.
+//!
+//! A user query is parsed into tokens: bare words become individual terms
+//! (implicit AND), and double-quoted spans become phrases that must match
+//! contiguously. Every token is emitted double-quoted in the MATCH string,
+//! which keeps FTS5 operators (AND, OR, NOT, NEAR, `-`, `*`, `:`) literal.
+
+/// A parsed unit of a user search query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FtsToken {
+    /// A single bare word; matches anywhere in the row.
+    Term(String),
+    /// A user-quoted span; must match contiguously.
+    Phrase(String),
+}
+
+impl FtsToken {
+    fn text(&self) -> &str {
+        match self {
+            FtsToken::Term(s) | FtsToken::Phrase(s) => s,
+        }
+    }
+}
+
+/// Parse a raw user query into terms and quoted phrases.
+///
+/// A `"` starts a phrase (ending any bare word in progress); the phrase runs
+/// to the next `"` or the end of the string, so unbalanced quotes are treated
+/// as if closed at the end. Empty or whitespace-only phrases are dropped.
+pub fn parse_query(query: &str) -> Vec<FtsToken> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_phrase = false;
+
+    let flush = |buf: &mut String, in_phrase: bool, tokens: &mut Vec<FtsToken>| {
+        if !buf.trim().is_empty() {
+            let text = std::mem::take(buf);
+            tokens.push(if in_phrase {
+                FtsToken::Phrase(text)
+            } else {
+                FtsToken::Term(text)
+            });
+        } else {
+            buf.clear();
+        }
+    };
+
+    for ch in query.chars() {
+        match ch {
+            '"' => {
+                flush(&mut current, in_phrase, &mut tokens);
+                in_phrase = !in_phrase;
+            }
+            c if c.is_whitespace() && !in_phrase => {
+                flush(&mut current, false, &mut tokens);
+            }
+            c => current.push(c),
+        }
+    }
+    flush(&mut current, in_phrase, &mut tokens);
+
+    tokens
+}
+
+/// Build an FTS5 MATCH expression from a user query.
+///
+/// Each token is double-quoted so FTS5 treats it literally; whitespace-joined
+/// quoted tokens give implicit-AND semantics. An empty query yields `""`
+/// (an empty phrase), which matches nothing.
+pub fn sanitize_fts_query(query: &str) -> String {
+    let tokens = parse_query(query);
+    if tokens.is_empty() {
+        return "\"\"".to_string();
+    }
+    tokens
+        .iter()
+        .map(|t| format!("\"{}\"", t.text()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// True when `text` contains every token, case-insensitively.
+///
+/// Mirrors the per-row semantics of the MATCH expression built by
+/// `sanitize_fts_query`, for filtering display text (e.g. context windows).
+/// An empty token list is vacuously true.
+pub fn matches_all_tokens(text: &str, tokens: &[FtsToken]) -> bool {
+    tokens
+        .iter()
+        .all(|t| crate::query::text::contains_ignore_case(text, t.text()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_query ---
+
+    #[test]
+    fn parse_single_word() {
+        assert_eq!(parse_query("hello"), vec![FtsToken::Term("hello".into())]);
+    }
+
+    #[test]
+    fn parse_multiple_words() {
+        assert_eq!(
+            parse_query("resource allocation"),
+            vec![
+                FtsToken::Term("resource".into()),
+                FtsToken::Term("allocation".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_quoted_phrase() {
+        assert_eq!(
+            parse_query("\"resource allocation\""),
+            vec![FtsToken::Phrase("resource allocation".into())]
+        );
+    }
+
+    #[test]
+    fn parse_phrase_and_terms_mixed() {
+        assert_eq!(
+            parse_query("budget \"status update\" quarterly"),
+            vec![
+                FtsToken::Term("budget".into()),
+                FtsToken::Phrase("status update".into()),
+                FtsToken::Term("quarterly".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_unbalanced_quote_runs_to_end() {
+        assert_eq!(
+            parse_query("foo \"bar baz"),
+            vec![
+                FtsToken::Term("foo".into()),
+                FtsToken::Phrase("bar baz".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_quote_attached_to_word() {
+        assert_eq!(
+            parse_query("foo\"bar baz\""),
+            vec![
+                FtsToken::Term("foo".into()),
+                FtsToken::Phrase("bar baz".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_empty_phrase_dropped() {
+        assert_eq!(parse_query("foo \"\" bar"), vec![
+            FtsToken::Term("foo".into()),
+            FtsToken::Term("bar".into())
+        ]);
+    }
+
+    #[test]
+    fn parse_whitespace_only_phrase_dropped() {
+        assert_eq!(parse_query("\"   \""), Vec::<FtsToken>::new());
+    }
+
+    #[test]
+    fn parse_empty_query() {
+        assert_eq!(parse_query(""), Vec::<FtsToken>::new());
+        assert_eq!(parse_query("   "), Vec::<FtsToken>::new());
+    }
+
+    #[test]
+    fn parse_keeps_punctuation_in_terms() {
+        assert_eq!(
+            parse_query("covid-19 v2.0"),
+            vec![
+                FtsToken::Term("covid-19".into()),
+                FtsToken::Term("v2.0".into())
+            ]
+        );
+    }
+
+    // --- sanitize_fts_query ---
+
+    #[test]
+    fn sanitize_single_word_is_quoted() {
+        assert_eq!(sanitize_fts_query("hello"), "\"hello\"");
+    }
+
+    #[test]
+    fn sanitize_multi_word_quotes_each_term() {
+        // Implicit AND: each word quoted separately, not one phrase.
+        assert_eq!(
+            sanitize_fts_query("resource allocation"),
+            "\"resource\" \"allocation\""
+        );
+    }
+
+    #[test]
+    fn sanitize_preserves_user_phrases() {
+        assert_eq!(
+            sanitize_fts_query("budget \"status update\""),
+            "\"budget\" \"status update\""
+        );
+    }
+
+    #[test]
+    fn sanitize_neutralizes_fts_operators() {
+        assert_eq!(sanitize_fts_query("cats OR dogs"), "\"cats\" \"OR\" \"dogs\"");
+        assert_eq!(sanitize_fts_query("foo NOT bar"), "\"foo\" \"NOT\" \"bar\"");
+        assert_eq!(sanitize_fts_query("col:value"), "\"col:value\"");
+        assert_eq!(sanitize_fts_query("wild*"), "\"wild*\"");
+    }
+
+    #[test]
+    fn sanitize_empty_query_matches_nothing() {
+        // Preserves the pre-existing behavior for empty input: an empty
+        // phrase, which no row matches.
+        assert_eq!(sanitize_fts_query(""), "\"\"");
+    }
+
+    // --- matches_all_tokens ---
+
+    #[test]
+    fn matches_all_terms_any_order() {
+        let tokens = parse_query("allocation resource");
+        assert!(matches_all_tokens(
+            "We discussed resource allocation today",
+            &tokens
+        ));
+    }
+
+    #[test]
+    fn matches_is_case_insensitive() {
+        let tokens = parse_query("RESOURCE");
+        assert!(matches_all_tokens("resource allocation", &tokens));
+    }
+
+    #[test]
+    fn missing_term_fails_match() {
+        let tokens = parse_query("resource headcount");
+        assert!(!matches_all_tokens(
+            "We discussed resource allocation today",
+            &tokens
+        ));
+    }
+
+    #[test]
+    fn phrase_must_be_contiguous() {
+        let tokens = parse_query("\"allocation resource\"");
+        assert!(!matches_all_tokens(
+            "We discussed resource allocation today",
+            &tokens
+        ));
+        let tokens = parse_query("\"resource allocation\"");
+        assert!(matches_all_tokens(
+            "We discussed resource allocation today",
+            &tokens
+        ));
+    }
+
+    #[test]
+    fn empty_tokens_match_vacuously() {
+        assert!(matches_all_tokens("anything", &[]));
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,4 +1,5 @@
 pub mod dates;
 pub mod filter;
+pub mod fts;
 pub mod search;
 pub mod text;

--- a/src/query/search.rs
+++ b/src/query/search.rs
@@ -1,7 +1,5 @@
 use crate::models::TranscriptUtterance;
-
-// Re-export from text module for backwards compatibility
-pub use crate::query::text::contains_ignore_case;
+use crate::query::fts::{matches_all_tokens, parse_query};
 
 /// A matched utterance with its surrounding context.
 #[derive(Debug, Clone)]
@@ -30,17 +28,19 @@ pub struct TextContextWindow {
 
 /// Build context windows for text segments that match the query.
 ///
-/// For each segment whose text contains the query (case-insensitive),
-/// includes `context_size` segments before and after as context.
+/// For each segment whose text contains every query term (case-insensitive,
+/// any order; user-quoted phrases must match contiguously), includes
+/// `context_size` segments before and after as context.
 pub fn build_text_context_windows(
     segments: &[TextSegment],
     query: &str,
     context_size: usize,
 ) -> Vec<TextContextWindow> {
+    let tokens = parse_query(query);
     let mut results = Vec::new();
 
     for (i, seg) in segments.iter().enumerate() {
-        if !contains_ignore_case(&seg.text, query) {
+        if !matches_all_tokens(&seg.text, &tokens) {
             continue;
         }
 


### PR DESCRIPTION
Implements Phase 1 of the search roadmap (#37): bm25 relevance ranking and implicit-AND query semantics for keyword search.

## What changed

- **Implicit-AND semantics**: `sanitize_fts_query` wrapped the whole query in double quotes, which FTS5 treats as a strict phrase, so multi-word searches only matched words adjacent and in order. The four duplicated copies are replaced by a shared tokenizer (`query::fts`) that quotes each term individually; user-supplied quotes still force phrase matching, and quoting every token keeps FTS5 operators literal (same injection-safety as before). Context-window filtering (`--context`) moved to the same per-token matching so display stays consistent with retrieval.
- **bm25 ranking**: results were ordered `created_at DESC`, so a passing mention in a recent meeting outranked the meeting actually about the topic. Keyword search now ranks by `bm25()` (best score across notes/transcripts/panels per document), with recency as tiebreak. Title substring matches rank as a tier above content matches; proper title-match weighting stays deferred to Phase 5. Applies to the combined search and the standalone transcript/notes/panel searches.
- **Error propagation**: the search paths dropped failed rows with `filter_map(|r| r.ok())`, which turned real query failures into silently empty results (this hid an FTS misuse error during development). Row errors now propagate.

Implementation note: FTS5 auxiliary functions cannot run in an aggregate context and the query flattener inlines plain subqueries into one, so per-row bm25 scores are computed in a `MATERIALIZED` CTE and grouped outside it.

## Benchmark (v2 golden set, 93 queries, k=10, ID matching, frozen snapshot `grans-snapshot-2026-07-09.db`)

| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
|---|---|---|---|---|
| fts before | 0.054 | 0.030 | 0.039 | ~5 ms |
| **fts after** | **0.172** | **0.093** | **0.139** | ~5 ms |
| semantic (unchanged) | 0.860 | 0.759 | 0.721 | ~58 ms |

**Gate check** (FTS-mode improves on exact-term, no per-query catastrophic regressions):

- exact-term stratum: hit-rate 0.33 → 0.58, MRR 0.22 → 0.43 (pre-re-audit labels, apples-to-apples with the Phase 0 baseline)
- per query: 11 flipped miss→hit, 0 hit→miss, worst rank change 7→9, no query with a top-3 result fell out of the top 10
- FTS vs semantic on best rank: 1 W / 90 L / 2 T → 2 W / 82 L / 9 T

Both runs recorded in the results ledger with full per-query output under `runs/`.

## Golden-set strata re-audit (issue checklist item)

The `query_type` labels were re-audited now that implicit-AND landed, using an operational test against the snapshot (all query terms verbatim within one FTS row of a labeled doc): 9 queries demoted to mixed only for the old phrase-match failure were promoted back to exact-term, and 4 exact-term labels that fail the test were demoted to mixed. Strata are now exact-term n=17 / mixed n=38 / paraphrase n=38. Under the new labels, FTS scores hit-rate 0.94 / MRR 0.76 on exact-term and zero on mixed/paraphrase; semantic scores 1.00 / 0.92 on exact-term. Post-re-audit runs for both modes were recorded to the ledger; the pre-re-audit golden set is backed up alongside it.

## Known limitation (intentional, noted in the roadmap)

Implicit-AND applies per FTS row: for transcripts all terms must co-occur within a single utterance. Multi-term queries whose terms are scattered across a conversation still miss; that class of query is what Phase 2 (hybrid) and semantic search cover.

## Testing

- TDD throughout: tokenizer unit tests (20), db-level regression tests for reversed-word matching in all four search paths, relevance/tiebreak ordering tests per search path, and a regression test that row errors surface instead of yielding empty results.
- Full suite passes (621 unit + 66 integration).
- CLI sanity checks against the live db (`list`, title search, multi-word AND search, `browse people list`). `grans sync` deliberately skipped to keep the corpus frozen for the benchmark comparison (see #37 definition of done).

Closes #39.
