### PR TITLE
#40: Hybrid retrieval (RRF fusion) behind --hybrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ grans search "budget" --semantic --in panels          # Only AI notes
 grans search "budget" --semantic --in transcripts     # Only transcripts
 grans search "budget" --semantic --in notes,panels    # Notes + AI notes
 
+# Hybrid search: run keyword and semantic together, fuse the rankings
+grans search "quarterly budget review" --hybrid
+
 # Limit results (default 10, use 0 for no limit)
 # Works with keyword, context window, and semantic search
 grans search "budget" --limit 5
@@ -182,6 +185,8 @@ grans search "old project" --semantic --include-deleted
 ```
 
 Keyword search matches every word in the query, in any order: `grans search "budget review"` finds meetings that mention both words. To require an exact phrase, quote it inside the query (e.g. `grans search '"budget review"'`). Results are ranked by relevance: meetings whose title contains the query come first, then content matches ranked by BM25, with newer meetings breaking ties.
+
+Hybrid search (`--hybrid`) runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either mode surfaces, and one ranked well by both rises to the top. It needs embeddings (like `--semantic`, it will prompt if many chunks are unembedded; `--yes` skips the prompt) and supports `--in`, `--meeting`, date filters, and `--limit`. It cannot be combined with `--semantic` or `--context`.
 
 Semantic search uses a local embedding model (`nomic-embed-text-v1.5`) to find meetings by meaning rather than exact keywords. On first use, the model is downloaded automatically (~270MB). Embeddings are built from transcripts, AI-generated panel sections, and your notes, and are stored in the main database. Use `--in` to restrict which sources are searched (e.g. `--in panels` to only search AI notes).
 

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -6,7 +6,8 @@ A staged plan to evolve `grans search` from two separate modes (FTS5 keyword, se
 
 - **Keyword search** (Phase 1, #39): FTS5 `MATCH` with implicit-AND semantics (each term quoted individually; user-supplied quotes force phrase matching), ranked by `bm25()` with recency as tiebreak. Title substring matches rank as a tier above content matches; weighting them properly is Phase 5. Applies to the combined search and the standalone transcript/notes/panel searches.
 - **Semantic search** (`--semantic`): nomic-embed-text-v1.5 (768d) via fastembed, brute-force cosine over in-memory vectors, `min_score` cutoff. Chunkers for transcripts (adaptive window), panels (section), notes (paragraph).
-- The two modes are mutually exclusive; `commands/search.rs` dispatches to one or the other.
+- **Hybrid search** (Phase 2, #40, opt-in `--hybrid`): runs both retrievers, truncates each ranked list to a 100-document candidate pool, and fuses by reciprocal rank fusion (k=60) in `query/fusion.rs` + `query/hybrid.rs`. Output is the fused meeting list; keyword and semantic remain the forcing modes.
+- The modes are mutually exclusive; `commands/search.rs` dispatches on a `SearchMode` enum.
 - **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. Implemented in `commands/benchmark/`.
 
 ## Target pipeline
@@ -66,6 +67,18 @@ Phase 1 results (2026-07-10, k=10, ID matching, same snapshot):
 | semantic (unchanged) | 0.86 | 0.76 | 0.72 | ~58 ms |
 
 Per query, 11 flipped miss-to-hit, none hit-to-miss, worst rank change 7 to 9; FTS vs semantic on best rank moved from 1/90/2 to 2/82/9 (W/L/T). Under the re-audited strata (below), FTS scores hit-rate 0.94 / MRR 0.76 on exact-term (n=17) and zero on mixed and paraphrase; semantic scores 1.00 / 0.92 on exact-term. Note the implicit-AND granularity: all terms must co-occur within one FTS row (a single utterance, panel, or notes document), so multi-term queries whose terms are scattered across a transcript still miss.
+
+Phase 2 results (2026-07-10, k=10, ID matching, same snapshot, re-audited strata):
+
+| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
+|---|---|---|---|---|
+| fts (Phase 1) | 0.17 | 0.09 | 0.14 | ~5 ms |
+| semantic | 0.86 | 0.76 | 0.72 | ~56 ms |
+| hybrid (RRF) | 0.86 | 0.76 | 0.72 | ~65 ms |
+
+Aggregates tie semantic, but the movement is where fusion should act: on exact-term queries hybrid reaches hit-rate 1.00 / MRR 1.000 (semantic 1.00 / 0.924, FTS 0.94 / 0.761), because FTS agreement pulls two semantically rank-2/rank-5 results to rank 1. Per query, hybrid matches or beats the better single mode on 90 of 93; the 3 losses are one-position slips (1→2, 2→3, 1→2) on mixed/paraphrase queries where an irrelevant FTS match fused above a relevant semantic one, costing ~0.015 MRR on those strata. No query with a top-3 result under either mode leaves the top 10, so the #40 gate passes. Against the single modes: hybrid vs FTS 69W/0L/24T, hybrid vs semantic 2W/3L/88T on best rank.
+
+The ceiling here is FTS itself: with FTS scoring zero outside exact-term, fusion has only one useful signal for mixed/paraphrase queries. Larger hybrid gains wait on reranking (Phase 3) and embedding improvements (Phase 4). Promotion of `--hybrid` to the default is a follow-up PR per #40.
 
 (v1-file baseline for reference: hit-rate@10 ~73%, MRR ~0.55, title matching.)
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -248,6 +248,8 @@ pub enum QualityMode {
     Fts,
     /// Semantic search over embeddings
     Semantic,
+    /// RRF fusion of FTS and semantic rankings (--hybrid)
+    Hybrid,
 }
 
 impl QualityMode {
@@ -255,6 +257,7 @@ impl QualityMode {
         match self {
             QualityMode::Fts => "fts",
             QualityMode::Semantic => "semantic",
+            QualityMode::Hybrid => "hybrid",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -54,6 +54,10 @@ pub enum Commands {
         #[arg(long)]
         semantic: bool,
 
+        /// Combine keyword and semantic search, fusing both rankings
+        #[arg(long, conflicts_with_all = ["semantic", "context"])]
+        hybrid: bool,
+
         /// Context window size: utterances for transcripts, sections for panels, paragraphs for notes (0 = disabled)
         #[arg(long, default_value = "0")]
         context: usize,

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -2,8 +2,8 @@
 //!
 //! Each mode returns the full document-level ranked list for a query;
 //! scoring (metrics.rs) applies k. Lists reflect current production
-//! behavior for the mode: FTS has no relevance ranking yet (Phase 1),
-//! semantic is ranked by best-chunk cosine score.
+//! behavior for the mode: FTS is ranked by bm25 with a recency tiebreak,
+//! semantic by best-chunk cosine score, and hybrid by RRF over both.
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -13,6 +13,7 @@ use crate::cli::args::QualityMode;
 use crate::embed::model::{Embedder, FastEmbedModel};
 use crate::embed::search::SemanticSearchResult;
 use crate::embed::{ensure_embeddings, EmbeddingIndex, DEFAULT_BATCH_SIZE};
+use crate::query::filter::SearchTarget;
 
 pub enum Retriever<'a> {
     Fts {
@@ -22,12 +23,17 @@ pub enum Retriever<'a> {
         embedder: FastEmbedModel,
         index: EmbeddingIndex,
     },
+    Hybrid {
+        conn: &'a Connection,
+        embedder: FastEmbedModel,
+        index: EmbeddingIndex,
+    },
 }
 
 impl<'a> Retriever<'a> {
-    /// Build the retriever for a mode. For semantic, the embedding model and
-    /// index are loaded once here so per-query latency measures search, not
-    /// one-time setup.
+    /// Build the retriever for a mode. For semantic and hybrid, the embedding
+    /// model and index are loaded once here so per-query latency measures
+    /// search, not one-time setup.
     pub fn build(mode: QualityMode, conn: &'a Connection) -> Result<Self> {
         match mode {
             QualityMode::Fts => Ok(Retriever::Fts { conn }),
@@ -35,6 +41,11 @@ impl<'a> Retriever<'a> {
                 let embedder = FastEmbedModel::new()?;
                 let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE)?;
                 Ok(Retriever::Semantic { embedder, index })
+            }
+            QualityMode::Hybrid => {
+                let embedder = FastEmbedModel::new()?;
+                let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE)?;
+                Ok(Retriever::Hybrid { conn, embedder, index })
             }
         }
     }
@@ -46,6 +57,9 @@ impl<'a> Retriever<'a> {
             Retriever::Semantic { embedder, index } => {
                 let query_vec = embedder.embed_query(query)?;
                 Ok(to_ranked(index.search(&query_vec, 0.0, None)))
+            }
+            Retriever::Hybrid { conn, embedder, index } => {
+                retrieve_hybrid(conn, embedder, index, query)
             }
         }
     }
@@ -63,6 +77,26 @@ fn retrieve_fts(conn: &Connection, query: &str) -> Result<Vec<RankedDoc>> {
         .map(|id| RankedDoc {
             document_id: id,
             score: None,
+        })
+        .collect())
+}
+
+/// Hybrid retrieval over the same default targets, in production fusion
+/// order (RRF over the FTS and semantic rankings).
+fn retrieve_hybrid(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    index: &EmbeddingIndex,
+    query: &str,
+) -> Result<Vec<RankedDoc>> {
+    let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
+    let fused =
+        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, false)?;
+    Ok(fused
+        .into_iter()
+        .map(|d| RankedDoc {
+            document_id: d.document_id,
+            score: Some(d.score as f32),
         })
         .collect())
 }
@@ -102,6 +136,49 @@ mod tests {
         let retriever = Retriever::Fts { conn: &conn };
 
         let ranked = retriever.retrieve("zebra xylophone").unwrap();
+
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn hybrid_retriever_fuses_fts_and_semantic() {
+        use crate::embed::model::MockEmbedder;
+        use crate::embed::store::StoredVector;
+
+        let conn = build_test_db(&meetings_state());
+        // doc-1 is the sole semantic candidate; MockEmbedder query vectors
+        // have non-negative components, so its cosine vs [1, 1] is >= 0 and
+        // it ranks first (and only) on the semantic side.
+        let index = EmbeddingIndex {
+            vectors: vec![StoredVector {
+                chunk_id: 0,
+                document_id: "doc-1".to_string(),
+                source_type: "transcript_window".to_string(),
+                text: String::new(),
+                vector: vec![1.0, 1.0],
+                metadata_json: None,
+            }],
+            stats: None,
+        };
+        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+
+        // "machine learning" matches doc-1 by FTS too (notes), so doc-1 is
+        // rank 1 in both lists: RRF score 2/(60 + 1).
+        let ranked = retrieve_hybrid(&conn, &embedder, &index, "machine learning").unwrap();
+
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].document_id, "doc-1");
+        let score = ranked[0].score.expect("hybrid results carry RRF scores");
+        assert!((score - 2.0 / 61.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn hybrid_retriever_empty_for_no_match() {
+        let conn = build_test_db(&meetings_state());
+        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
+        let embedder = crate::embed::model::MockEmbedder { dim: 2, max_length: 512 };
+
+        let ranked = retrieve_hybrid(&conn, &embedder, &index, "zebra xylophone").unwrap();
 
         assert!(ranked.is_empty());
     }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
-use crate::models::SpeakerFilter;
+use crate::models::{Document, SpeakerFilter};
 use crate::output::format::OutputMode;
 use crate::query::dates::DateRange;
 use crate::query::filter::SearchTarget;
@@ -34,12 +34,20 @@ pub enum SearchMode {
         yes: bool,
         limit: usize,
     },
+    Hybrid {
+        targets: Vec<SearchTarget>,
+        meeting_filter: Option<String>,
+        yes: bool,
+        limit: usize,
+    },
 }
 
 impl SearchMode {
     /// Construct a SearchMode from CLI arguments.
-    /// Priority: semantic > context > keyword.
+    /// Priority: hybrid > semantic > context > keyword.
+    #[allow(clippy::too_many_arguments)]
     pub fn from_cli_args(
+        hybrid: bool,
         semantic: bool,
         context: usize,
         in_targets: &str,
@@ -48,7 +56,14 @@ impl SearchMode {
         yes: bool,
         limit: usize,
     ) -> Self {
-        if semantic {
+        if hybrid {
+            SearchMode::Hybrid {
+                targets: SearchTarget::parse_list(in_targets),
+                meeting_filter: meeting_filter.map(String::from),
+                yes,
+                limit,
+            }
+        } else if semantic {
             SearchMode::Semantic {
                 targets: SearchTarget::parse_list(in_targets),
                 context_size: context,
@@ -124,6 +139,22 @@ pub fn search(
             include_deleted,
             ctx,
         ),
+        SearchMode::Hybrid {
+            targets,
+            meeting_filter,
+            yes,
+            limit,
+        } => hybrid_search(
+            conn,
+            query,
+            &targets,
+            meeting_filter.as_deref(),
+            yes,
+            limit,
+            date_range,
+            include_deleted,
+            ctx,
+        ),
     }
 }
 
@@ -180,27 +211,76 @@ fn keyword_search(
         include_deleted,
     )?;
 
-    // If a meeting filter is specified, filter the results
-    let results = if let Some(filter) = meeting_filter {
-        let filter_lower = filter.to_lowercase();
-        results
-            .into_iter()
-            .filter(|doc| {
-                doc.title
-                    .as_ref()
-                    .map(|t| t.to_lowercase().contains(&filter_lower))
-                    .unwrap_or(false)
-                    || doc
-                        .id
-                        .as_ref()
-                        .map(|id| id.to_lowercase().contains(&filter_lower))
-                        .unwrap_or(false)
-            })
-            .collect()
-    } else {
-        results
-    };
+    let results = filter_by_meeting(results, meeting_filter);
+    render_meeting_list(results, query, limit, ctx);
 
+    Ok(())
+}
+
+/// Run keyword and semantic retrieval, fuse the rankings, and display the
+/// resulting meetings.
+#[allow(clippy::too_many_arguments)]
+fn hybrid_search(
+    conn: &Connection,
+    query: &str,
+    targets: &[SearchTarget],
+    meeting_filter: Option<&str>,
+    yes: bool,
+    limit: usize,
+    date_range: Option<DateRange>,
+    include_deleted: bool,
+    ctx: &RunContext,
+) -> Result<()> {
+    if !confirm_embedding_work(conn, yes, ctx)? {
+        return Ok(());
+    }
+
+    let embedder = crate::embed::model::FastEmbedModel::new()?;
+    let index = crate::embed::ensure_embeddings(conn, &embedder, crate::embed::DEFAULT_BATCH_SIZE)?;
+
+    let fused = crate::query::hybrid::hybrid_ranked(
+        conn,
+        &embedder,
+        &index,
+        query,
+        targets,
+        date_range.as_ref(),
+        include_deleted,
+    )?;
+    let ids: Vec<String> = fused.into_iter().map(|d| d.document_id).collect();
+    let results = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
+
+    let results = filter_by_meeting(results, meeting_filter);
+    render_meeting_list(results, query, limit, ctx);
+
+    Ok(())
+}
+
+/// Keep only documents whose title or id contains `filter` (case-insensitive).
+/// No filter keeps everything.
+fn filter_by_meeting(results: Vec<Document>, meeting_filter: Option<&str>) -> Vec<Document> {
+    let Some(filter) = meeting_filter else {
+        return results;
+    };
+    let filter_lower = filter.to_lowercase();
+    results
+        .into_iter()
+        .filter(|doc| {
+            doc.title
+                .as_ref()
+                .map(|t| t.to_lowercase().contains(&filter_lower))
+                .unwrap_or(false)
+                || doc
+                    .id
+                    .as_ref()
+                    .map(|id| id.to_lowercase().contains(&filter_lower))
+                    .unwrap_or(false)
+        })
+        .collect()
+}
+
+/// Print a ranked meeting list, honoring the output mode and result limit.
+fn render_meeting_list(results: Vec<Document>, query: &str, limit: usize, ctx: &RunContext) {
     let total = results.len();
     let results = apply_limit(results, limit);
 
@@ -213,7 +293,7 @@ fn keyword_search(
         OutputMode::Tty => {
             if results.is_empty() {
                 println!("No meetings found matching \"{}\".", query);
-                return Ok(());
+                return;
             }
             if total > results.len() {
                 println!(
@@ -233,8 +313,6 @@ fn keyword_search(
             }
         }
     }
-
-    Ok(())
 }
 
 fn context_window_search(
@@ -413,35 +491,10 @@ fn context_window_search(
     Ok(())
 }
 
-fn semantic_search(
-    conn: &Connection,
-    query: &str,
-    targets: &[SearchTarget],
-    context_size: usize,
-    date_range: Option<DateRange>,
-    speaker_filter: Option<&SpeakerFilter>,
-    yes: bool,
-    limit: usize,
-    include_deleted: bool,
-    ctx: &RunContext,
-) -> Result<()> {
-    use crate::query::filter::semantic_source_filter;
-
-    // Parse --in targets and compute source type filter for semantic search
-    let filter = semantic_source_filter(targets);
-
-    // If only non-embeddable targets selected (e.g. --in titles), inform user
-    if let Some(ref f) = filter {
-        if f.is_empty() {
-            if ctx.output_mode == OutputMode::Tty {
-                eprintln!("Semantic search does not support searching in titles only.");
-                eprintln!("Try: grans search \"{}\" --semantic --in transcripts,panels,notes", query);
-            }
-            return Ok(());
-        }
-    }
-
-    // Check embedding status and prompt if many chunks need embedding
+/// Check embedding status and, on a TTY, prompt before a large or full
+/// re-embedding run. Returns false when the user declines (the search
+/// should stop). `yes` skips the prompt.
+fn confirm_embedding_work(conn: &Connection, yes: bool, ctx: &RunContext) -> Result<bool> {
     let status = crate::embed::get_embedding_status(conn, crate::embed::model::MODEL_NAME)?;
     let needs_full_reembed = status.orphaned_chunks > 0
         || status.legacy_max_length_warning
@@ -483,9 +536,44 @@ fn semantic_search(
             io::stdin().read_line(&mut input)?;
             if !input.trim().eq_ignore_ascii_case("y") {
                 println!("Search cancelled. Run `grans embed` to build embeddings.");
-                return Ok(());
+                return Ok(false);
             }
         }
+    }
+
+    Ok(true)
+}
+
+fn semantic_search(
+    conn: &Connection,
+    query: &str,
+    targets: &[SearchTarget],
+    context_size: usize,
+    date_range: Option<DateRange>,
+    speaker_filter: Option<&SpeakerFilter>,
+    yes: bool,
+    limit: usize,
+    include_deleted: bool,
+    ctx: &RunContext,
+) -> Result<()> {
+    use crate::query::filter::semantic_source_filter;
+
+    // Parse --in targets and compute source type filter for semantic search
+    let filter = semantic_source_filter(targets);
+
+    // If only non-embeddable targets selected (e.g. --in titles), inform user
+    if let Some(ref f) = filter {
+        if f.is_empty() {
+            if ctx.output_mode == OutputMode::Tty {
+                eprintln!("Semantic search does not support searching in titles only.");
+                eprintln!("Try: grans search \"{}\" --semantic --in transcripts,panels,notes", query);
+            }
+            return Ok(());
+        }
+    }
+
+    if !confirm_embedding_work(conn, yes, ctx)? {
+        return Ok(());
     }
 
     let filter_strs = filter.as_deref();
@@ -685,8 +773,30 @@ mod tests {
     use super::*;
 
     #[test]
+    fn from_cli_args_hybrid_takes_priority() {
+        let mode =
+            SearchMode::from_cli_args(true, true, 5, "titles,notes", Some("standup"), None, true, 10);
+        match mode {
+            SearchMode::Hybrid {
+                targets,
+                meeting_filter,
+                yes,
+                limit,
+            } => {
+                assert_eq!(targets.len(), 2);
+                assert!(targets.contains(&SearchTarget::Titles));
+                assert!(targets.contains(&SearchTarget::Notes));
+                assert_eq!(meeting_filter.as_deref(), Some("standup"));
+                assert!(yes);
+                assert_eq!(limit, 10);
+            }
+            _ => panic!("Expected Hybrid variant"),
+        }
+    }
+
+    #[test]
     fn from_cli_args_semantic_takes_priority() {
-        let mode = SearchMode::from_cli_args(true, 5, "titles", Some("standup"), None, true, 10);
+        let mode = SearchMode::from_cli_args(false, true, 5, "titles", Some("standup"), None, true, 10);
         match mode {
             SearchMode::Semantic {
                 targets,
@@ -706,7 +816,7 @@ mod tests {
 
     #[test]
     fn from_cli_args_context_takes_priority_over_keyword() {
-        let mode = SearchMode::from_cli_args(false, 3, "titles,notes", Some("standup"), None, false, 10);
+        let mode = SearchMode::from_cli_args(false, false, 3, "titles,notes", Some("standup"), None, false, 10);
         match mode {
             SearchMode::ContextWindow {
                 targets,
@@ -728,7 +838,7 @@ mod tests {
 
     #[test]
     fn from_cli_args_defaults_to_keyword() {
-        let mode = SearchMode::from_cli_args(false, 0, "titles,notes", None, None, false, 10);
+        let mode = SearchMode::from_cli_args(false, false, 0, "titles,notes", None, None, false, 10);
         match mode {
             SearchMode::Keyword {
                 targets,
@@ -748,7 +858,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_keyword() {
         let mode =
-            SearchMode::from_cli_args(false, 0, "transcripts", Some("daily"), None, false, 10);
+            SearchMode::from_cli_args(false, false, 0, "transcripts", Some("daily"), None, false, 10);
         match mode {
             SearchMode::Keyword {
                 meeting_filter, ..
@@ -762,7 +872,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_context_window() {
         let mode =
-            SearchMode::from_cli_args(false, 5, "titles", Some("retro"), None, false, 10);
+            SearchMode::from_cli_args(false, false, 5, "titles", Some("retro"), None, false, 10);
         match mode {
             SearchMode::ContextWindow {
                 meeting_filter, ..
@@ -776,7 +886,7 @@ mod tests {
     #[test]
     fn from_cli_args_speaker_filter_threads_to_context_window() {
         let speaker = SpeakerFilter::Me;
-        let mode = SearchMode::from_cli_args(false, 3, "transcripts", None, Some(&speaker), false, 10);
+        let mode = SearchMode::from_cli_args(false, false, 3, "transcripts", None, Some(&speaker), false, 10);
         match mode {
             SearchMode::ContextWindow {
                 speaker_filter, ..
@@ -790,7 +900,7 @@ mod tests {
     #[test]
     fn from_cli_args_speaker_filter_threads_to_semantic() {
         let speaker = SpeakerFilter::Other;
-        let mode = SearchMode::from_cli_args(true, 0, "transcripts", None, Some(&speaker), false, 10);
+        let mode = SearchMode::from_cli_args(false, true, 0, "transcripts", None, Some(&speaker), false, 10);
         match mode {
             SearchMode::Semantic {
                 speaker_filter, ..

--- a/src/db/meetings.rs
+++ b/src/db/meetings.rs
@@ -316,6 +316,50 @@ pub fn search_meetings(
     Ok(rows.into_iter().map(row_to_document).collect())
 }
 
+/// Fetch documents by id, returned in the order the ids were given.
+/// Unknown ids are skipped. No deleted filter is applied: callers pass ids
+/// from a search that already honored include_deleted.
+pub fn get_meetings_by_ids(conn: &Connection, ids: &[String]) -> Result<Vec<Document>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    let sql = format!(
+        "SELECT id, title, created_at, updated_at, deleted_at, doc_type, notes_plain, notes_markdown, summary, people_json, google_calendar_event_json
+         FROM documents WHERE id IN ({})",
+        placeholders
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let params: Vec<&dyn rusqlite::types::ToSql> =
+        ids.iter().map(|id| id as &dyn rusqlite::types::ToSql).collect();
+    let rows = stmt.query_map(params.as_slice(), |row| {
+        Ok(DocumentRow {
+            id: row.get(0)?,
+            title: row.get(1)?,
+            created_at: row.get(2)?,
+            updated_at: row.get(3)?,
+            deleted_at: row.get(4)?,
+            doc_type: row.get(5)?,
+            notes_plain: row.get(6)?,
+            notes_markdown: row.get(7)?,
+            summary: row.get(8)?,
+            people_json: row.get(9)?,
+            google_calendar_event_json: row.get(10)?,
+        })
+    })?;
+    let rows = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let mut by_id: std::collections::HashMap<String, Document> = rows
+        .into_iter()
+        .map(row_to_document)
+        .filter_map(|d| d.id.clone().map(|id| (id, d)))
+        .collect();
+
+    Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
+}
+
 fn append_date_filter(
     sql: &mut String,
     params: &mut Vec<Box<dyn rusqlite::types::ToSql>>,
@@ -346,6 +390,32 @@ mod tests {
         let docs = list_meetings(&conn, None, None, false).unwrap();
         // deleted doc excluded
         assert_eq!(docs.len(), 2);
+    }
+
+    #[test]
+    fn test_get_meetings_by_ids_preserves_input_order() {
+        let conn = build_test_db(&meetings_state());
+        let ids = vec!["doc-2".to_string(), "doc-1".to_string()];
+        let docs = get_meetings_by_ids(&conn, &ids).unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].id.as_deref(), Some("doc-2"));
+        assert_eq!(docs[1].id.as_deref(), Some("doc-1"));
+    }
+
+    #[test]
+    fn test_get_meetings_by_ids_skips_unknown_ids() {
+        let conn = build_test_db(&meetings_state());
+        let ids = vec!["doc-1".to_string(), "doc-missing".to_string()];
+        let docs = get_meetings_by_ids(&conn, &ids).unwrap();
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].id.as_deref(), Some("doc-1"));
+    }
+
+    #[test]
+    fn test_get_meetings_by_ids_empty_input() {
+        let conn = build_test_db(&meetings_state());
+        let docs = get_meetings_by_ids(&conn, &[]).unwrap();
+        assert!(docs.is_empty());
     }
 
     #[test]

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -525,7 +525,32 @@ pub fn semantic_search(
 ) -> Result<(Vec<SemanticSearchResult>, usize)> {
     let embedder = model::FastEmbedModel::new()?;
     let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE)?;
+    semantic_search_with_index(
+        conn,
+        &embedder,
+        &index,
+        query,
+        date_range,
+        limit,
+        source_type_filter,
+        include_deleted,
+    )
+}
 
+/// Run a semantic search against an already-loaded embedder and index.
+/// Callers that issue many queries (hybrid search, benchmarks) load the
+/// model and index once and reuse them here.
+#[allow(clippy::too_many_arguments)]
+pub fn semantic_search_with_index(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    index: &EmbeddingIndex,
+    query: &str,
+    date_range: Option<&crate::query::dates::DateRange>,
+    limit: usize,
+    source_type_filter: Option<&[&str]>,
+    include_deleted: bool,
+) -> Result<(Vec<SemanticSearchResult>, usize)> {
     if index.is_empty() {
         return Ok((Vec::new(), 0));
     }
@@ -570,22 +595,7 @@ pub fn semantic_search_with_embedder_and_limit(
     limit: usize,
 ) -> Result<(Vec<SemanticSearchResult>, usize)> {
     let index = ensure_embeddings(conn, embedder, DEFAULT_BATCH_SIZE)?;
-
-    if index.is_empty() {
-        return Ok((Vec::new(), 0));
-    }
-
-    let query_vec = embedder.embed_query(query)?;
-    let results = index.search(&query_vec, 0.0, None);
-    let total_count = results.len();
-
-    let results = if limit > 0 {
-        results.into_iter().take(limit).collect()
-    } else {
-        results
-    };
-
-    Ok((results, total_count))
+    semantic_search_with_index(conn, embedder, &index, query, None, limit, None, false)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ fn main() -> Result<()> {
             query,
             r#in,
             semantic,
+            hybrid,
             context,
             meeting,
             from,
@@ -97,6 +98,7 @@ fn main() -> Result<()> {
             include_deleted,
         } => {
             let mode = SearchMode::from_cli_args(
+                *hybrid,
                 *semantic,
                 *context,
                 r#in,

--- a/src/query/fusion.rs
+++ b/src/query/fusion.rs
@@ -1,0 +1,148 @@
+//! Reciprocal rank fusion (RRF) for combining ranked retrieval lists.
+//!
+//! RRF fuses lists by rank alone, which sidesteps the incomparability of
+//! bm25 and cosine scores: `score(d) = Σ 1/(k + rank_i(d))` over every list
+//! that contains `d`, with 1-based ranks.
+
+/// RRF constant. 60 is the standard value from Cormack et al. (2009) and
+/// works well without per-corpus tuning.
+pub const RRF_K: f64 = 60.0;
+
+/// A document with its fused relevance score (higher is better).
+#[derive(Debug, Clone, PartialEq)]
+pub struct FusedDoc {
+    pub document_id: String,
+    pub score: f64,
+}
+
+/// Fuse ranked document-id lists (best first) with reciprocal rank fusion.
+///
+/// A duplicate occurrence of a document within one list is ignored; only its
+/// best rank in that list contributes. Results sort by score descending, with
+/// exact ties broken by the document's best rank across lists, then by
+/// document id so the order is deterministic.
+pub fn reciprocal_rank_fusion(lists: &[Vec<String>], k: f64) -> Vec<FusedDoc> {
+    use std::collections::hash_map::Entry;
+    use std::collections::{HashMap, HashSet};
+
+    // doc id -> (accumulated score, best rank seen in any list)
+    let mut scores: HashMap<&str, (f64, usize)> = HashMap::new();
+
+    for list in lists {
+        let mut seen_in_list: HashSet<&str> = HashSet::new();
+        for (i, doc_id) in list.iter().enumerate() {
+            if !seen_in_list.insert(doc_id) {
+                continue;
+            }
+            let rank = i + 1;
+            let contribution = 1.0 / (k + rank as f64);
+            match scores.entry(doc_id) {
+                Entry::Occupied(mut e) => {
+                    let (score, best_rank) = e.get_mut();
+                    *score += contribution;
+                    *best_rank = (*best_rank).min(rank);
+                }
+                Entry::Vacant(e) => {
+                    e.insert((contribution, rank));
+                }
+            }
+        }
+    }
+
+    let mut fused: Vec<(&str, f64, usize)> = scores
+        .into_iter()
+        .map(|(doc_id, (score, best_rank))| (doc_id, score, best_rank))
+        .collect();
+    fused.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.2.cmp(&b.2))
+            .then(a.0.cmp(b.0))
+    });
+
+    fused
+        .into_iter()
+        .map(|(doc_id, score, _)| FusedDoc {
+            document_id: doc_id.to_string(),
+            score,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ids(docs: &[FusedDoc]) -> Vec<&str> {
+        docs.iter().map(|d| d.document_id.as_str()).collect()
+    }
+
+    #[test]
+    fn doc_in_both_lists_outranks_single_list_docs() {
+        let lists = vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["b".to_string(), "c".to_string()],
+        ];
+        let fused = reciprocal_rank_fusion(&lists, RRF_K);
+        assert_eq!(ids(&fused), vec!["b", "a", "c"]);
+    }
+
+    #[test]
+    fn score_is_reciprocal_of_k_plus_one_based_rank() {
+        let lists = vec![vec!["x".to_string(), "y".to_string()]];
+        let fused = reciprocal_rank_fusion(&lists, 60.0);
+        assert_eq!(fused[0].document_id, "x");
+        assert!((fused[0].score - 1.0 / 61.0).abs() < 1e-12);
+        assert!((fused[1].score - 1.0 / 62.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn empty_lists_fuse_to_empty() {
+        let fused = reciprocal_rank_fusion(&[Vec::new(), Vec::new()], RRF_K);
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn no_lists_fuse_to_empty() {
+        let fused = reciprocal_rank_fusion(&[], RRF_K);
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn duplicate_within_one_list_keeps_best_rank_only() {
+        let lists = vec![vec!["a".to_string(), "a".to_string(), "b".to_string()]];
+        let fused = reciprocal_rank_fusion(&lists, 60.0);
+        assert_eq!(fused.len(), 2);
+        // "a" scores as rank 1 only, not rank 1 + rank 2.
+        assert!((fused[0].score - 1.0 / 61.0).abs() < 1e-12);
+        // "b" still ranks 3rd in the input list.
+        assert!((fused[1].score - 1.0 / 63.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn single_list_order_is_preserved() {
+        let lists = vec![vec!["a".to_string(), "b".to_string(), "c".to_string()]];
+        let fused = reciprocal_rank_fusion(&lists, RRF_K);
+        assert_eq!(ids(&fused), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn equal_scores_break_ties_by_best_rank_then_id() {
+        // With k=0: "y" scores 1/2 + 1/2 = 1.0 across two lists, "z" scores
+        // 1/1 = 1.0 in one. Equal scores, but "z" holds the better single
+        // rank, so it wins even though "y" < "z" as an id. "pad" scores 2.0
+        // and stays clear of the tie.
+        let lists = vec![
+            vec!["z".to_string()],
+            vec!["pad".to_string(), "y".to_string()],
+            vec!["pad".to_string(), "y".to_string()],
+        ];
+        let fused = reciprocal_rank_fusion(&lists, 0.0);
+        assert_eq!(ids(&fused), vec!["pad", "z", "y"]);
+
+        // Identical score and best rank: falls back to document id.
+        let lists = vec![vec!["b".to_string()], vec!["a".to_string()]];
+        let fused = reciprocal_rank_fusion(&lists, RRF_K);
+        assert_eq!(ids(&fused), vec!["a", "b"]);
+    }
+}

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -1,0 +1,203 @@
+//! Hybrid retrieval: fuse FTS keyword and semantic rankings with RRF.
+//!
+//! Both retrievers run over the same query; their document-level ranked
+//! lists are truncated to a candidate pool and fused by rank (see
+//! [`crate::query::fusion`]). Used by `grans search --hybrid` and the
+//! quality benchmark's hybrid mode.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::embed::model::Embedder;
+use crate::embed::EmbeddingIndex;
+use crate::query::dates::DateRange;
+use crate::query::filter::{semantic_source_filter, SearchTarget};
+use crate::query::fusion::{reciprocal_rank_fusion, FusedDoc, RRF_K};
+
+/// How many top documents each retriever contributes to fusion.
+pub const CANDIDATE_POOL: usize = 100;
+
+/// Run FTS and semantic retrieval for `query` and fuse the rankings.
+/// Returns fused documents, best first.
+pub fn hybrid_ranked(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    index: &EmbeddingIndex,
+    query: &str,
+    targets: &[SearchTarget],
+    date_range: Option<&DateRange>,
+    include_deleted: bool,
+) -> Result<Vec<FusedDoc>> {
+    let fts_docs = crate::db::meetings::search_meetings(
+        conn,
+        query,
+        targets.contains(&SearchTarget::Titles),
+        targets.contains(&SearchTarget::Transcripts),
+        targets.contains(&SearchTarget::Notes),
+        targets.contains(&SearchTarget::Panels),
+        date_range,
+        include_deleted,
+    )?;
+    let fts_ids: Vec<String> = fts_docs.into_iter().filter_map(|d| d.id).collect();
+
+    let source_filter = semantic_source_filter(targets);
+    let (semantic_results, _) = crate::embed::semantic_search_with_index(
+        conn,
+        embedder,
+        index,
+        query,
+        date_range,
+        CANDIDATE_POOL,
+        source_filter.as_deref(),
+        include_deleted,
+    )?;
+    let semantic_ids: Vec<String> = semantic_results.into_iter().map(|r| r.document_id).collect();
+
+    Ok(fuse_candidates(fts_ids, semantic_ids))
+}
+
+/// Truncate each ranked id list to the candidate pool and fuse with RRF.
+fn fuse_candidates(mut fts_ids: Vec<String>, mut semantic_ids: Vec<String>) -> Vec<FusedDoc> {
+    fts_ids.truncate(CANDIDATE_POOL);
+    semantic_ids.truncate(CANDIDATE_POOL);
+    reciprocal_rank_fusion(&[fts_ids, semantic_ids], RRF_K)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_fixtures::build_test_db;
+    use crate::embed::store::StoredVector;
+    use serde_json::json;
+
+    /// Embedder whose query vector is fixed, so cosine rankings against
+    /// hand-built stored vectors are fully controlled.
+    struct FixedEmbedder;
+
+    impl Embedder for FixedEmbedder {
+        fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![1.0, 0.0]).collect())
+        }
+
+        fn embed_query(&self, _text: &str) -> Result<Vec<f32>> {
+            Ok(vec![1.0, 0.0])
+        }
+
+        fn dimension(&self) -> usize {
+            2
+        }
+
+        fn model_name(&self) -> &str {
+            "fixed-embedder"
+        }
+
+        fn max_length(&self) -> usize {
+            512
+        }
+    }
+
+    fn stored(doc_id: &str, vector: Vec<f32>) -> StoredVector {
+        StoredVector {
+            chunk_id: 0,
+            document_id: doc_id.to_string(),
+            source_type: "transcript_window".to_string(),
+            text: String::new(),
+            vector,
+            metadata_json: None,
+        }
+    }
+
+    /// Three docs: "doc-both" is found by FTS (title) and ranks first
+    /// semantically; "doc-fts" only matches by title; "doc-sem" only ranks
+    /// semantically. The doc in both lists must fuse to the top.
+    fn hybrid_state() -> serde_json::Value {
+        json!({
+            "documents": {
+                "doc-both": {"id": "doc-both", "title": "Kumquat sync A", "created_at": "2026-01-20T10:00:00Z"},
+                "doc-fts": {"id": "doc-fts", "title": "Kumquat sync B", "created_at": "2026-01-25T10:00:00Z"},
+                "doc-sem": {"id": "doc-sem", "title": "Unrelated", "created_at": "2026-01-15T10:00:00Z"}
+            }
+        })
+    }
+
+    fn hybrid_index() -> EmbeddingIndex {
+        EmbeddingIndex {
+            vectors: vec![
+                // cosine vs [1, 0]: doc-both = 1.0, doc-sem ~= 0.707
+                stored("doc-both", vec![1.0, 0.0]),
+                stored("doc-sem", vec![1.0, 1.0]),
+            ],
+            stats: None,
+        }
+    }
+
+    fn all_targets() -> Vec<SearchTarget> {
+        SearchTarget::parse_list("titles,transcripts,notes,panels")
+    }
+
+    #[test]
+    fn doc_found_by_both_retrievers_fuses_to_top() {
+        let conn = build_test_db(&hybrid_state());
+        let index = hybrid_index();
+
+        let fused =
+            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, false)
+                .unwrap();
+
+        // FTS title tier orders by recency: [doc-fts, doc-both].
+        // Semantic orders by cosine: [doc-both, doc-sem].
+        // doc-both appears in both lists, so it wins; doc-fts (rank 1 in
+        // FTS) and doc-sem (rank 2 in semantic) follow.
+        let ids: Vec<&str> = fused.iter().map(|d| d.document_id.as_str()).collect();
+        assert_eq!(ids[0], "doc-both");
+        assert!(ids.contains(&"doc-fts"));
+        assert!(ids.contains(&"doc-sem"));
+        assert_eq!(fused.len(), 3);
+        // doc-fts holds rank 1 in the FTS list, doc-sem rank 2 in the
+        // semantic list, so doc-fts scores higher.
+        assert_eq!(ids, vec!["doc-both", "doc-fts", "doc-sem"]);
+    }
+
+    #[test]
+    fn titles_only_targets_exclude_semantic_results() {
+        let conn = build_test_db(&hybrid_state());
+        let index = hybrid_index();
+        let targets = SearchTarget::parse_list("titles");
+
+        let fused =
+            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &targets, None, false)
+                .unwrap();
+
+        // Semantic search is filtered to no embeddable source types, so
+        // only the FTS title matches remain, in FTS order.
+        let ids: Vec<&str> = fused.iter().map(|d| d.document_id.as_str()).collect();
+        assert_eq!(ids, vec!["doc-fts", "doc-both"]);
+    }
+
+    #[test]
+    fn no_matches_fuse_to_empty() {
+        let conn = build_test_db(&hybrid_state());
+        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
+
+        let fused =
+            hybrid_ranked(&conn, &FixedEmbedder, &index, "zyzzyva", &all_targets(), None, false)
+                .unwrap();
+
+        assert!(fused.is_empty());
+    }
+
+    #[test]
+    fn fuse_candidates_truncates_each_list_to_pool() {
+        let fts: Vec<String> = (0..150).map(|i| format!("fts-{i:03}")).collect();
+        let semantic: Vec<String> = (0..150).map(|i| format!("sem-{i:03}")).collect();
+
+        let fused = fuse_candidates(fts, semantic);
+
+        assert_eq!(fused.len(), 2 * CANDIDATE_POOL);
+        let ids: Vec<&str> = fused.iter().map(|d| d.document_id.as_str()).collect();
+        assert!(ids.contains(&"fts-099"));
+        assert!(!ids.contains(&"fts-100"));
+        assert!(ids.contains(&"sem-099"));
+        assert!(!ids.contains(&"sem-100"));
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,5 +1,6 @@
 pub mod dates;
 pub mod filter;
 pub mod fts;
+pub mod fusion;
 pub mod search;
 pub mod text;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -2,5 +2,6 @@ pub mod dates;
 pub mod filter;
 pub mod fts;
 pub mod fusion;
+pub mod hybrid;
 pub mod search;
 pub mod text;


### PR DESCRIPTION
Closes #40.

Adds hybrid retrieval behind an opt-in `--hybrid` flag: both retrievers run over the same query, each ranked list is truncated to a 100-document candidate pool, and the lists are fused with reciprocal rank fusion (`score = Σ 1/(k + rank)`, k=60). Rank-based fusion sidesteps the incomparability of bm25 and cosine scores. Chunk-level semantic candidates were already deduplicated to meetings by best chunk; fusion operates on document ids throughout.

## What changed

- `query/fusion.rs` (new): pure RRF over ranked id lists. Exact score ties break by best single-list rank, then document id, so output order is deterministic.
- `query/hybrid.rs` (new): orchestration shared by the CLI and the benchmark, so the benchmark measures the exact production fusion path. Search targets thread to both sides (FTS section flags, semantic source-type filter).
- `embed`: `semantic_search_with_index` separates index loading from searching; repeated queries load the model once.
- CLI: `--hybrid` on `grans search`, conflicting with `--semantic` and `--context`. Output reuses the keyword meeting-row format; `--in`, `--meeting`, date filters, `--limit`, and the embedding confirmation prompt all apply. The keyword display, meeting filter, and embedding prompt moved into helpers shared by both modes.
- Benchmark: `--mode hybrid` and `--compare fts,semantic,hybrid`.
- `db::meetings::get_meetings_by_ids` maps fused ids back to rows in ranked order.

## Benchmarks

Frozen snapshot (872 docs), 93-query golden set, k=10, ID matching, re-audited strata:

| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
|---|---|---|---|---|
| fts (Phase 1) | 0.172 | 0.093 | 0.139 | ~5 ms |
| semantic | 0.860 | 0.759 | 0.721 | ~56 ms |
| **hybrid (this PR)** | **0.860** | **0.759** | **0.722** | ~65 ms |

Per stratum (hit-rate / MRR):

| Stratum | n | fts | semantic | hybrid |
|---|---|---|---|---|
| exact-term | 17 | 0.94 / 0.76 | 1.00 / 0.92 | **1.00 / 1.00** |
| mixed | 38 | 0.00 / 0.00 | 0.82 / 0.71 | 0.82 / 0.69 |
| paraphrase | 38 | 0.00 / 0.00 | 0.84 / 0.64 | 0.84 / 0.63 |

Aggregates tie semantic; the movement is exactly where fusion should act. On exact-term queries FTS agreement pulls two semantically rank-2/rank-5 results to rank 1, taking the stratum to a perfect MRR. The cost is three one-position slips (1→2, 2→3, 1→2) on mixed/paraphrase queries where an irrelevant FTS match fused above a relevant semantic one.

## Gate (from #40)

- **Hybrid matches or beats the better of (FTS, semantic) per query in most cases**: 90 of 93 (97%). Against the single modes: vs FTS 69W/0L/24T, vs semantic 2W/3L/88T on best rank.
- **No query whose first relevant result ranks in the top 3 under either mode falls out of the top k**: zero violations; the worst movement anywhere is one position.

Gate passes. Per the issue, promotion to default is a follow-up PR; `--keyword`-equivalent (plain) and `--semantic` remain the forcing modes.

Recorded run appended to the benchmarks ledger (`2026-07-10`, mode `hybrid`, binary `f59ef42`) with per-query output under `runs/`.

## Known limitation

With FTS scoring zero outside the exact-term stratum, fusion has only one useful signal for mixed/paraphrase queries, which caps hybrid at semantic's level there. Larger gains wait on reranking (Phase 3, #41) and embedding improvements (Phase 4, #42).

## Follow-up

`commands/search.rs` now sits at ~770 code lines across four mode handlers plus shared display helpers. Splitting it into a `commands/search/` module directory (dispatch + one file per mode) is worth doing as its own mechanical PR so this diff stays reviewable.
