### PR TITLE
#41: Cross-encoder reranking behind --hybrid --rerank

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ grans search "budget" --semantic --in notes,panels    # Notes + AI notes
 # Hybrid search: run keyword and semantic together, fuse the rankings
 grans search "quarterly budget review" --hybrid
 
+# Rerank the top hybrid candidates with a cross-encoder (slower, higher quality)
+grans search "quarterly budget review" --hybrid --rerank
+grans search "quarterly budget review" --hybrid --rerank --min-score 0.5
+
 # Limit results (default 10, use 0 for no limit)
 # Works with keyword, context window, and semantic search
 grans search "budget" --limit 5
@@ -187,6 +191,8 @@ grans search "old project" --semantic --include-deleted
 Keyword search matches every word in the query, in any order: `grans search "budget review"` finds meetings that mention both words. To require an exact phrase, quote it inside the query (e.g. `grans search '"budget review"'`). Results are ranked by relevance: meetings whose title contains the query come first, then content matches ranked by BM25, with newer meetings breaking ties.
 
 Hybrid search (`--hybrid`) runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either mode surfaces, and one ranked well by both rises to the top. It needs embeddings (like `--semantic`, it will prompt if many chunks are unembedded; `--yes` skips the prompt) and supports `--in`, `--meeting`, date filters, and `--limit`. It cannot be combined with `--semantic` or `--context`.
+
+Adding `--rerank` scores the top 50 fused candidates with a cross-encoder reranker (`jina-reranker-v1-turbo-en`, downloaded automatically on first use, ~150MB) and reorders them by how well each meeting actually answers the query. Reranked results show a relevance score between 0 and 1, and `--min-score` drops results below a threshold. Reranking adds a couple of seconds per query on CPU, which is why it is opt-in.
 
 Semantic search uses a local embedding model (`nomic-embed-text-v1.5`) to find meetings by meaning rather than exact keywords. On first use, the model is downloaded automatically (~270MB). Embeddings are built from transcripts, AI-generated panel sections, and your notes, and are stored in the main database. Use `--in` to restrict which sources are searched (e.g. `--in panels` to only search AI notes).
 

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -7,6 +7,7 @@ A staged plan to evolve `grans search` from two separate modes (FTS5 keyword, se
 - **Keyword search** (Phase 1, #39): FTS5 `MATCH` with implicit-AND semantics (each term quoted individually; user-supplied quotes force phrase matching), ranked by `bm25()` with recency as tiebreak. Title substring matches rank as a tier above content matches; weighting them properly is Phase 5. Applies to the combined search and the standalone transcript/notes/panel searches.
 - **Semantic search** (`--semantic`): nomic-embed-text-v1.5 (768d) via fastembed, brute-force cosine over in-memory vectors, `min_score` cutoff. Chunkers for transcripts (adaptive window), panels (section), notes (paragraph).
 - **Hybrid search** (Phase 2, #40, opt-in `--hybrid`): runs both retrievers, truncates each ranked list to a 100-document candidate pool, and fuses by reciprocal rank fusion (k=60) in `query/fusion.rs` + `query/hybrid.rs`. Output is the fused meeting list; keyword and semantic remain the forcing modes.
+- **Reranking** (Phase 3, #41, opt-in `--hybrid --rerank`): a cross-encoder (fastembed `TextRerank`, jina-reranker-v1-turbo-en) scores the top 50 fused candidates as title + best-chunk passages and reorders them (`embed/rerank.rs` + `query/rerank.rs`). The sigmoid relevance probability is the user-facing score; `--min-score` filters on it. Opt-in per the Phase 3 gate (see results below).
 - The modes are mutually exclusive; `commands/search.rs` dispatches on a `SearchMode` enum.
 - **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. Implemented in `commands/benchmark/`.
 
@@ -79,6 +80,18 @@ Phase 2 results (2026-07-10, k=10, ID matching, same snapshot, re-audited strata
 Aggregates tie semantic, but the movement is where fusion should act: on exact-term queries hybrid reaches hit-rate 1.00 / MRR 1.000 (semantic 1.00 / 0.924, FTS 0.94 / 0.761), because FTS agreement pulls two semantically rank-2/rank-5 results to rank 1. Per query, hybrid matches or beats the better single mode on 90 of 93; the 3 losses are one-position slips (1→2, 2→3, 1→2) on mixed/paraphrase queries where an irrelevant FTS match fused above a relevant semantic one, costing ~0.015 MRR on those strata. No query with a top-3 result under either mode leaves the top 10, so the #40 gate passes. Against the single modes: hybrid vs FTS 69W/0L/24T, hybrid vs semantic 2W/3L/88T on best rank.
 
 The ceiling here is FTS itself: with FTS scoring zero outside exact-term, fusion has only one useful signal for mixed/paraphrase queries. Larger hybrid gains wait on reranking (Phase 3) and embedding improvements (Phase 4). Promotion of `--hybrid` to the default is a follow-up PR per #40.
+
+Phase 3 results (2026-07-10, k=10, ID matching, same snapshot, all modes in one `--compare` run):
+
+| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
+|---|---|---|---|---|
+| hybrid (RRF) | 0.86 | 0.76 | 0.72 | ~63 ms |
+| rerank-jina | 0.90 | 0.75 | 0.77 | ~2.0 s |
+| rerank-bge | 0.89 | 0.70 | 0.70 | ~7.2 s |
+
+jina-reranker-v1-turbo-en is the model pick: it beats bge-reranker-base on every aggregate and stratum at under a third of the latency, so it backs `--rerank`. Per stratum (hit / MRR), jina reaches mixed 0.87 / 0.759 and paraphrase 0.89 / 0.702 against hybrid's 0.82 / 0.694 and 0.84 / 0.626; exact-term keeps hit 1.00 but MRR slips 1.000 to 0.941 (two one-position slips). Per query at k=10 it goes 23W / 15L / 55T against the better of (hybrid, semantic), matching or beating it on 78 of 93.
+
+The gate: the lift is real but reranking does not become part of plain `--hybrid`. Three queries whose relevant meeting ranked top-3 under fusion fall out of the top 10 (to ranks 13-15), which rule 2 above treats as outweighing the wins, and per-query latency rises from 63 ms to ~2 s plus reranker model load in a one-shot CLI. So `--rerank` is opt-in. Revisit if the dropouts get fixed, e.g. by blending the fusion prior into the reranked order (Phase 5 ranking-polish territory) or a stronger small reranker.
 
 (v1-file baseline for reference: hit-rate@10 ~73%, MRR ~0.55, title matching.)
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -257,8 +257,12 @@ pub enum QualityMode {
     Fts,
     /// Semantic search over embeddings
     Semantic,
-    /// RRF fusion of FTS and semantic rankings (--hybrid)
+    /// RRF fusion of FTS and semantic rankings (--hybrid --fast)
     Hybrid,
+    /// Fusion + jina-reranker-v1-turbo-en cross-encoder
+    RerankJina,
+    /// Fusion + bge-reranker-base cross-encoder
+    RerankBge,
 }
 
 impl QualityMode {
@@ -267,6 +271,8 @@ impl QualityMode {
             QualityMode::Fts => "fts",
             QualityMode::Semantic => "semantic",
             QualityMode::Hybrid => "hybrid",
+            QualityMode::RerankJina => "rerank-jina",
+            QualityMode::RerankBge => "rerank-bge",
         }
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -54,9 +54,18 @@ pub enum Commands {
         #[arg(long)]
         semantic: bool,
 
-        /// Combine keyword and semantic search, fusing both rankings
+        /// Combine keyword and semantic search: fuse both rankings and
+        /// rerank the top candidates with a cross-encoder
         #[arg(long, conflicts_with_all = ["semantic", "context"])]
         hybrid: bool,
+
+        /// Skip the reranking stage of hybrid search
+        #[arg(long, requires = "hybrid")]
+        fast: bool,
+
+        /// Minimum reranker relevance score (0-1) for hybrid results
+        #[arg(long, requires = "hybrid", conflicts_with = "fast")]
+        min_score: Option<f32>,
 
         /// Context window size: utterances for transcripts, sections for panels, paragraphs for notes (0 = disabled)
         #[arg(long, default_value = "0")]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -54,17 +54,17 @@ pub enum Commands {
         #[arg(long)]
         semantic: bool,
 
-        /// Combine keyword and semantic search: fuse both rankings and
-        /// rerank the top candidates with a cross-encoder
+        /// Combine keyword and semantic search, fusing both rankings
         #[arg(long, conflicts_with_all = ["semantic", "context"])]
         hybrid: bool,
 
-        /// Skip the reranking stage of hybrid search
+        /// Rerank the top hybrid candidates with a cross-encoder
+        /// (slower, higher quality; shows relevance scores)
         #[arg(long, requires = "hybrid")]
-        fast: bool,
+        rerank: bool,
 
         /// Minimum reranker relevance score (0-1) for hybrid results
-        #[arg(long, requires = "hybrid", conflicts_with = "fast")]
+        #[arg(long, requires = "rerank")]
         min_score: Option<f32>,
 
         /// Context window size: utterances for transcripts, sections for panels, paragraphs for notes (0 = disabled)
@@ -257,9 +257,9 @@ pub enum QualityMode {
     Fts,
     /// Semantic search over embeddings
     Semantic,
-    /// RRF fusion of FTS and semantic rankings (--hybrid --fast)
+    /// RRF fusion of FTS and semantic rankings (--hybrid)
     Hybrid,
-    /// Fusion + jina-reranker-v1-turbo-en cross-encoder
+    /// Fusion + jina-reranker-v1-turbo-en cross-encoder (--hybrid --rerank)
     RerankJina,
     /// Fusion + bge-reranker-base cross-encoder
     RerankBge,

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -3,7 +3,8 @@
 //! Each mode returns the full document-level ranked list for a query;
 //! scoring (metrics.rs) applies k. Lists reflect current production
 //! behavior for the mode: FTS is ranked by bm25 with a recency tiebreak,
-//! semantic by best-chunk cosine score, and hybrid by RRF over both.
+//! semantic by best-chunk cosine score, hybrid by RRF over both, and the
+//! rerank modes by cross-encoder score over the top of the fused pool.
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -11,6 +12,7 @@ use rusqlite::Connection;
 use super::metrics::RankedDoc;
 use crate::cli::args::QualityMode;
 use crate::embed::model::{Embedder, FastEmbedModel};
+use crate::embed::rerank::{FastEmbedReranker, RerankModel, Reranker};
 use crate::embed::search::SemanticSearchResult;
 use crate::embed::{ensure_embeddings, EmbeddingIndex, DEFAULT_BATCH_SIZE};
 use crate::query::filter::SearchTarget;
@@ -28,12 +30,18 @@ pub enum Retriever<'a> {
         embedder: FastEmbedModel,
         index: EmbeddingIndex,
     },
+    HybridRerank {
+        conn: &'a Connection,
+        embedder: FastEmbedModel,
+        index: EmbeddingIndex,
+        reranker: Box<FastEmbedReranker>,
+    },
 }
 
 impl<'a> Retriever<'a> {
-    /// Build the retriever for a mode. For semantic and hybrid, the embedding
-    /// model and index are loaded once here so per-query latency measures
-    /// search, not one-time setup.
+    /// Build the retriever for a mode. For semantic, hybrid, and rerank
+    /// modes, the models and index are loaded once here so per-query
+    /// latency measures search, not one-time setup.
     pub fn build(mode: QualityMode, conn: &'a Connection) -> Result<Self> {
         match mode {
             QualityMode::Fts => Ok(Retriever::Fts { conn }),
@@ -46,6 +54,16 @@ impl<'a> Retriever<'a> {
                 let embedder = FastEmbedModel::new()?;
                 let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE)?;
                 Ok(Retriever::Hybrid { conn, embedder, index })
+            }
+            QualityMode::RerankJina | QualityMode::RerankBge => {
+                let embedder = FastEmbedModel::new()?;
+                let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE)?;
+                let model = match mode {
+                    QualityMode::RerankJina => RerankModel::JinaTurbo,
+                    _ => RerankModel::BgeBase,
+                };
+                let reranker = Box::new(FastEmbedReranker::new(model)?);
+                Ok(Retriever::HybridRerank { conn, embedder, index, reranker })
             }
         }
     }
@@ -60,6 +78,9 @@ impl<'a> Retriever<'a> {
             }
             Retriever::Hybrid { conn, embedder, index } => {
                 retrieve_hybrid(conn, embedder, index, query)
+            }
+            Retriever::HybridRerank { conn, embedder, index, reranker } => {
+                retrieve_hybrid_rerank(conn, embedder, index, reranker.as_ref(), query)
             }
         }
     }
@@ -98,6 +119,29 @@ fn retrieve_hybrid(
         .map(|d| RankedDoc {
             document_id: d.document_id,
             score: Some(d.score as f32),
+        })
+        .collect())
+}
+
+/// Reranked hybrid retrieval over the same default targets: production
+/// fusion, then the cross-encoder reorders the top candidates (the
+/// `grans search --hybrid` default path).
+fn retrieve_hybrid_rerank(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    index: &EmbeddingIndex,
+    reranker: &dyn Reranker,
+    query: &str,
+) -> Result<Vec<RankedDoc>> {
+    let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
+    let ranking =
+        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, false)?;
+    let reranked = crate::query::rerank::rerank_hybrid(conn, reranker, query, &ranking)?;
+    Ok(reranked
+        .into_iter()
+        .map(|d| RankedDoc {
+            document_id: d.document_id,
+            score: Some(d.score),
         })
         .collect())
 }
@@ -180,6 +224,62 @@ mod tests {
         let embedder = crate::embed::model::MockEmbedder { dim: 2, max_length: 512 };
 
         let ranked = retrieve_hybrid(&conn, &embedder, &index, "zebra xylophone").unwrap();
+
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn hybrid_rerank_retriever_reorders_by_cross_encoder() {
+        use crate::embed::model::MockEmbedder;
+        use crate::embed::rerank::MockReranker;
+        use crate::embed::store::StoredVector;
+
+        let conn = build_test_db(&meetings_state());
+        // Query "standup": FTS matches doc-2 by title, and MockEmbedder's
+        // query vector has a larger first component, so doc-1 (vector
+        // [1, 0]) outranks doc-2 ([0, 1]) semantically. Fusion puts doc-2
+        // (in both lists) first. The passages reverse that: doc-1's chunk
+        // repeats the query three times, doc-2's not at all (its single
+        // occurrence is the title).
+        let stored = |doc_id: &str, text: &str, vector: Vec<f32>| StoredVector {
+            chunk_id: 0,
+            document_id: doc_id.to_string(),
+            source_type: "transcript_window".to_string(),
+            text: text.to_string(),
+            vector,
+            metadata_json: None,
+        };
+        let index = EmbeddingIndex {
+            vectors: vec![
+                stored("doc-1", "standup standup standup", vec![1.0, 0.0]),
+                stored("doc-2", "planning", vec![0.0, 1.0]),
+            ],
+            stats: None,
+        };
+        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+
+        let ranked =
+            retrieve_hybrid_rerank(&conn, &embedder, &index, &MockReranker, "standup").unwrap();
+
+        assert_eq!(ranked.len(), 2);
+        assert_eq!(ranked[0].document_id, "doc-1");
+        assert_eq!(ranked[0].score, Some(3.0));
+        assert_eq!(ranked[1].document_id, "doc-2");
+        assert_eq!(ranked[1].score, Some(1.0));
+    }
+
+    #[test]
+    fn hybrid_rerank_retriever_empty_for_no_match() {
+        use crate::embed::model::MockEmbedder;
+        use crate::embed::rerank::MockReranker;
+
+        let conn = build_test_db(&meetings_state());
+        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
+        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+
+        let ranked =
+            retrieve_hybrid_rerank(&conn, &embedder, &index, &MockReranker, "zebra xylophone")
+                .unwrap();
 
         assert!(ranked.is_empty());
     }

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -91,7 +91,8 @@ fn retrieve_hybrid(
 ) -> Result<Vec<RankedDoc>> {
     let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
     let fused =
-        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, false)?;
+        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, false)?
+            .fused;
     Ok(fused
         .into_iter()
         .map(|d| RankedDoc {

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -238,7 +238,7 @@ fn hybrid_search(
     let embedder = crate::embed::model::FastEmbedModel::new()?;
     let index = crate::embed::ensure_embeddings(conn, &embedder, crate::embed::DEFAULT_BATCH_SIZE)?;
 
-    let fused = crate::query::hybrid::hybrid_ranked(
+    let ranking = crate::query::hybrid::hybrid_ranked(
         conn,
         &embedder,
         &index,
@@ -247,7 +247,7 @@ fn hybrid_search(
         date_range.as_ref(),
         include_deleted,
     )?;
-    let ids: Vec<String> = fused.into_iter().map(|d| d.document_id).collect();
+    let ids: Vec<String> = ranking.fused.into_iter().map(|d| d.document_id).collect();
     let results = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
 
     let results = filter_by_meeting(results, meeting_filter);

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -37,6 +37,8 @@ pub enum SearchMode {
     Hybrid {
         targets: Vec<SearchTarget>,
         meeting_filter: Option<String>,
+        rerank: bool,
+        min_score: Option<f32>,
         yes: bool,
         limit: usize,
     },
@@ -48,6 +50,8 @@ impl SearchMode {
     #[allow(clippy::too_many_arguments)]
     pub fn from_cli_args(
         hybrid: bool,
+        fast: bool,
+        min_score: Option<f32>,
         semantic: bool,
         context: usize,
         in_targets: &str,
@@ -60,6 +64,8 @@ impl SearchMode {
             SearchMode::Hybrid {
                 targets: SearchTarget::parse_list(in_targets),
                 meeting_filter: meeting_filter.map(String::from),
+                rerank: !fast,
+                min_score,
                 yes,
                 limit,
             }
@@ -142,6 +148,8 @@ pub fn search(
         SearchMode::Hybrid {
             targets,
             meeting_filter,
+            rerank,
+            min_score,
             yes,
             limit,
         } => hybrid_search(
@@ -149,6 +157,8 @@ pub fn search(
             query,
             &targets,
             meeting_filter.as_deref(),
+            rerank,
+            min_score,
             yes,
             limit,
             date_range,
@@ -217,14 +227,16 @@ fn keyword_search(
     Ok(())
 }
 
-/// Run keyword and semantic retrieval, fuse the rankings, and display the
-/// resulting meetings.
+/// Run keyword and semantic retrieval, fuse the rankings, rerank the top
+/// candidates (unless skipped), and display the resulting meetings.
 #[allow(clippy::too_many_arguments)]
 fn hybrid_search(
     conn: &Connection,
     query: &str,
     targets: &[SearchTarget],
     meeting_filter: Option<&str>,
+    rerank: bool,
+    min_score: Option<f32>,
     yes: bool,
     limit: usize,
     date_range: Option<DateRange>,
@@ -247,6 +259,32 @@ fn hybrid_search(
         date_range.as_ref(),
         include_deleted,
     )?;
+
+    if rerank {
+        let reranker =
+            crate::embed::rerank::FastEmbedReranker::new(crate::embed::rerank::DEFAULT_RERANK_MODEL)?;
+        let mut reranked = crate::query::rerank::rerank_hybrid(conn, &reranker, query, &ranking)?;
+        if let Some(min) = min_score {
+            reranked.retain(|d| d.score >= min);
+        }
+
+        let ids: Vec<String> = reranked.iter().map(|d| d.document_id.clone()).collect();
+        let docs = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
+        let scores: std::collections::HashMap<String, f32> =
+            reranked.into_iter().map(|d| (d.document_id, d.score)).collect();
+        let results: Vec<(Document, f32)> = docs
+            .into_iter()
+            .filter_map(|doc| {
+                let score = doc.id.as_ref().and_then(|id| scores.get(id)).copied()?;
+                Some((doc, score))
+            })
+            .collect();
+
+        let results = filter_scored_by_meeting(results, meeting_filter);
+        render_scored_meeting_list(results, query, limit, ctx);
+        return Ok(());
+    }
+
     let ids: Vec<String> = ranking.fused.into_iter().map(|d| d.document_id).collect();
     let results = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
 
@@ -256,6 +294,19 @@ fn hybrid_search(
     Ok(())
 }
 
+/// True when the document's title or id contains the lowercased filter.
+fn matches_meeting_filter(doc: &Document, filter_lower: &str) -> bool {
+    doc.title
+        .as_ref()
+        .map(|t| t.to_lowercase().contains(filter_lower))
+        .unwrap_or(false)
+        || doc
+            .id
+            .as_ref()
+            .map(|id| id.to_lowercase().contains(filter_lower))
+            .unwrap_or(false)
+}
+
 /// Keep only documents whose title or id contains `filter` (case-insensitive).
 /// No filter keeps everything.
 fn filter_by_meeting(results: Vec<Document>, meeting_filter: Option<&str>) -> Vec<Document> {
@@ -263,20 +314,19 @@ fn filter_by_meeting(results: Vec<Document>, meeting_filter: Option<&str>) -> Ve
         return results;
     };
     let filter_lower = filter.to_lowercase();
-    results
-        .into_iter()
-        .filter(|doc| {
-            doc.title
-                .as_ref()
-                .map(|t| t.to_lowercase().contains(&filter_lower))
-                .unwrap_or(false)
-                || doc
-                    .id
-                    .as_ref()
-                    .map(|id| id.to_lowercase().contains(&filter_lower))
-                    .unwrap_or(false)
-        })
-        .collect()
+    results.into_iter().filter(|doc| matches_meeting_filter(doc, &filter_lower)).collect()
+}
+
+/// [`filter_by_meeting`] for scored results.
+fn filter_scored_by_meeting(
+    results: Vec<(Document, f32)>,
+    meeting_filter: Option<&str>,
+) -> Vec<(Document, f32)> {
+    let Some(filter) = meeting_filter else {
+        return results;
+    };
+    let filter_lower = filter.to_lowercase();
+    results.into_iter().filter(|(doc, _)| matches_meeting_filter(doc, &filter_lower)).collect()
 }
 
 /// Print a ranked meeting list, honoring the output mode and result limit.
@@ -307,6 +357,49 @@ fn render_meeting_list(results: Vec<Document>, query: &str, limit: usize, ctx: &
             }
             for doc in &results {
                 println!("{}", crate::output::table::format_meeting_row(doc, &ctx.tz));
+            }
+            if total > results.len() {
+                println!("\nUse --limit 0 to show all {} results.", total);
+            }
+        }
+    }
+}
+
+/// Print a reranked meeting list with relevance scores, honoring the
+/// output mode and result limit.
+fn render_scored_meeting_list(
+    results: Vec<(Document, f32)>,
+    query: &str,
+    limit: usize,
+    ctx: &RunContext,
+) {
+    let total = results.len();
+    let results = apply_limit(results, limit);
+
+    match ctx.output_mode {
+        OutputMode::Json => {
+            println!("{}", crate::output::json::format_scored_meetings(&results));
+        }
+        OutputMode::Tty => {
+            if results.is_empty() {
+                println!("No meetings found matching \"{}\".", query);
+                return;
+            }
+            if total > results.len() {
+                println!(
+                    "Found {} meeting(s) matching \"{}\" (showing {}):\n",
+                    total,
+                    query,
+                    results.len()
+                );
+            } else {
+                println!("Found {} meeting(s) matching \"{}\":\n", results.len(), query);
+            }
+            for (doc, score) in &results {
+                println!(
+                    "{}",
+                    crate::output::table::format_scored_meeting_row(doc, *score, &ctx.tz)
+                );
             }
             if total > results.len() {
                 println!("\nUse --limit 0 to show all {} results.", total);
@@ -773,13 +866,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_cli_args_hybrid_takes_priority() {
-        let mode =
-            SearchMode::from_cli_args(true, true, 5, "titles,notes", Some("standup"), None, true, 10);
+    fn from_cli_args_hybrid_takes_priority_and_reranks_by_default() {
+        let mode = SearchMode::from_cli_args(
+            true, false, None, true, 5, "titles,notes", Some("standup"), None, true, 10,
+        );
         match mode {
             SearchMode::Hybrid {
                 targets,
                 meeting_filter,
+                rerank,
+                min_score,
                 yes,
                 limit,
             } => {
@@ -787,6 +883,8 @@ mod tests {
                 assert!(targets.contains(&SearchTarget::Titles));
                 assert!(targets.contains(&SearchTarget::Notes));
                 assert_eq!(meeting_filter.as_deref(), Some("standup"));
+                assert!(rerank);
+                assert_eq!(min_score, None);
                 assert!(yes);
                 assert_eq!(limit, 10);
             }
@@ -795,8 +893,29 @@ mod tests {
     }
 
     #[test]
+    fn from_cli_args_fast_skips_rerank() {
+        let mode =
+            SearchMode::from_cli_args(true, true, None, false, 0, "titles", None, None, false, 10);
+        match mode {
+            SearchMode::Hybrid { rerank, .. } => assert!(!rerank),
+            _ => panic!("Expected Hybrid variant"),
+        }
+    }
+
+    #[test]
+    fn from_cli_args_min_score_threads_to_hybrid() {
+        let mode = SearchMode::from_cli_args(
+            true, false, Some(0.4), false, 0, "titles", None, None, false, 10,
+        );
+        match mode {
+            SearchMode::Hybrid { min_score, .. } => assert_eq!(min_score, Some(0.4)),
+            _ => panic!("Expected Hybrid variant"),
+        }
+    }
+
+    #[test]
     fn from_cli_args_semantic_takes_priority() {
-        let mode = SearchMode::from_cli_args(false, true, 5, "titles", Some("standup"), None, true, 10);
+        let mode = SearchMode::from_cli_args(false, false, None, true, 5, "titles", Some("standup"), None, true, 10);
         match mode {
             SearchMode::Semantic {
                 targets,
@@ -816,7 +935,7 @@ mod tests {
 
     #[test]
     fn from_cli_args_context_takes_priority_over_keyword() {
-        let mode = SearchMode::from_cli_args(false, false, 3, "titles,notes", Some("standup"), None, false, 10);
+        let mode = SearchMode::from_cli_args(false, false, None, false, 3, "titles,notes", Some("standup"), None, false, 10);
         match mode {
             SearchMode::ContextWindow {
                 targets,
@@ -838,7 +957,7 @@ mod tests {
 
     #[test]
     fn from_cli_args_defaults_to_keyword() {
-        let mode = SearchMode::from_cli_args(false, false, 0, "titles,notes", None, None, false, 10);
+        let mode = SearchMode::from_cli_args(false, false, None, false, 0, "titles,notes", None, None, false, 10);
         match mode {
             SearchMode::Keyword {
                 targets,
@@ -858,7 +977,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_keyword() {
         let mode =
-            SearchMode::from_cli_args(false, false, 0, "transcripts", Some("daily"), None, false, 10);
+            SearchMode::from_cli_args(false, false, None, false, 0, "transcripts", Some("daily"), None, false, 10);
         match mode {
             SearchMode::Keyword {
                 meeting_filter, ..
@@ -872,7 +991,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_context_window() {
         let mode =
-            SearchMode::from_cli_args(false, false, 5, "titles", Some("retro"), None, false, 10);
+            SearchMode::from_cli_args(false, false, None, false, 5, "titles", Some("retro"), None, false, 10);
         match mode {
             SearchMode::ContextWindow {
                 meeting_filter, ..
@@ -886,7 +1005,7 @@ mod tests {
     #[test]
     fn from_cli_args_speaker_filter_threads_to_context_window() {
         let speaker = SpeakerFilter::Me;
-        let mode = SearchMode::from_cli_args(false, false, 3, "transcripts", None, Some(&speaker), false, 10);
+        let mode = SearchMode::from_cli_args(false, false, None, false, 3, "transcripts", None, Some(&speaker), false, 10);
         match mode {
             SearchMode::ContextWindow {
                 speaker_filter, ..
@@ -900,7 +1019,7 @@ mod tests {
     #[test]
     fn from_cli_args_speaker_filter_threads_to_semantic() {
         let speaker = SpeakerFilter::Other;
-        let mode = SearchMode::from_cli_args(false, true, 0, "transcripts", None, Some(&speaker), false, 10);
+        let mode = SearchMode::from_cli_args(false, false, None, true, 0, "transcripts", None, Some(&speaker), false, 10);
         match mode {
             SearchMode::Semantic {
                 speaker_filter, ..

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -50,7 +50,7 @@ impl SearchMode {
     #[allow(clippy::too_many_arguments)]
     pub fn from_cli_args(
         hybrid: bool,
-        fast: bool,
+        rerank: bool,
         min_score: Option<f32>,
         semantic: bool,
         context: usize,
@@ -64,7 +64,7 @@ impl SearchMode {
             SearchMode::Hybrid {
                 targets: SearchTarget::parse_list(in_targets),
                 meeting_filter: meeting_filter.map(String::from),
-                rerank: !fast,
+                rerank,
                 min_score,
                 yes,
                 limit,
@@ -228,7 +228,7 @@ fn keyword_search(
 }
 
 /// Run keyword and semantic retrieval, fuse the rankings, rerank the top
-/// candidates (unless skipped), and display the resulting meetings.
+/// candidates when requested, and display the resulting meetings.
 #[allow(clippy::too_many_arguments)]
 fn hybrid_search(
     conn: &Connection,
@@ -866,7 +866,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_cli_args_hybrid_takes_priority_and_reranks_by_default() {
+    fn from_cli_args_hybrid_takes_priority_without_rerank_by_default() {
         let mode = SearchMode::from_cli_args(
             true, false, None, true, 5, "titles,notes", Some("standup"), None, true, 10,
         );
@@ -883,7 +883,7 @@ mod tests {
                 assert!(targets.contains(&SearchTarget::Titles));
                 assert!(targets.contains(&SearchTarget::Notes));
                 assert_eq!(meeting_filter.as_deref(), Some("standup"));
-                assert!(rerank);
+                assert!(!rerank);
                 assert_eq!(min_score, None);
                 assert!(yes);
                 assert_eq!(limit, 10);
@@ -893,11 +893,11 @@ mod tests {
     }
 
     #[test]
-    fn from_cli_args_fast_skips_rerank() {
+    fn from_cli_args_rerank_opts_in() {
         let mode =
             SearchMode::from_cli_args(true, true, None, false, 0, "titles", None, None, false, 10);
         match mode {
-            SearchMode::Hybrid { rerank, .. } => assert!(!rerank),
+            SearchMode::Hybrid { rerank, .. } => assert!(rerank),
             _ => panic!("Expected Hybrid variant"),
         }
     }
@@ -905,7 +905,7 @@ mod tests {
     #[test]
     fn from_cli_args_min_score_threads_to_hybrid() {
         let mode = SearchMode::from_cli_args(
-            true, false, Some(0.4), false, 0, "titles", None, None, false, 10,
+            true, true, Some(0.4), false, 0, "titles", None, None, false, 10,
         );
         match mode {
             SearchMode::Hybrid { min_score, .. } => assert_eq!(min_score, Some(0.4)),

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -2,6 +2,7 @@ pub mod chunk;
 pub mod chunker;
 pub mod model;
 pub mod progress;
+pub mod rerank;
 pub mod search;
 pub mod store;
 

--- a/src/embed/model.rs
+++ b/src/embed/model.rs
@@ -25,12 +25,17 @@ pub struct FastEmbedModel {
     dim: usize,
 }
 
-/// Set HF_HOME so fastembed caches models in a consistent location
-/// (the platform data directory, e.g. ~/.local/share/grans/fastembed_cache)
-/// rather than dropping cache directories in the current working directory.
-pub(crate) fn set_hf_cache_dir() -> Result<()> {
+/// The model cache directory (in the platform data directory), created if
+/// missing. Models must cache here rather than in a CWD-relative directory.
+pub(crate) fn hf_cache_dir() -> Result<std::path::PathBuf> {
     let cache_dir = platform::data_dir()?.join("fastembed_cache");
     std::fs::create_dir_all(&cache_dir)?;
+    Ok(cache_dir)
+}
+
+/// Set HF_HOME so fastembed's hf-hub downloads land in [`hf_cache_dir`].
+pub(crate) fn set_hf_cache_dir() -> Result<()> {
+    let cache_dir = hf_cache_dir()?;
 
     // SAFETY: called during model initialization (single-threaded context),
     // before any threads the model wrappers spawn.

--- a/src/embed/model.rs
+++ b/src/embed/model.rs
@@ -25,21 +25,68 @@ pub struct FastEmbedModel {
     dim: usize,
 }
 
+/// Set HF_HOME so fastembed caches models in a consistent location
+/// (the platform data directory, e.g. ~/.local/share/grans/fastembed_cache)
+/// rather than dropping cache directories in the current working directory.
+pub(crate) fn set_hf_cache_dir() -> Result<()> {
+    let cache_dir = platform::data_dir()?.join("fastembed_cache");
+    std::fs::create_dir_all(&cache_dir)?;
+
+    // SAFETY: called during model initialization (single-threaded context),
+    // before any threads the model wrappers spawn.
+    unsafe {
+        env::set_var("HF_HOME", cache_dir);
+    }
+    Ok(())
+}
+
+/// Hardware execution providers enabled by cargo features. CPU is always
+/// the implicit fallback in ort.
+pub(crate) fn execution_providers() -> Vec<ort::execution_providers::ExecutionProviderDispatch> {
+    #[allow(unused_mut)]
+    let mut providers = Vec::new();
+
+    #[cfg(feature = "cuda")]
+    {
+        use ort::execution_providers::CUDAExecutionProvider;
+        providers.push(
+            ort::execution_providers::ExecutionProviderDispatch::from(
+                CUDAExecutionProvider::default(),
+            )
+            .error_on_failure(),
+        );
+    }
+
+    #[cfg(feature = "directml")]
+    {
+        use ort::execution_providers::DirectMLExecutionProvider;
+        providers.push(
+            ort::execution_providers::ExecutionProviderDispatch::from(
+                DirectMLExecutionProvider::default(),
+            )
+            .error_on_failure(),
+        );
+    }
+
+    #[cfg(feature = "coreml")]
+    {
+        use ort::execution_providers::CoreMLExecutionProvider;
+        providers.push(
+            ort::execution_providers::ExecutionProviderDispatch::from(
+                CoreMLExecutionProvider::default(),
+            )
+            .error_on_failure(),
+        );
+    }
+
+    providers
+}
+
 impl FastEmbedModel {
     pub fn new() -> Result<Self> {
-        // Set HF_HOME to ensure fastembed caches models in a consistent location
-        // rather than dropping cache directories in the current working directory.
-        // This uses the platform-specific data directory (e.g., ~/.local/share/grans/fastembed_cache)
-        let cache_dir = platform::data_dir()?.join("fastembed_cache");
-        std::fs::create_dir_all(&cache_dir)?;
+        set_hf_cache_dir()?;
 
-        // SAFETY: We're setting HF_HOME before any other threads are spawned from FastEmbedModel,
-        // and this is only called during model initialization (single-threaded context).
-        unsafe {
-            env::set_var("HF_HOME", cache_dir);
-        }
-
-        let providers = Self::execution_providers();
+        let providers = execution_providers();
 
         let mut opts =
             fastembed::TextInitOptions::new(fastembed::EmbeddingModel::NomicEmbedTextV15)
@@ -56,47 +103,6 @@ impl FastEmbedModel {
             model: RefCell::new(model),
             dim: 768,
         })
-    }
-
-    fn execution_providers() -> Vec<ort::execution_providers::ExecutionProviderDispatch> {
-        #[allow(unused_mut)]
-        let mut providers = Vec::new();
-
-        #[cfg(feature = "cuda")]
-        {
-            use ort::execution_providers::CUDAExecutionProvider;
-            providers.push(
-                ort::execution_providers::ExecutionProviderDispatch::from(
-                    CUDAExecutionProvider::default(),
-                )
-                .error_on_failure(),
-            );
-        }
-
-        #[cfg(feature = "directml")]
-        {
-            use ort::execution_providers::DirectMLExecutionProvider;
-            providers.push(
-                ort::execution_providers::ExecutionProviderDispatch::from(
-                    DirectMLExecutionProvider::default(),
-                )
-                .error_on_failure(),
-            );
-        }
-
-        #[cfg(feature = "coreml")]
-        {
-            use ort::execution_providers::CoreMLExecutionProvider;
-            providers.push(
-                ort::execution_providers::ExecutionProviderDispatch::from(
-                    CoreMLExecutionProvider::default(),
-                )
-                .error_on_failure(),
-            );
-        }
-
-        // CPU is always the implicit fallback in ort
-        providers
     }
 }
 

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -49,20 +49,25 @@ pub struct FastEmbedReranker {
     model: RefCell<fastembed::TextRerank>,
 }
 
+/// Init options for a reranker model: data-dir cache, download progress,
+/// hardware execution providers. `TextRerank` resolves its cache from these
+/// options alone (it ignores HF_HOME, unlike `TextEmbedding`), so the cache
+/// directory must be explicit.
+fn init_options(choice: RerankModel) -> Result<fastembed::RerankInitOptions> {
+    let mut opts = fastembed::RerankInitOptions::new(choice.fastembed_model())
+        .with_cache_dir(super::model::hf_cache_dir()?)
+        .with_show_download_progress(true);
+
+    let providers = super::model::execution_providers();
+    if !providers.is_empty() {
+        opts = opts.with_execution_providers(providers);
+    }
+    Ok(opts)
+}
+
 impl FastEmbedReranker {
     pub fn new(choice: RerankModel) -> Result<Self> {
-        super::model::set_hf_cache_dir()?;
-
-        let providers = super::model::execution_providers();
-
-        let mut opts = fastembed::RerankInitOptions::new(choice.fastembed_model())
-            .with_show_download_progress(true);
-        if !providers.is_empty() {
-            opts = opts.with_execution_providers(providers);
-        }
-
-        let model = fastembed::TextRerank::try_new(opts)?;
-
+        let model = fastembed::TextRerank::try_new(init_options(choice)?)?;
         Ok(Self { model: RefCell::new(model) })
     }
 }
@@ -116,6 +121,17 @@ mod tests {
         // f32 rounding saturates extreme logits to the interval bounds.
         assert!(sigmoid(-20.0) >= 0.0);
         assert!(sigmoid(20.0) <= 1.0);
+    }
+
+    #[test]
+    fn init_options_cache_models_in_the_data_dir() {
+        // TextRerank resolves its cache from the init options alone (it
+        // ignores HF_HOME, unlike TextEmbedding), so the data-dir cache
+        // must be set explicitly or models land in a CWD-relative
+        // .fastembed_cache.
+        let opts = init_options(RerankModel::JinaTurbo).unwrap();
+        let expected = crate::platform::data_dir().unwrap().join("fastembed_cache");
+        assert_eq!(opts.cache_dir, expected);
     }
 
     #[test]

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -15,7 +15,6 @@ pub trait Reranker {
     /// order; higher is more relevant. Production models return sigmoid
     /// probabilities in [0, 1].
     fn rerank(&self, query: &str, documents: &[&str]) -> Result<Vec<f32>>;
-    fn model_name(&self) -> &str;
 }
 
 /// Reranker model selection. Both candidates from the Phase 3 evaluation
@@ -32,13 +31,6 @@ pub enum RerankModel {
 pub const DEFAULT_RERANK_MODEL: RerankModel = RerankModel::JinaTurbo;
 
 impl RerankModel {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            RerankModel::JinaTurbo => "jina-reranker-v1-turbo-en",
-            RerankModel::BgeBase => "bge-reranker-base",
-        }
-    }
-
     fn fastembed_model(&self) -> fastembed::RerankerModel {
         match self {
             RerankModel::JinaTurbo => fastembed::RerankerModel::JINARerankerV1TurboEn,
@@ -55,7 +47,6 @@ fn sigmoid(logit: f32) -> f32 {
 /// Production reranker using fastembed's `TextRerank`.
 pub struct FastEmbedReranker {
     model: RefCell<fastembed::TextRerank>,
-    choice: RerankModel,
 }
 
 impl FastEmbedReranker {
@@ -72,10 +63,7 @@ impl FastEmbedReranker {
 
         let model = fastembed::TextRerank::try_new(opts)?;
 
-        Ok(Self {
-            model: RefCell::new(model),
-            choice,
-        })
+        Ok(Self { model: RefCell::new(model) })
     }
 }
 
@@ -93,10 +81,6 @@ impl Reranker for FastEmbedReranker {
         }
         Ok(scores)
     }
-
-    fn model_name(&self) -> &str {
-        self.choice.as_str()
-    }
 }
 
 /// Mock reranker for testing: a document's score is the number of times the
@@ -113,10 +97,6 @@ impl Reranker for MockReranker {
             .iter()
             .map(|d| d.to_lowercase().matches(&needle).count() as f32)
             .collect())
-    }
-
-    fn model_name(&self) -> &str {
-        "mock-reranker"
     }
 }
 
@@ -157,12 +137,5 @@ mod tests {
         let reranker: &dyn Reranker = &MockReranker;
         let scores = reranker.rerank("q", &["q"]).unwrap();
         assert_eq!(scores.len(), 1);
-        assert_eq!(reranker.model_name(), "mock-reranker");
-    }
-
-    #[test]
-    fn rerank_model_names() {
-        assert_eq!(RerankModel::JinaTurbo.as_str(), "jina-reranker-v1-turbo-en");
-        assert_eq!(RerankModel::BgeBase.as_str(), "bge-reranker-base");
     }
 }

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -1,0 +1,168 @@
+//! Cross-encoder reranking models.
+//!
+//! A reranker scores (query, passage) pairs jointly with a cross-encoder,
+//! slower but more accurate than the bi-encoder cosine ranking in
+//! [`crate::embed::model`]. The hybrid search pipeline uses it to reorder
+//! the top fused candidates (see [`crate::query::rerank`]).
+
+use std::cell::RefCell;
+
+use anyhow::Result;
+
+/// Trait for rerankers scoring (query, document) pairs.
+pub trait Reranker {
+    /// Score every document against the query. Scores come back in input
+    /// order; higher is more relevant. Production models return sigmoid
+    /// probabilities in [0, 1].
+    fn rerank(&self, query: &str, documents: &[&str]) -> Result<Vec<f32>>;
+    fn model_name(&self) -> &str;
+}
+
+/// Reranker model selection. Both candidates from the Phase 3 evaluation
+/// stay available so the comparison is re-runnable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RerankModel {
+    /// jinaai/jina-reranker-v1-turbo-en: 6-layer English reranker.
+    JinaTurbo,
+    /// BAAI/bge-reranker-base: 12-layer English/Chinese reranker.
+    BgeBase,
+}
+
+/// Model used by `grans search --hybrid` (winner of the Phase 3 benchmark).
+pub const DEFAULT_RERANK_MODEL: RerankModel = RerankModel::JinaTurbo;
+
+impl RerankModel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RerankModel::JinaTurbo => "jina-reranker-v1-turbo-en",
+            RerankModel::BgeBase => "bge-reranker-base",
+        }
+    }
+
+    fn fastembed_model(&self) -> fastembed::RerankerModel {
+        match self {
+            RerankModel::JinaTurbo => fastembed::RerankerModel::JINARerankerV1TurboEn,
+            RerankModel::BgeBase => fastembed::RerankerModel::BGERerankerBase,
+        }
+    }
+}
+
+/// Map a cross-encoder logit to a relevance probability in [0, 1].
+fn sigmoid(logit: f32) -> f32 {
+    1.0 / (1.0 + (-logit).exp())
+}
+
+/// Production reranker using fastembed's `TextRerank`.
+pub struct FastEmbedReranker {
+    model: RefCell<fastembed::TextRerank>,
+    choice: RerankModel,
+}
+
+impl FastEmbedReranker {
+    pub fn new(choice: RerankModel) -> Result<Self> {
+        super::model::set_hf_cache_dir()?;
+
+        let providers = super::model::execution_providers();
+
+        let mut opts = fastembed::RerankInitOptions::new(choice.fastembed_model())
+            .with_show_download_progress(true);
+        if !providers.is_empty() {
+            opts = opts.with_execution_providers(providers);
+        }
+
+        let model = fastembed::TextRerank::try_new(opts)?;
+
+        Ok(Self {
+            model: RefCell::new(model),
+            choice,
+        })
+    }
+}
+
+impl Reranker for FastEmbedReranker {
+    fn rerank(&self, query: &str, documents: &[&str]) -> Result<Vec<f32>> {
+        if documents.is_empty() {
+            return Ok(Vec::new());
+        }
+        // fastembed returns results sorted by score; `index` maps each back
+        // to its input position.
+        let results = self.model.borrow_mut().rerank(query, documents, false, None)?;
+        let mut scores = vec![0.0_f32; documents.len()];
+        for r in results {
+            scores[r.index] = sigmoid(r.score);
+        }
+        Ok(scores)
+    }
+
+    fn model_name(&self) -> &str {
+        self.choice.as_str()
+    }
+}
+
+/// Mock reranker for testing: a document's score is the number of times the
+/// query appears in it (case-insensitive), so tests control ordering by
+/// repeating the query in passages.
+#[cfg(test)]
+pub struct MockReranker;
+
+#[cfg(test)]
+impl Reranker for MockReranker {
+    fn rerank(&self, query: &str, documents: &[&str]) -> Result<Vec<f32>> {
+        let needle = query.to_lowercase();
+        Ok(documents
+            .iter()
+            .map(|d| d.to_lowercase().matches(&needle).count() as f32)
+            .collect())
+    }
+
+    fn model_name(&self) -> &str {
+        "mock-reranker"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sigmoid_maps_zero_logit_to_half() {
+        assert!((sigmoid(0.0) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn sigmoid_is_monotonic_and_bounded() {
+        assert!(sigmoid(-4.0) < sigmoid(0.0));
+        assert!(sigmoid(0.0) < sigmoid(4.0));
+        // f32 rounding saturates extreme logits to the interval bounds.
+        assert!(sigmoid(-20.0) >= 0.0);
+        assert!(sigmoid(20.0) <= 1.0);
+    }
+
+    #[test]
+    fn mock_reranker_scores_in_input_order() {
+        let scores = MockReranker
+            .rerank("budget", &["no match", "budget", "budget budget"])
+            .unwrap();
+        assert_eq!(scores, vec![0.0, 1.0, 2.0]);
+    }
+
+    #[test]
+    fn mock_reranker_is_case_insensitive() {
+        let scores = MockReranker.rerank("Budget", &["the BUDGET meeting"]).unwrap();
+        assert_eq!(scores, vec![1.0]);
+    }
+
+    #[test]
+    fn reranker_usable_as_trait_object() {
+        let reranker: &dyn Reranker = &MockReranker;
+        let scores = reranker.rerank("q", &["q"]).unwrap();
+        assert_eq!(scores.len(), 1);
+        assert_eq!(reranker.model_name(), "mock-reranker");
+    }
+
+    #[test]
+    fn rerank_model_names() {
+        assert_eq!(RerankModel::JinaTurbo.as_str(), "jina-reranker-v1-turbo-en");
+        assert_eq!(RerankModel::BgeBase.as_str(), "bge-reranker-base");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,8 @@ fn main() -> Result<()> {
             r#in,
             semantic,
             hybrid,
+            fast,
+            min_score,
             context,
             meeting,
             from,
@@ -99,6 +101,8 @@ fn main() -> Result<()> {
         } => {
             let mode = SearchMode::from_cli_args(
                 *hybrid,
+                *fast,
+                *min_score,
                 *semantic,
                 *context,
                 r#in,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn main() -> Result<()> {
             r#in,
             semantic,
             hybrid,
-            fast,
+            rerank,
             min_score,
             context,
             meeting,
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
         } => {
             let mode = SearchMode::from_cli_args(
                 *hybrid,
-                *fast,
+                *rerank,
                 *min_score,
                 *semantic,
                 *context,

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -22,6 +22,23 @@ pub fn format_meeting_detail(doc: &Document) -> String {
     to_json(doc)
 }
 
+/// A document with its reranker relevance score.
+#[derive(Debug, Serialize)]
+struct ScoredMeetingJson<'a> {
+    score: f32,
+    #[serde(flatten)]
+    document: &'a Document,
+}
+
+/// Format reranked hybrid results as JSON: each document plus its score.
+pub fn format_scored_meetings(results: &[(Document, f32)]) -> String {
+    let items: Vec<ScoredMeetingJson> = results
+        .iter()
+        .map(|(doc, score)| ScoredMeetingJson { score: *score, document: doc })
+        .collect();
+    to_json(&items)
+}
+
 /// JSON-serializable context window.
 #[derive(Debug, Serialize)]
 pub struct ContextWindowJson {

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -36,6 +36,24 @@ pub fn format_meeting_row(doc: &Document, tz: &FixedOffset) -> String {
     format!("{} {} {}", id, date, title)
 }
 
+/// Color a relevance score by band: strong green, medium yellow, weak dimmed.
+fn colored_score(score: f32) -> String {
+    let score_str = format!("{:.2}", score);
+    if score > 0.8 {
+        score_str.green().bold().to_string()
+    } else if score > 0.6 {
+        score_str.yellow().to_string()
+    } else {
+        score_str.dimmed().to_string()
+    }
+}
+
+/// Format a meeting row prefixed with its relevance score (reranked hybrid
+/// search results).
+pub fn format_scored_meeting_row(doc: &Document, score: f32, tz: &FixedOffset) -> String {
+    format!("{} {}", colored_score(score), format_meeting_row(doc, tz))
+}
+
 /// Format a meeting detail view for TTY.
 pub fn format_meeting_detail(doc: &Document, tz: &FixedOffset) -> String {
     let mut lines = Vec::new();
@@ -299,14 +317,7 @@ pub fn format_search_separator(index: usize, total: usize, title: &str, score: O
 
 /// Format a semantic search result for TTY display.
 pub fn format_semantic_result(result: &SemanticSearchResult, conn: &Connection, tz: &FixedOffset) -> String {
-    let score_str = format!("{:.2}", result.score);
-    let score_colored = if result.score > 0.8 {
-        score_str.green().bold().to_string()
-    } else if result.score > 0.6 {
-        score_str.yellow().to_string()
-    } else {
-        score_str.dimmed().to_string()
-    };
+    let score_colored = colored_score(result.score);
 
     let (title, date) = lookup_document_meta(conn, &result.document_id, tz);
     let title_str = title.bold().to_string();

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -5,6 +5,8 @@
 //! [`crate::query::fusion`]). Used by `grans search --hybrid` and the
 //! quality benchmark's hybrid mode.
 
+use std::collections::HashMap;
+
 use anyhow::Result;
 use rusqlite::Connection;
 
@@ -17,8 +19,17 @@ use crate::query::fusion::{reciprocal_rank_fusion, FusedDoc, RRF_K};
 /// How many top documents each retriever contributes to fusion.
 pub const CANDIDATE_POOL: usize = 100;
 
+/// Hybrid retrieval output: the fused ranking plus each document's
+/// best-matching chunk text from the semantic pass. The rerank stage uses
+/// the chunk texts as passages; documents without embedded content (e.g.
+/// title-only FTS matches) have no entry.
+pub struct HybridRanking {
+    pub fused: Vec<FusedDoc>,
+    pub best_chunks: HashMap<String, String>,
+}
+
 /// Run FTS and semantic retrieval for `query` and fuse the rankings.
-/// Returns fused documents, best first.
+/// Fused documents come back best first.
 pub fn hybrid_ranked(
     conn: &Connection,
     embedder: &dyn Embedder,
@@ -27,7 +38,7 @@ pub fn hybrid_ranked(
     targets: &[SearchTarget],
     date_range: Option<&DateRange>,
     include_deleted: bool,
-) -> Result<Vec<FusedDoc>> {
+) -> Result<HybridRanking> {
     let fts_docs = crate::db::meetings::search_meetings(
         conn,
         query,
@@ -40,6 +51,9 @@ pub fn hybrid_ranked(
     )?;
     let fts_ids: Vec<String> = fts_docs.into_iter().filter_map(|d| d.id).collect();
 
+    // No limit: the per-document best chunks must cover every candidate,
+    // including FTS-only documents outside the semantic top of the pool.
+    // Fusion still truncates each id list to the pool.
     let source_filter = semantic_source_filter(targets);
     let (semantic_results, _) = crate::embed::semantic_search_with_index(
         conn,
@@ -47,13 +61,22 @@ pub fn hybrid_ranked(
         index,
         query,
         date_range,
-        CANDIDATE_POOL,
+        0,
         source_filter.as_deref(),
         include_deleted,
     )?;
-    let semantic_ids: Vec<String> = semantic_results.into_iter().map(|r| r.document_id).collect();
 
-    Ok(fuse_candidates(fts_ids, semantic_ids))
+    let mut semantic_ids = Vec::with_capacity(semantic_results.len());
+    let mut best_chunks = HashMap::with_capacity(semantic_results.len());
+    for r in semantic_results {
+        semantic_ids.push(r.document_id.clone());
+        best_chunks.insert(r.document_id, r.matched_text);
+    }
+
+    Ok(HybridRanking {
+        fused: fuse_candidates(fts_ids, semantic_ids),
+        best_chunks,
+    })
 }
 
 /// Truncate each ranked id list to the candidate pool and fuse with RRF.
@@ -96,12 +119,12 @@ mod tests {
         }
     }
 
-    fn stored(doc_id: &str, vector: Vec<f32>) -> StoredVector {
+    fn stored(doc_id: &str, text: &str, vector: Vec<f32>) -> StoredVector {
         StoredVector {
             chunk_id: 0,
             document_id: doc_id.to_string(),
             source_type: "transcript_window".to_string(),
-            text: String::new(),
+            text: text.to_string(),
             vector,
             metadata_json: None,
         }
@@ -124,8 +147,8 @@ mod tests {
         EmbeddingIndex {
             vectors: vec![
                 // cosine vs [1, 0]: doc-both = 1.0, doc-sem ~= 0.707
-                stored("doc-both", vec![1.0, 0.0]),
-                stored("doc-sem", vec![1.0, 1.0]),
+                stored("doc-both", "both chunk", vec![1.0, 0.0]),
+                stored("doc-sem", "sem chunk", vec![1.0, 1.0]),
             ],
             stats: None,
         }
@@ -142,7 +165,8 @@ mod tests {
 
         let fused =
             hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, false)
-                .unwrap();
+                .unwrap()
+                .fused;
 
         // FTS title tier orders by recency: [doc-fts, doc-both].
         // Semantic orders by cosine: [doc-both, doc-sem].
@@ -166,7 +190,8 @@ mod tests {
 
         let fused =
             hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &targets, None, false)
-                .unwrap();
+                .unwrap()
+                .fused;
 
         // Semantic search is filtered to no embeddable source types, so
         // only the FTS title matches remain, in FTS order.
@@ -175,15 +200,39 @@ mod tests {
     }
 
     #[test]
+    fn ranking_exposes_best_chunk_text_per_document() {
+        let conn = build_test_db(&hybrid_state());
+        // doc-sem has two chunks; the higher-cosine one must win.
+        let index = EmbeddingIndex {
+            vectors: vec![
+                stored("doc-both", "both chunk", vec![1.0, 0.0]),
+                stored("doc-sem", "weak chunk", vec![0.0, 1.0]),
+                stored("doc-sem", "strong chunk", vec![1.0, 0.5]),
+            ],
+            stats: None,
+        };
+
+        let ranking =
+            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, false)
+                .unwrap();
+
+        assert_eq!(ranking.best_chunks.get("doc-both").map(String::as_str), Some("both chunk"));
+        assert_eq!(ranking.best_chunks.get("doc-sem").map(String::as_str), Some("strong chunk"));
+        // doc-fts has no chunks, so it has no passage entry.
+        assert!(!ranking.best_chunks.contains_key("doc-fts"));
+    }
+
+    #[test]
     fn no_matches_fuse_to_empty() {
         let conn = build_test_db(&hybrid_state());
         let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
 
-        let fused =
+        let ranking =
             hybrid_ranked(&conn, &FixedEmbedder, &index, "zyzzyva", &all_targets(), None, false)
                 .unwrap();
 
-        assert!(fused.is_empty());
+        assert!(ranking.fused.is_empty());
+        assert!(ranking.best_chunks.is_empty());
     }
 
     #[test]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -3,5 +3,6 @@ pub mod filter;
 pub mod fts;
 pub mod fusion;
 pub mod hybrid;
+pub mod rerank;
 pub mod search;
 pub mod text;

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -1,0 +1,196 @@
+//! Cross-encoder rerank stage for hybrid search.
+//!
+//! Takes the top fused candidates from [`crate::query::hybrid`], builds a
+//! (title + best chunk) passage per document, and reorders them by
+//! cross-encoder relevance. The reranker score is the user-facing score
+//! for hybrid results.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::embed::rerank::Reranker;
+use crate::query::hybrid::HybridRanking;
+
+/// How many top fused candidates the reranker scores. Documents fused
+/// below this cutoff are dropped from reranked results.
+pub const RERANK_POOL: usize = 50;
+
+/// A reranked document with its relevance score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RerankedDoc {
+    pub document_id: String,
+    pub score: f32,
+}
+
+/// Build the passage the reranker judges for one document: the title and
+/// the best-matching chunk, whichever exist.
+fn build_passage(title: Option<&str>, best_chunk: Option<&str>) -> String {
+    match (title, best_chunk) {
+        (Some(t), Some(c)) => format!("{t}\n\n{c}"),
+        (Some(t), None) => t.to_string(),
+        (None, Some(c)) => c.to_string(),
+        (None, None) => String::new(),
+    }
+}
+
+/// Score `(document_id, passage)` candidates against the query and sort
+/// best-first. Ties keep the candidates' input (fused) order.
+pub fn rerank_candidates(
+    reranker: &dyn Reranker,
+    query: &str,
+    candidates: &[(String, String)],
+) -> Result<Vec<RerankedDoc>> {
+    let passages: Vec<&str> = candidates.iter().map(|(_, p)| p.as_str()).collect();
+    let scores = reranker.rerank(query, &passages)?;
+
+    let mut reranked: Vec<RerankedDoc> = candidates
+        .iter()
+        .zip(scores)
+        .map(|((id, _), score)| RerankedDoc { document_id: id.clone(), score })
+        .collect();
+    // Stable sort: equal scores keep the fused order.
+    reranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    Ok(reranked)
+}
+
+/// Rerank the top [`RERANK_POOL`] fused candidates of a hybrid ranking:
+/// fetch titles, build passages, score with the cross-encoder.
+pub fn rerank_hybrid(
+    conn: &Connection,
+    reranker: &dyn Reranker,
+    query: &str,
+    ranking: &HybridRanking,
+) -> Result<Vec<RerankedDoc>> {
+    let pool_ids: Vec<String> = ranking
+        .fused
+        .iter()
+        .take(RERANK_POOL)
+        .map(|d| d.document_id.clone())
+        .collect();
+    let docs = crate::db::meetings::get_meetings_by_ids(conn, &pool_ids)?;
+
+    let candidates: Vec<(String, String)> = docs
+        .into_iter()
+        .filter_map(|doc| doc.id.map(|id| (id, doc.title)))
+        .map(|(id, title)| {
+            let passage =
+                build_passage(title.as_deref(), ranking.best_chunks.get(&id).map(String::as_str));
+            (id, passage)
+        })
+        .collect();
+
+    rerank_candidates(reranker, query, &candidates)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_fixtures::build_test_db;
+    use crate::embed::rerank::MockReranker;
+    use crate::query::fusion::FusedDoc;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn passage_combines_title_and_chunk() {
+        assert_eq!(build_passage(Some("Title"), Some("chunk text")), "Title\n\nchunk text");
+        assert_eq!(build_passage(Some("Title"), None), "Title");
+        assert_eq!(build_passage(None, Some("chunk text")), "chunk text");
+        assert_eq!(build_passage(None, None), "");
+    }
+
+    #[test]
+    fn candidates_sort_by_score_descending() {
+        // MockReranker scores by query occurrences: 0, 2, 1.
+        let candidates = vec![
+            ("doc-a".to_string(), "nothing here".to_string()),
+            ("doc-b".to_string(), "kumquat kumquat".to_string()),
+            ("doc-c".to_string(), "kumquat".to_string()),
+        ];
+
+        let reranked = rerank_candidates(&MockReranker, "kumquat", &candidates).unwrap();
+
+        let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
+        assert_eq!(ids, vec!["doc-b", "doc-c", "doc-a"]);
+        assert_eq!(reranked[0].score, 2.0);
+        assert_eq!(reranked[2].score, 0.0);
+    }
+
+    #[test]
+    fn tied_candidates_keep_input_order() {
+        let candidates = vec![
+            ("doc-first".to_string(), "kumquat".to_string()),
+            ("doc-second".to_string(), "kumquat".to_string()),
+        ];
+
+        let reranked = rerank_candidates(&MockReranker, "kumquat", &candidates).unwrap();
+
+        let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
+        assert_eq!(ids, vec!["doc-first", "doc-second"]);
+    }
+
+    #[test]
+    fn empty_candidates_rerank_to_empty() {
+        let reranked = rerank_candidates(&MockReranker, "kumquat", &[]).unwrap();
+        assert!(reranked.is_empty());
+    }
+
+    fn fused(ids: &[&str]) -> Vec<FusedDoc> {
+        ids.iter()
+            .map(|id| FusedDoc { document_id: id.to_string(), score: 0.0 })
+            .collect()
+    }
+
+    #[test]
+    fn hybrid_rerank_scores_titles_and_chunks() {
+        // doc-chunk matches the query twice via its chunk; doc-title once
+        // via its title; doc-none not at all. Fused order is the reverse
+        // of relevance so reordering is observable.
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-none": {"id": "doc-none", "title": "Unrelated", "created_at": "2026-01-01T10:00:00Z"},
+                "doc-title": {"id": "doc-title", "title": "Kumquat sync", "created_at": "2026-01-02T10:00:00Z"},
+                "doc-chunk": {"id": "doc-chunk", "title": "Planning", "created_at": "2026-01-03T10:00:00Z"}
+            }
+        }));
+        let ranking = HybridRanking {
+            fused: fused(&["doc-none", "doc-title", "doc-chunk"]),
+            best_chunks: HashMap::from([(
+                "doc-chunk".to_string(),
+                "kumquat kumquat".to_string(),
+            )]),
+        };
+
+        let reranked = rerank_hybrid(&conn, &MockReranker, "kumquat", &ranking).unwrap();
+
+        let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
+        assert_eq!(ids, vec!["doc-chunk", "doc-title", "doc-none"]);
+    }
+
+    #[test]
+    fn hybrid_rerank_considers_only_the_pool() {
+        // 60 fused documents; the strongest match sits below the pool
+        // cutoff, so it must not appear in the reranked output.
+        let mut docs = serde_json::Map::new();
+        for i in 0..60 {
+            let id = format!("doc-{i:02}");
+            docs.insert(
+                id.clone(),
+                json!({"id": id, "title": format!("Meeting {i}"), "created_at": "2026-01-01T10:00:00Z"}),
+            );
+        }
+        let conn = build_test_db(&json!({ "documents": docs }));
+
+        let ids: Vec<String> = (0..60).map(|i| format!("doc-{i:02}")).collect();
+        let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+        let ranking = HybridRanking {
+            fused: fused(&id_refs),
+            best_chunks: HashMap::from([("doc-59".to_string(), "kumquat".to_string())]),
+        };
+
+        let reranked = rerank_hybrid(&conn, &MockReranker, "kumquat", &ranking).unwrap();
+
+        assert_eq!(reranked.len(), RERANK_POOL);
+        assert!(reranked.iter().all(|d| d.document_id != "doc-59"));
+    }
+}


### PR DESCRIPTION
Closes #41.

Adds cross-encoder reranking to the hybrid pipeline: the top 50 fused candidates are scored as (title + best semantic chunk) passages by a fastembed `TextRerank` model and reordered by relevance. Both issue candidates were benchmarked in one `--compare` run; jina-reranker-v1-turbo-en won on every metric and backs the feature. Per the gate, reranking ships opt-in as `--hybrid --rerank` rather than becoming part of plain `--hybrid` (details below), so the issue's `--fast` flag has no role and does not exist: fusion-only is already the default.

## What changed

- `embed/rerank.rs` (new): `Reranker` trait mirroring `Embedder`, with `FastEmbedReranker` wrapping fastembed's `TextRerank`. Logits map through sigmoid so scores are relevance probabilities in [0, 1], returned in input order. Both benchmark candidates stay selectable; `DEFAULT_RERANK_MODEL` is jina.
- `query/hybrid.rs`: `hybrid_ranked` now returns the fused list plus each document's best-matching chunk text from the semantic pass (the semantic side runs unlimited so FTS-only candidates outside the semantic top-100 still get passages; fusion still truncates to the pool).
- `query/rerank.rs` (new): the rerank stage. Passage = title + best chunk; ties keep fused order; documents fused below the 50-candidate pool drop out.
- CLI: `--rerank` (requires `--hybrid`) opts in. The reranker probability is the user-facing score: TTY rows show it color-banded like semantic scores, JSON carries a `score` field, and `--min-score` (0-1, requires `--rerank`) filters on it, a more threshold-stable scale than cosine.
- Benchmark: `--mode rerank-jina|rerank-bge` and `--compare` support, running the exact production fusion-then-rerank path.
- Fix found along the way: `TextRerank` resolves its cache from init options alone and ignores `HF_HOME` (unlike `TextEmbedding`), so reranker weights were landing in a CWD-relative `.fastembed_cache`. The cache dir is now passed explicitly, with a regression test on the options builder.

## Benchmarks

Frozen snapshot (872 docs), 93-query golden set, k=10, ID matching, all modes measured in one `--compare` run (binary f1feb59):

| Mode | hit-rate@10 | recall@10 | MRR@10 | avg latency |
|---|---|---|---|---|
| hybrid (RRF, Phase 2) | 0.860 | 0.759 | 0.722 | ~63 ms |
| **rerank-jina (this PR)** | **0.903** | 0.749 | **0.769** | ~2.0 s |
| rerank-bge | 0.892 | 0.696 | 0.700 | ~7.2 s |

Model pick: jina beats bge on every aggregate and stratum at under a third of the latency.

Per stratum (hit / MRR), rerank-jina vs hybrid:

| Stratum | n | hybrid | rerank-jina |
|---|---|---|---|
| exact-term | 17 | 1.00 / 1.000 | 1.00 / 0.941 |
| mixed | 38 | 0.82 / 0.694 | **0.87 / 0.759** |
| paraphrase | 38 | 0.84 / 0.626 | **0.89 / 0.702** |

The reranker delivers exactly where fusion is blind (mixed and paraphrase queries, where FTS contributes nothing), at the cost of two one-position slips on exact-term. Per query at k=10 vs the better of (hybrid, semantic): 23W / 15L / 55T, match-or-beat on 78 of 93.

## Gate: reranking stays opt-in

The issue's gate says quality gain must justify the latency cost, and marginal lift keeps reranking opt-in. The lift here is real, but two things keep it out of plain `--hybrid`:

- Three queries whose relevant meeting ranked top-3 under fusion fall out of the top 10 (to raw ranks 13-15). The methodology treats one catastrophic regression as outweighing several mild wins.
- Per-query latency rises 63 ms to ~2 s, and a one-shot CLI additionally pays the reranker model load on every invocation.

Revisiting is cheap once the dropouts are addressed (e.g. blending the fusion prior into the reranked order, Phase 5 territory).

Recorded runs appended to the benchmarks ledger (`2026-07-10`, modes `hybrid`, `rerank-jina`, `rerank-bge`, binary `f1feb59`) with per-query output under `runs/`.
