### PR TITLE
#50: Blend the fusion prior into reranked order and make reranking the --hybrid default

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ grans search "budget" --semantic --in panels          # Only AI notes
 grans search "budget" --semantic --in transcripts     # Only transcripts
 grans search "budget" --semantic --in notes,panels    # Notes + AI notes
 
-# Hybrid search: run keyword and semantic together, fuse the rankings
+# Hybrid search: keyword + semantic fused, then reranked by a cross-encoder
 grans search "quarterly budget review" --hybrid
+grans search "quarterly budget review" --hybrid --min-score 0.5
 
-# Rerank the top hybrid candidates with a cross-encoder (slower, higher quality)
-grans search "quarterly budget review" --hybrid --rerank
-grans search "quarterly budget review" --hybrid --rerank --min-score 0.5
+# Skip the rerank stage for a faster fusion-only search
+grans search "quarterly budget review" --hybrid --fast
 
 # Limit results (default 10, use 0 for no limit)
 # Works with keyword, context window, and semantic search
@@ -190,9 +190,9 @@ grans search "old project" --semantic --include-deleted
 
 Keyword search matches every word in the query, in any order: `grans search "budget review"` finds meetings that mention both words. To require an exact phrase, quote it inside the query (e.g. `grans search '"budget review"'`). Results are ranked by relevance: meetings whose title contains the query come first, then content matches ranked by BM25, with newer meetings breaking ties.
 
-Hybrid search (`--hybrid`) runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either mode surfaces, and one ranked well by both rises to the top. It needs embeddings (like `--semantic`, it will prompt if many chunks are unembedded; `--yes` skips the prompt) and supports `--in`, `--meeting`, date filters, and `--limit`. It cannot be combined with `--semantic` or `--context`.
+Hybrid search (`--hybrid`) runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either mode surfaces, and one ranked well by both rises to the top. The top 50 fused candidates are then scored by a cross-encoder reranker (`jina-reranker-v1-turbo-en`, downloaded automatically on first use, ~150MB) for how well each meeting actually answers the query, and the final order blends that judgment with the fusion ranking. Results show the reranker's relevance score between 0 and 1, and `--min-score` drops results below a threshold. Hybrid search needs embeddings (like `--semantic`, it will prompt if many chunks are unembedded; `--yes` skips the prompt) and supports `--in`, `--meeting`, date filters, and `--limit`. It cannot be combined with `--semantic` or `--context`.
 
-Adding `--rerank` scores the top 50 fused candidates with a cross-encoder reranker (`jina-reranker-v1-turbo-en`, downloaded automatically on first use, ~150MB) and reorders them by how well each meeting actually answers the query. Reranked results show a relevance score between 0 and 1, and `--min-score` drops results below a threshold. Reranking adds a couple of seconds per query on CPU, which is why it is opt-in.
+The rerank stage adds a couple of seconds per query on CPU. `--fast` skips it and returns fusion-order results (no relevance scores) in tens of milliseconds.
 
 Semantic search uses a local embedding model (`nomic-embed-text-v1.5`) to find meetings by meaning rather than exact keywords. On first use, the model is downloaded automatically (~270MB). Embeddings are built from transcripts, AI-generated panel sections, and your notes, and are stored in the main database. Use `--in` to restrict which sources are searched (e.g. `--in panels` to only search AI notes).
 

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -7,9 +7,9 @@ A staged plan to evolve `grans search` from two separate modes (FTS5 keyword, se
 - **Keyword search** (Phase 1, #39): FTS5 `MATCH` with implicit-AND semantics (each term quoted individually; user-supplied quotes force phrase matching), ranked by `bm25()` with recency as tiebreak. Title substring matches rank as a tier above content matches; weighting them properly is Phase 5. Applies to the combined search and the standalone transcript/notes/panel searches.
 - **Semantic search** (`--semantic`): nomic-embed-text-v1.5 (768d) via fastembed, brute-force cosine over in-memory vectors, `min_score` cutoff. Chunkers for transcripts (adaptive window), panels (section), notes (paragraph).
 - **Hybrid search** (Phase 2, #40, opt-in `--hybrid`): runs both retrievers, truncates each ranked list to a 100-document candidate pool, and fuses by reciprocal rank fusion (k=60) in `query/fusion.rs` + `query/hybrid.rs`. Output is the fused meeting list; keyword and semantic remain the forcing modes.
-- **Reranking** (Phase 3, #41, opt-in `--hybrid --rerank`): a cross-encoder (fastembed `TextRerank`, jina-reranker-v1-turbo-en) scores the top 50 fused candidates as title + best-chunk passages and reorders them (`embed/rerank.rs` + `query/rerank.rs`). The sigmoid relevance probability is the user-facing score; `--min-score` filters on it. Opt-in per the Phase 3 gate (see results below).
+- **Reranking** (Phase 3, #41 + follow-up, part of `--hybrid` by default): a cross-encoder (fastembed `TextRerank`, jina-reranker-v1-turbo-en) scores the top 50 fused candidates as title + best-chunk passages, and the final order blends that score with the fusion prior (`rerank_score + 30 × RRF score`, `embed/rerank.rs` + `query/rerank.rs`). The sigmoid relevance probability is the user-facing score; `--min-score` filters on it; `--fast` skips the stage for fusion-only ordering (~63 ms instead of ~2 s per query).
 - The modes are mutually exclusive; `commands/search.rs` dispatches on a `SearchMode` enum.
-- **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. Implemented in `commands/benchmark/`.
+- **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. For rerank modes, `--dump-candidates <path>` writes each query's candidates (fused rank, RRF score, passage, rerank score) as JSONL for offline ranking experiments; dumps carry meeting content and stay outside the repo. Implemented in `commands/benchmark/`.
 
 ## Target pipeline
 
@@ -20,7 +20,7 @@ query
         ↓
  reciprocal rank fusion (RRF, k≈60)                 → top ~30-50
         ↓
- cross-encoder reranker (fastembed TextRerank)      → top N
+ cross-encoder reranker + weighted fusion prior     → top N
         ↓
  per-meeting grouping, recency tiebreak, snippets
 ```
@@ -30,10 +30,7 @@ query
 Every phase below ships with a before/after run of the quality benchmark, and the numbers go in the PR description. The rules:
 
 1. **Per-query, not aggregate.** The benchmark reports rank-of-first-relevant per query per mode, plus win/loss/tie counts between modes. Aggregate MRR can improve while individual queries regress; the per-query table catches that.
-2. **The hybrid gate.** Hybrid becomes the default only when, on the golden set:
-   - per query, hybrid matches or beats the better of (FTS, semantic) for that query in most cases, and
-   - no query whose first relevant result currently ranks in the top 3 falls out of the top k.
-   One catastrophic regression outweighs several mild improvements.
+2. **The promotion gate.** A change ships (or a mode becomes a default) when, per query on the golden set, the new behavior matches or beats the old in most cases with net wins clearly positive. Regressions are diagnostic signals, not automatic vetoes: a query whose top-3 result falls out of the top k gets diagnosed before shipping. A systematic cause (a failure mode that will recur in real use) blocks promotion until fixed; an idiosyncratic one-off weighs like any other loss. The strict no-regression standard is reserved for changes to a mode already in real daily use, where breaking a search someone relies on costs trust; during pre-adoption iteration the benchmark is the only user and there is no incumbent to protect. Phase 3 is the case study: three dropouts were first treated as a veto, but diagnosing them exposed one shared failure mode whose fix beat both the regressed and the protected configuration.
 3. **Strata.** Golden-set queries carry a `query_type` label (`exact-term`, `paraphrase`, `mixed`). Success reads as: hybrid ≈ FTS on exact-term, hybrid ≈ semantic on paraphrase, hybrid ≥ both on mixed.
 4. **Results ledger.** Each benchmark run is appended to a dated ledger file kept next to the golden set (outside the repo): commit hash, mode, metrics, latency, notes. `benchmark quality --record` does this automatically. Trends stay visible across months.
 5. **Failures feed the suite.** Any real-world search that returns bad results becomes a new labeled query in the golden set. The suite gets more trustworthy exactly where it was wrong.
@@ -89,9 +86,19 @@ Phase 3 results (2026-07-10, k=10, ID matching, same snapshot, all modes in one 
 | rerank-jina | 0.90 | 0.75 | 0.77 | ~2.0 s |
 | rerank-bge | 0.89 | 0.70 | 0.70 | ~7.2 s |
 
-jina-reranker-v1-turbo-en is the model pick: it beats bge-reranker-base on every aggregate and stratum at under a third of the latency, so it backs `--rerank`. Per stratum (hit / MRR), jina reaches mixed 0.87 / 0.759 and paraphrase 0.89 / 0.702 against hybrid's 0.82 / 0.694 and 0.84 / 0.626; exact-term keeps hit 1.00 but MRR slips 1.000 to 0.941 (two one-position slips). Per query at k=10 it goes 23W / 15L / 55T against the better of (hybrid, semantic), matching or beating it on 78 of 93.
+jina-reranker-v1-turbo-en is the model pick: it beats bge-reranker-base on every aggregate and stratum at under a third of the latency, so it backs the rerank stage. Per stratum (hit / MRR), jina reaches mixed 0.87 / 0.759 and paraphrase 0.89 / 0.702 against hybrid's 0.82 / 0.694 and 0.84 / 0.626; exact-term keeps hit 1.00 but MRR slips 1.000 to 0.941 (two one-position slips). Per query at k=10 it goes 23W / 15L / 55T against the better of (hybrid, semantic), matching or beating it on 78 of 93.
 
-The gate: the lift is real but reranking does not become part of plain `--hybrid`. Three queries whose relevant meeting ranked top-3 under fusion fall out of the top 10 (to ranks 13-15), which rule 2 above treats as outweighing the wins, and per-query latency rises from 63 ms to ~2 s plus reranker model load in a one-shot CLI. So `--rerank` is opt-in. Revisit if the dropouts get fixed, e.g. by blending the fusion prior into the reranked order (Phase 5 ranking-polish territory) or a stronger small reranker.
+The initial gate call: the lift was real but three queries whose relevant meeting ranked top-3 under fusion fell out of the top 10 (to ranks 13-15), so reranking first shipped opt-in rather than as part of plain `--hybrid`, pending a diagnosis of the dropouts.
+
+Phase 3 follow-up (2026-07-11, same snapshot): the three dropouts shared one cause rather than being three one-offs. On queries where the cross-encoder is unconfident (best candidate scoring 0.40-0.62, against the 0.8+ it assigns to answers it recognizes), its ordering is noise-dominated: it buried documents fusion had ranked top-3 while promoting candidates from fused ranks 13-48. The fix blends the fusion prior into the final order (`rerank_score + 30 × RRF score`; the user-facing score stays the cross-encoder probability). The weight came from sweeping w offline over a `--dump-candidates` capture of all 93 queries:
+
+| Mode | hit-rate@10 | recall@10 | MRR@10 | fusion-top-3 dropouts |
+|---|---|---|---|---|
+| hybrid (RRF only) | 0.86 | 0.76 | 0.72 | — |
+| rerank, no prior (w=0) | 0.90 | 0.75 | 0.77 | 3 |
+| rerank + prior (w=30) | 0.94 | 0.80 | 0.80 | 0 |
+
+The blend beats both plain fusion and unblended reranking on every aggregate and every stratum: exact-term returns to hit 1.00 / MRR 1.000 (fixing the two slips), mixed reaches 0.92 / 0.768, paraphrase 0.92 / 0.754. Against hybrid at k=10 it goes 22W / 9L / 62T with no fusion-top-3 document leaving the top 10. With the quality objection gone, reranking became the `--hybrid` default; the remaining cost is latency, so `--fast` skips the stage for fusion-only ordering (~63 ms vs ~2 s per query).
 
 (v1-file baseline for reference: hit-rate@10 ~73%, MRR ~0.55, title matching.)
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -333,6 +333,12 @@ pub enum BenchmarkAction {
         /// Note stored with the ledger entry
         #[arg(long, requires = "record")]
         note: Option<String>,
+
+        /// Write each query's reranked candidates (fused rank, RRF score,
+        /// passage, rerank score) as JSONL, for offline ranking experiments
+        /// (rerank modes only)
+        #[arg(long, value_name = "PATH", conflicts_with = "compare")]
+        dump_candidates: Option<std::path::PathBuf>,
     },
 }
 
@@ -613,6 +619,22 @@ mod tests {
             "fts",
             "--compare",
             "fts,semantic",
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn benchmark_quality_dump_candidates_conflicts_with_compare() {
+        let result = Cli::try_parse_from([
+            "grans",
+            "benchmark",
+            "quality",
+            "--file",
+            "golden.json",
+            "--compare",
+            "rerank-jina,rerank-bge",
+            "--dump-candidates",
+            "dump.jsonl",
         ]);
         assert!(result.is_err());
     }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -54,17 +54,18 @@ pub enum Commands {
         #[arg(long)]
         semantic: bool,
 
-        /// Combine keyword and semantic search, fusing both rankings
+        /// Combine keyword and semantic search: fuse both rankings and
+        /// rerank the top candidates with a cross-encoder
         #[arg(long, conflicts_with_all = ["semantic", "context"])]
         hybrid: bool,
 
-        /// Rerank the top hybrid candidates with a cross-encoder
-        /// (slower, higher quality; shows relevance scores)
+        /// Skip the cross-encoder rerank stage of hybrid search
+        /// (fusion order only; faster, but no relevance scores)
         #[arg(long, requires = "hybrid")]
-        rerank: bool,
+        fast: bool,
 
         /// Minimum reranker relevance score (0-1) for hybrid results
-        #[arg(long, requires = "rerank")]
+        #[arg(long, requires = "hybrid", conflicts_with = "fast")]
         min_score: Option<f32>,
 
         /// Context window size: utterances for transcripts, sections for panels, paragraphs for notes (0 = disabled)
@@ -257,9 +258,10 @@ pub enum QualityMode {
     Fts,
     /// Semantic search over embeddings
     Semantic,
-    /// RRF fusion of FTS and semantic rankings (--hybrid)
+    /// RRF fusion of FTS and semantic rankings (--hybrid --fast)
     Hybrid,
-    /// Fusion + jina-reranker-v1-turbo-en cross-encoder (--hybrid --rerank)
+    /// Fusion + jina-reranker-v1-turbo-en cross-encoder blended with the
+    /// fusion prior (the --hybrid default)
     RerankJina,
     /// Fusion + bge-reranker-base cross-encoder
     RerankBge,

--- a/src/commands/benchmark/dump.rs
+++ b/src/commands/benchmark/dump.rs
@@ -1,0 +1,94 @@
+//! --dump-candidates output: per-query rerank candidates as JSONL.
+//!
+//! One line per query: the query text and every reranked candidate with its
+//! fusion components (fused rank, RRF score, passage, rerank score). Used
+//! for offline ranking experiments (e.g. blend-weight sweeps). Dumps carry
+//! real meeting content, so they belong outside the repo, alongside the
+//! golden set.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::query::rerank::RerankCandidate;
+
+#[derive(Serialize)]
+struct DumpLine<'a> {
+    query: &'a str,
+    candidates: &'a [RerankCandidate],
+}
+
+pub(super) struct CandidateDumpWriter {
+    writer: BufWriter<File>,
+}
+
+impl CandidateDumpWriter {
+    pub(super) fn create(path: &Path) -> Result<Self> {
+        let file = File::create(path)
+            .with_context(|| format!("Failed to create dump file: {}", path.display()))?;
+        Ok(Self { writer: BufWriter::new(file) })
+    }
+
+    pub(super) fn write_query(
+        &mut self,
+        query: &str,
+        candidates: &[RerankCandidate],
+    ) -> Result<()> {
+        serde_json::to_writer(&mut self.writer, &DumpLine { query, candidates })?;
+        self.writer.write_all(b"\n")?;
+        Ok(())
+    }
+
+    /// Flush and close. Explicit so write errors surface instead of being
+    /// swallowed by a buffered writer's drop.
+    pub(super) fn finish(mut self) -> Result<()> {
+        self.writer.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(id: &str, fused_rank: usize) -> RerankCandidate {
+        RerankCandidate {
+            document_id: id.to_string(),
+            fused_rank,
+            fused_score: 0.016,
+            passage: format!("Title {id}\n\nchunk text"),
+            rerank_score: 0.9,
+        }
+    }
+
+    #[test]
+    fn writes_one_json_line_per_query() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dump.jsonl");
+
+        let mut writer = CandidateDumpWriter::create(&path).unwrap();
+        writer.write_query("first query", &[candidate("doc-a", 1), candidate("doc-b", 2)]).unwrap();
+        writer.write_query("second query", &[candidate("doc-c", 1)]).unwrap();
+        writer.finish().unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(first["query"], "first query");
+        assert_eq!(first["candidates"].as_array().unwrap().len(), 2);
+        assert_eq!(first["candidates"][0]["document_id"], "doc-a");
+        assert_eq!(first["candidates"][0]["fused_rank"], 1);
+        assert_eq!(first["candidates"][0]["fused_score"], 0.016);
+        assert_eq!(first["candidates"][0]["passage"], "Title doc-a\n\nchunk text");
+        assert!((first["candidates"][0]["rerank_score"].as_f64().unwrap() - 0.9).abs() < 1e-6);
+
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(second["query"], "second query");
+        assert_eq!(second["candidates"].as_array().unwrap().len(), 1);
+    }
+}

--- a/src/commands/benchmark/mod.rs
+++ b/src/commands/benchmark/mod.rs
@@ -1,5 +1,6 @@
 //! Benchmark commands: search performance and quality measurement.
 
+mod dump;
 mod ledger;
 mod metrics;
 mod perf;
@@ -45,6 +46,7 @@ pub fn run(
             detail,
             record,
             note,
+            dump_candidates,
         } => {
             let args = quality::QualityArgs {
                 file,
@@ -55,6 +57,7 @@ pub fn run(
                 record: *record,
                 note: note.as_deref(),
                 db: db_path,
+                dump_candidates: dump_candidates.as_deref(),
             };
             quality::run_quality_benchmark(conn, &args, output_mode)
         }

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -31,6 +31,8 @@ pub struct QualityArgs<'a> {
     pub note: Option<&'a str>,
     /// --db override, when given; the default database path otherwise applies.
     pub db: Option<&'a Path>,
+    /// Write per-query rerank candidates as JSONL here, when given.
+    pub dump_candidates: Option<&'a Path>,
 }
 
 /// A single test query from the benchmark file.
@@ -152,16 +154,44 @@ pub(super) fn run_quality_benchmark(
     let title_map = build_title_map(conn)?;
     let modes = resolve_modes(args.mode, args.compare)?;
 
+    let mut dump = match args.dump_candidates {
+        Some(path) => {
+            ensure_dump_modes(&modes)?;
+            Some(super::dump::CandidateDumpWriter::create(path)?)
+        }
+        None => None,
+    };
+
     let mut runs = Vec::with_capacity(modes.len());
     for mode in modes {
         let retriever = Retriever::build(mode, conn)?;
         runs.push(run_queries(
-            |q| retriever.retrieve(q),
+            |q| match dump.as_mut() {
+                Some(writer) => {
+                    let detailed = retriever
+                        .retrieve_detailed(q)?
+                        .context("rerank modes always produce candidate detail")?;
+                    writer.write_query(q, &detailed)?;
+                    Ok(detailed
+                        .into_iter()
+                        .map(|c| RankedDoc {
+                            document_id: c.document_id,
+                            score: Some(c.rerank_score),
+                        })
+                        .collect())
+                }
+                None => retriever.retrieve(q),
+            },
             &queries,
             &title_map,
             mode,
             args.k,
         )?);
+    }
+
+    if let (Some(writer), Some(path)) = (dump.take(), args.dump_candidates) {
+        writer.finish()?;
+        eprintln!("Candidate dump written: {}", path.display());
     }
 
     let comparisons = pairwise_comparisons(&runs);
@@ -235,14 +265,14 @@ fn parse_benchmark(content: &str) -> Result<Vec<BenchmarkQuery>> {
 
 /// Run every query through one retrieval function and score the results.
 fn run_queries<F>(
-    retrieve: F,
+    mut retrieve: F,
     queries: &[BenchmarkQuery],
     title_map: &HashMap<String, String>,
     mode: QualityMode,
     k: usize,
 ) -> Result<ModeRun>
 where
-    F: Fn(&str) -> Result<Vec<RankedDoc>>,
+    F: FnMut(&str) -> Result<Vec<RankedDoc>>,
 {
     let mut outcomes = Vec::with_capacity(queries.len());
     for bq in queries {
@@ -324,6 +354,20 @@ fn latency_stats(outcomes: &[QueryOutcome]) -> LatencyStats {
         avg_ms: latencies.iter().sum::<f64>() / latencies.len() as f64,
         p50_ms: percentile(&latencies, 50.0),
     }
+}
+
+/// --dump-candidates needs per-candidate rerank detail, which only the
+/// rerank modes produce.
+fn ensure_dump_modes(modes: &[QualityMode]) -> Result<()> {
+    for mode in modes {
+        if !matches!(mode, QualityMode::RerankJina | QualityMode::RerankBge) {
+            bail!(
+                "--dump-candidates requires a rerank mode, got --mode {}",
+                mode.as_str()
+            );
+        }
+    }
+    Ok(())
 }
 
 /// The modes to run: the --compare list when given (validated), else the
@@ -461,6 +505,20 @@ mod tests {
         assert_eq!(matching_summary(&["id", "id"]), "id");
         assert_eq!(matching_summary(&["title"]), "title");
         assert_eq!(matching_summary(&["id", "title"]), "mixed");
+    }
+
+    #[test]
+    fn dump_modes_accepts_rerank_modes() {
+        assert!(ensure_dump_modes(&[QualityMode::RerankJina]).is_ok());
+        assert!(ensure_dump_modes(&[QualityMode::RerankBge]).is_ok());
+    }
+
+    #[test]
+    fn dump_modes_rejects_modes_without_rerank_detail() {
+        for mode in [QualityMode::Fts, QualityMode::Semantic, QualityMode::Hybrid] {
+            let err = ensure_dump_modes(&[mode]).unwrap_err();
+            assert!(err.to_string().contains("requires a rerank mode"));
+        }
     }
 
     #[test]

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -4,7 +4,8 @@
 //! scoring (metrics.rs) applies k. Lists reflect current production
 //! behavior for the mode: FTS is ranked by bm25 with a recency tiebreak,
 //! semantic by best-chunk cosine score, hybrid by RRF over both, and the
-//! rerank modes by cross-encoder score over the top of the fused pool.
+//! rerank modes by cross-encoder score blended with the fusion prior over
+//! the top of the fused pool.
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -152,7 +153,7 @@ fn retrieve_hybrid_rerank_detailed(
 }
 
 /// Reranked hybrid retrieval in production result shape (the
-/// `grans search --hybrid --rerank` path).
+/// `grans search --hybrid` default path).
 fn retrieve_hybrid_rerank(
     conn: &Connection,
     embedder: &dyn Embedder,

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -16,6 +16,7 @@ use crate::embed::rerank::{FastEmbedReranker, RerankModel, Reranker};
 use crate::embed::search::SemanticSearchResult;
 use crate::embed::{ensure_embeddings, EmbeddingIndex, DEFAULT_BATCH_SIZE};
 use crate::query::filter::SearchTarget;
+use crate::query::rerank::RerankCandidate;
 
 pub enum Retriever<'a> {
     Fts {
@@ -84,6 +85,17 @@ impl<'a> Retriever<'a> {
             }
         }
     }
+
+    /// Per-candidate rerank detail (fused rank, RRF score, passage, rerank
+    /// score) for modes with a rerank stage; `None` for the others.
+    pub fn retrieve_detailed(&self, query: &str) -> Result<Option<Vec<RerankCandidate>>> {
+        match self {
+            Retriever::HybridRerank { conn, embedder, index, reranker } => Ok(Some(
+                retrieve_hybrid_rerank_detailed(conn, embedder, index, reranker.as_ref(), query)?,
+            )),
+            _ => Ok(None),
+        }
+    }
 }
 
 /// FTS keyword search over the same targets `grans search` uses by default
@@ -123,9 +135,24 @@ fn retrieve_hybrid(
         .collect())
 }
 
-/// Reranked hybrid retrieval over the same default targets: production
-/// fusion, then the cross-encoder reorders the top candidates (the
-/// `grans search --hybrid` default path).
+/// Reranked hybrid retrieval over the same default targets, with each
+/// candidate's fusion components: production fusion, then the
+/// cross-encoder scores the top candidates.
+fn retrieve_hybrid_rerank_detailed(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    index: &EmbeddingIndex,
+    reranker: &dyn Reranker,
+    query: &str,
+) -> Result<Vec<RerankCandidate>> {
+    let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
+    let ranking =
+        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, false)?;
+    crate::query::rerank::rerank_hybrid_detailed(conn, reranker, query, &ranking)
+}
+
+/// Reranked hybrid retrieval in production result shape (the
+/// `grans search --hybrid --rerank` path).
 fn retrieve_hybrid_rerank(
     conn: &Connection,
     embedder: &dyn Embedder,
@@ -133,15 +160,11 @@ fn retrieve_hybrid_rerank(
     reranker: &dyn Reranker,
     query: &str,
 ) -> Result<Vec<RankedDoc>> {
-    let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
-    let ranking =
-        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, false)?;
-    let reranked = crate::query::rerank::rerank_hybrid(conn, reranker, query, &ranking)?;
-    Ok(reranked
+    Ok(retrieve_hybrid_rerank_detailed(conn, embedder, index, reranker, query)?
         .into_iter()
-        .map(|d| RankedDoc {
-            document_id: d.document_id,
-            score: Some(d.score),
+        .map(|c| RankedDoc {
+            document_id: c.document_id,
+            score: Some(c.rerank_score),
         })
         .collect())
 }
@@ -266,6 +289,56 @@ mod tests {
         assert_eq!(ranked[0].score, Some(3.0));
         assert_eq!(ranked[1].document_id, "doc-2");
         assert_eq!(ranked[1].score, Some(1.0));
+    }
+
+    #[test]
+    fn hybrid_rerank_detailed_carries_fusion_components() {
+        use crate::embed::model::MockEmbedder;
+        use crate::embed::rerank::MockReranker;
+        use crate::embed::store::StoredVector;
+
+        // Same setup as the reorder test: fusion puts doc-2 first, the
+        // cross-encoder reverses that, so doc-1 must carry fused_rank 2.
+        let conn = build_test_db(&meetings_state());
+        let stored = |doc_id: &str, text: &str, vector: Vec<f32>| StoredVector {
+            chunk_id: 0,
+            document_id: doc_id.to_string(),
+            source_type: "transcript_window".to_string(),
+            text: text.to_string(),
+            vector,
+            metadata_json: None,
+        };
+        let index = EmbeddingIndex {
+            vectors: vec![
+                stored("doc-1", "standup standup standup", vec![1.0, 0.0]),
+                stored("doc-2", "planning", vec![0.0, 1.0]),
+            ],
+            stats: None,
+        };
+        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+
+        let detailed =
+            retrieve_hybrid_rerank_detailed(&conn, &embedder, &index, &MockReranker, "standup")
+                .unwrap();
+
+        assert_eq!(detailed.len(), 2);
+        assert_eq!(detailed[0].document_id, "doc-1");
+        assert_eq!(detailed[0].fused_rank, 2);
+        assert_eq!(detailed[0].rerank_score, 3.0);
+        assert!(detailed[0].fused_score > 0.0);
+        assert!(detailed[0].passage.contains("standup standup standup"));
+        assert_eq!(detailed[1].document_id, "doc-2");
+        assert_eq!(detailed[1].fused_rank, 1);
+    }
+
+    #[test]
+    fn non_rerank_retriever_has_no_candidate_detail() {
+        let conn = build_test_db(&meetings_state());
+        let retriever = Retriever::Fts { conn: &conn };
+
+        let detailed = retriever.retrieve_detailed("machine learning").unwrap();
+
+        assert!(detailed.is_none());
     }
 
     #[test]

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -50,7 +50,7 @@ impl SearchMode {
     #[allow(clippy::too_many_arguments)]
     pub fn from_cli_args(
         hybrid: bool,
-        rerank: bool,
+        fast: bool,
         min_score: Option<f32>,
         semantic: bool,
         context: usize,
@@ -64,7 +64,7 @@ impl SearchMode {
             SearchMode::Hybrid {
                 targets: SearchTarget::parse_list(in_targets),
                 meeting_filter: meeting_filter.map(String::from),
-                rerank,
+                rerank: !fast,
                 min_score,
                 yes,
                 limit,
@@ -866,7 +866,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn from_cli_args_hybrid_takes_priority_without_rerank_by_default() {
+    fn from_cli_args_hybrid_takes_priority_and_reranks_by_default() {
         let mode = SearchMode::from_cli_args(
             true, false, None, true, 5, "titles,notes", Some("standup"), None, true, 10,
         );
@@ -883,7 +883,7 @@ mod tests {
                 assert!(targets.contains(&SearchTarget::Titles));
                 assert!(targets.contains(&SearchTarget::Notes));
                 assert_eq!(meeting_filter.as_deref(), Some("standup"));
-                assert!(!rerank);
+                assert!(rerank);
                 assert_eq!(min_score, None);
                 assert!(yes);
                 assert_eq!(limit, 10);
@@ -893,11 +893,11 @@ mod tests {
     }
 
     #[test]
-    fn from_cli_args_rerank_opts_in() {
+    fn from_cli_args_fast_skips_rerank() {
         let mode =
             SearchMode::from_cli_args(true, true, None, false, 0, "titles", None, None, false, 10);
         match mode {
-            SearchMode::Hybrid { rerank, .. } => assert!(rerank),
+            SearchMode::Hybrid { rerank, .. } => assert!(!rerank),
             _ => panic!("Expected Hybrid variant"),
         }
     }
@@ -905,7 +905,7 @@ mod tests {
     #[test]
     fn from_cli_args_min_score_threads_to_hybrid() {
         let mode = SearchMode::from_cli_args(
-            true, true, Some(0.4), false, 0, "titles", None, None, false, 10,
+            true, false, Some(0.4), false, 0, "titles", None, None, false, 10,
         );
         match mode {
             SearchMode::Hybrid { min_score, .. } => assert_eq!(min_score, Some(0.4)),

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -228,7 +228,8 @@ fn keyword_search(
 }
 
 /// Run keyword and semantic retrieval, fuse the rankings, rerank the top
-/// candidates when requested, and display the resulting meetings.
+/// candidates (unless skipped via --fast), and display the resulting
+/// meetings.
 #[allow(clippy::too_many_arguments)]
 fn hybrid_search(
     conn: &Connection,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn main() -> Result<()> {
             r#in,
             semantic,
             hybrid,
-            rerank,
+            fast,
             min_score,
             context,
             meeting,
@@ -101,7 +101,7 @@ fn main() -> Result<()> {
         } => {
             let mode = SearchMode::from_cli_args(
                 *hybrid,
-                *rerank,
+                *fast,
                 *min_score,
                 *semantic,
                 *context,

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -2,8 +2,9 @@
 //!
 //! Takes the top fused candidates from [`crate::query::hybrid`], builds a
 //! (title + best chunk) passage per document, and reorders them by
-//! cross-encoder relevance. The reranker score is the user-facing score
-//! for hybrid results.
+//! cross-encoder relevance blended with the RRF fusion prior (see
+//! [`FUSION_BLEND_WEIGHT`]). The reranker probability is the user-facing
+//! score for hybrid results; the blend affects ordering only.
 
 use std::collections::HashMap;
 
@@ -17,6 +18,16 @@ use crate::query::hybrid::HybridRanking;
 /// How many top fused candidates the reranker scores. Documents fused
 /// below this cutoff are dropped from reranked results.
 pub const RERANK_POOL: usize = 50;
+
+/// Weight of the RRF fusion score in the final ranking, blended as
+/// `rerank_score + FUSION_BLEND_WEIGHT * fused_score`. RRF scores top out
+/// near 2/(60+1), so 30 scales the prior to roughly the cross-encoder's
+/// [0, 1] range. Without the prior, queries where the cross-encoder is
+/// unconfident (max score well under 0.8) get noise-dominated orderings
+/// that can bury documents fusion ranked highly; the sweep on the 93-query
+/// golden set picked 30 (hit-rate@10 0.935, MRR@10 0.804, no fusion top-3
+/// document leaving the top 10).
+pub const FUSION_BLEND_WEIGHT: f32 = 30.0;
 
 /// A reranked document with its relevance score.
 #[derive(Debug, Clone, PartialEq)]
@@ -39,6 +50,15 @@ pub struct RerankCandidate {
     pub rerank_score: f32,
 }
 
+impl RerankCandidate {
+    /// The ranking score: cross-encoder probability plus the weighted
+    /// fusion prior. Ordering only; the user-facing score stays
+    /// [`RerankCandidate::rerank_score`].
+    pub fn blended_score(&self) -> f32 {
+        self.rerank_score + FUSION_BLEND_WEIGHT * self.fused_score as f32
+    }
+}
+
 /// Build the passage the reranker judges for one document: the title and
 /// the best-matching chunk, whichever exist.
 fn build_passage(title: Option<&str>, best_chunk: Option<&str>) -> String {
@@ -52,7 +72,7 @@ fn build_passage(title: Option<&str>, best_chunk: Option<&str>) -> String {
 
 /// Rerank the top [`RERANK_POOL`] fused candidates of a hybrid ranking,
 /// keeping each candidate's fusion components: fetch titles, build
-/// passages, score with the cross-encoder. Sorted best-first by rerank
+/// passages, score with the cross-encoder. Sorted best-first by blended
 /// score; ties keep the fused order.
 pub fn rerank_hybrid_detailed(
     conn: &Connection,
@@ -92,7 +112,7 @@ pub fn rerank_hybrid_detailed(
         candidate.rerank_score = score;
     }
     candidates.sort_by(|a, b| {
-        b.rerank_score.partial_cmp(&a.rerank_score).unwrap_or(std::cmp::Ordering::Equal)
+        b.blended_score().partial_cmp(&a.blended_score()).unwrap_or(std::cmp::Ordering::Equal)
     });
     Ok(candidates)
 }
@@ -161,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn detailed_carries_fusion_components_and_sorts_by_rerank_score() {
+    fn detailed_carries_fusion_components_and_sorts_by_blended_score() {
         // Fused order is the reverse of cross-encoder relevance: doc-chunk
         // matches "kumquat" twice via its chunk, doc-title once via its
         // title, doc-none not at all.
@@ -200,6 +220,38 @@ mod tests {
         assert_eq!(detailed[2].document_id, "doc-none");
         assert_eq!(detailed[2].fused_rank, 1);
         assert_eq!(detailed[2].rerank_score, 0.0);
+    }
+
+    #[test]
+    fn blend_prefers_strong_fusion_prior_in_close_calls() {
+        // doc-deep outscores doc-fused on the cross-encoder (2 vs 1 query
+        // occurrences), but doc-fused carries a far stronger fusion prior,
+        // so the blended ordering must put doc-fused first.
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-fused": {"id": "doc-fused", "title": "Kumquat sync", "created_at": "2026-01-01T10:00:00Z"},
+                "doc-deep": {"id": "doc-deep", "title": "Planning", "created_at": "2026-01-02T10:00:00Z"}
+            }
+        }));
+        let ranking = HybridRanking {
+            fused: vec![
+                FusedDoc { document_id: "doc-fused".to_string(), score: 0.1 },
+                FusedDoc { document_id: "doc-deep".to_string(), score: 0.0 },
+            ],
+            best_chunks: HashMap::from([(
+                "doc-deep".to_string(),
+                "kumquat kumquat".to_string(),
+            )]),
+        };
+
+        let detailed =
+            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking).unwrap();
+
+        // Blends: doc-fused 1 + 30 * 0.1 = 4, doc-deep 2 + 30 * 0 = 2.
+        assert_eq!(detailed[0].document_id, "doc-fused");
+        assert_eq!(detailed[0].rerank_score, 1.0);
+        assert_eq!(detailed[1].document_id, "doc-deep");
+        assert_eq!(detailed[1].rerank_score, 2.0);
     }
 
     #[test]

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -5,8 +5,11 @@
 //! cross-encoder relevance. The reranker score is the user-facing score
 //! for hybrid results.
 
+use std::collections::HashMap;
+
 use anyhow::Result;
 use rusqlite::Connection;
+use serde::Serialize;
 
 use crate::embed::rerank::Reranker;
 use crate::query::hybrid::HybridRanking;
@@ -22,6 +25,20 @@ pub struct RerankedDoc {
     pub score: f32,
 }
 
+/// One reranked candidate with the components that produced its position:
+/// where fusion placed it, its RRF score, and the passage the cross-encoder
+/// judged. Serialized by the benchmark's --dump-candidates output.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct RerankCandidate {
+    pub document_id: String,
+    /// 1-based rank in the fused list.
+    pub fused_rank: usize,
+    /// RRF score from fusion.
+    pub fused_score: f64,
+    pub passage: String,
+    pub rerank_score: f32,
+}
+
 /// Build the passage the reranker judges for one document: the title and
 /// the best-matching chunk, whichever exist.
 fn build_passage(title: Option<&str>, best_chunk: Option<&str>) -> String {
@@ -33,24 +50,51 @@ fn build_passage(title: Option<&str>, best_chunk: Option<&str>) -> String {
     }
 }
 
-/// Score `(document_id, passage)` candidates against the query and sort
-/// best-first. Ties keep the candidates' input (fused) order.
-pub fn rerank_candidates(
+/// Rerank the top [`RERANK_POOL`] fused candidates of a hybrid ranking,
+/// keeping each candidate's fusion components: fetch titles, build
+/// passages, score with the cross-encoder. Sorted best-first by rerank
+/// score; ties keep the fused order.
+pub fn rerank_hybrid_detailed(
+    conn: &Connection,
     reranker: &dyn Reranker,
     query: &str,
-    candidates: &[(String, String)],
-) -> Result<Vec<RerankedDoc>> {
-    let passages: Vec<&str> = candidates.iter().map(|(_, p)| p.as_str()).collect();
-    let scores = reranker.rerank(query, &passages)?;
+    ranking: &HybridRanking,
+) -> Result<Vec<RerankCandidate>> {
+    let pool = &ranking.fused[..ranking.fused.len().min(RERANK_POOL)];
+    let pool_ids: Vec<String> = pool.iter().map(|d| d.document_id.clone()).collect();
+    let docs = crate::db::meetings::get_meetings_by_ids(conn, &pool_ids)?;
+    let titles: HashMap<String, Option<String>> =
+        docs.into_iter().filter_map(|doc| doc.id.map(|id| (id, doc.title))).collect();
 
-    let mut reranked: Vec<RerankedDoc> = candidates
+    // Candidates are built in fused order so the stable sort below keeps
+    // that order for ties; documents missing from the db drop out.
+    let mut candidates: Vec<RerankCandidate> = pool
         .iter()
-        .zip(scores)
-        .map(|((id, _), score)| RerankedDoc { document_id: id.clone(), score })
+        .enumerate()
+        .filter_map(|(i, fused)| {
+            let title = titles.get(&fused.document_id)?;
+            Some(RerankCandidate {
+                document_id: fused.document_id.clone(),
+                fused_rank: i + 1,
+                fused_score: fused.score,
+                passage: build_passage(
+                    title.as_deref(),
+                    ranking.best_chunks.get(&fused.document_id).map(String::as_str),
+                ),
+                rerank_score: 0.0,
+            })
+        })
         .collect();
-    // Stable sort: equal scores keep the fused order.
-    reranked.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
-    Ok(reranked)
+
+    let passages: Vec<&str> = candidates.iter().map(|c| c.passage.as_str()).collect();
+    let scores = reranker.rerank(query, &passages)?;
+    for (candidate, score) in candidates.iter_mut().zip(scores) {
+        candidate.rerank_score = score;
+    }
+    candidates.sort_by(|a, b| {
+        b.rerank_score.partial_cmp(&a.rerank_score).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    Ok(candidates)
 }
 
 /// Rerank the top [`RERANK_POOL`] fused candidates of a hybrid ranking:
@@ -61,25 +105,10 @@ pub fn rerank_hybrid(
     query: &str,
     ranking: &HybridRanking,
 ) -> Result<Vec<RerankedDoc>> {
-    let pool_ids: Vec<String> = ranking
-        .fused
-        .iter()
-        .take(RERANK_POOL)
-        .map(|d| d.document_id.clone())
-        .collect();
-    let docs = crate::db::meetings::get_meetings_by_ids(conn, &pool_ids)?;
-
-    let candidates: Vec<(String, String)> = docs
+    Ok(rerank_hybrid_detailed(conn, reranker, query, ranking)?
         .into_iter()
-        .filter_map(|doc| doc.id.map(|id| (id, doc.title)))
-        .map(|(id, title)| {
-            let passage =
-                build_passage(title.as_deref(), ranking.best_chunks.get(&id).map(String::as_str));
-            (id, passage)
-        })
-        .collect();
-
-    rerank_candidates(reranker, query, &candidates)
+        .map(|c| RerankedDoc { document_id: c.document_id, score: c.rerank_score })
+        .collect())
 }
 
 #[cfg(test)]
@@ -97,42 +126,6 @@ mod tests {
         assert_eq!(build_passage(Some("Title"), None), "Title");
         assert_eq!(build_passage(None, Some("chunk text")), "chunk text");
         assert_eq!(build_passage(None, None), "");
-    }
-
-    #[test]
-    fn candidates_sort_by_score_descending() {
-        // MockReranker scores by query occurrences: 0, 2, 1.
-        let candidates = vec![
-            ("doc-a".to_string(), "nothing here".to_string()),
-            ("doc-b".to_string(), "kumquat kumquat".to_string()),
-            ("doc-c".to_string(), "kumquat".to_string()),
-        ];
-
-        let reranked = rerank_candidates(&MockReranker, "kumquat", &candidates).unwrap();
-
-        let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
-        assert_eq!(ids, vec!["doc-b", "doc-c", "doc-a"]);
-        assert_eq!(reranked[0].score, 2.0);
-        assert_eq!(reranked[2].score, 0.0);
-    }
-
-    #[test]
-    fn tied_candidates_keep_input_order() {
-        let candidates = vec![
-            ("doc-first".to_string(), "kumquat".to_string()),
-            ("doc-second".to_string(), "kumquat".to_string()),
-        ];
-
-        let reranked = rerank_candidates(&MockReranker, "kumquat", &candidates).unwrap();
-
-        let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
-        assert_eq!(ids, vec!["doc-first", "doc-second"]);
-    }
-
-    #[test]
-    fn empty_candidates_rerank_to_empty() {
-        let reranked = rerank_candidates(&MockReranker, "kumquat", &[]).unwrap();
-        assert!(reranked.is_empty());
     }
 
     fn fused(ids: &[&str]) -> Vec<FusedDoc> {
@@ -165,6 +158,83 @@ mod tests {
 
         let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
         assert_eq!(ids, vec!["doc-chunk", "doc-title", "doc-none"]);
+    }
+
+    #[test]
+    fn detailed_carries_fusion_components_and_sorts_by_rerank_score() {
+        // Fused order is the reverse of cross-encoder relevance: doc-chunk
+        // matches "kumquat" twice via its chunk, doc-title once via its
+        // title, doc-none not at all.
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-none": {"id": "doc-none", "title": "Unrelated", "created_at": "2026-01-01T10:00:00Z"},
+                "doc-title": {"id": "doc-title", "title": "Kumquat sync", "created_at": "2026-01-02T10:00:00Z"},
+                "doc-chunk": {"id": "doc-chunk", "title": "Planning", "created_at": "2026-01-03T10:00:00Z"}
+            }
+        }));
+        let ranking = HybridRanking {
+            fused: vec![
+                FusedDoc { document_id: "doc-none".to_string(), score: 0.03 },
+                FusedDoc { document_id: "doc-title".to_string(), score: 0.02 },
+                FusedDoc { document_id: "doc-chunk".to_string(), score: 0.01 },
+            ],
+            best_chunks: HashMap::from([(
+                "doc-chunk".to_string(),
+                "kumquat kumquat".to_string(),
+            )]),
+        };
+
+        let detailed =
+            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking).unwrap();
+
+        assert_eq!(detailed.len(), 3);
+        assert_eq!(detailed[0].document_id, "doc-chunk");
+        assert_eq!(detailed[0].fused_rank, 3);
+        assert_eq!(detailed[0].fused_score, 0.01);
+        assert_eq!(detailed[0].passage, "Planning\n\nkumquat kumquat");
+        assert_eq!(detailed[0].rerank_score, 2.0);
+        assert_eq!(detailed[1].document_id, "doc-title");
+        assert_eq!(detailed[1].fused_rank, 2);
+        assert_eq!(detailed[1].passage, "Kumquat sync");
+        assert_eq!(detailed[1].rerank_score, 1.0);
+        assert_eq!(detailed[2].document_id, "doc-none");
+        assert_eq!(detailed[2].fused_rank, 1);
+        assert_eq!(detailed[2].rerank_score, 0.0);
+    }
+
+    #[test]
+    fn detailed_ties_keep_fused_order() {
+        // Both passages score 1, so the fused order must survive the sort
+        // regardless of the order the database returns rows in.
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-second": {"id": "doc-second", "title": "Kumquat retro", "created_at": "2026-01-01T10:00:00Z"},
+                "doc-first": {"id": "doc-first", "title": "Kumquat sync", "created_at": "2026-01-02T10:00:00Z"}
+            }
+        }));
+        let ranking = HybridRanking {
+            fused: fused(&["doc-first", "doc-second"]),
+            best_chunks: HashMap::new(),
+        };
+
+        let detailed =
+            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking).unwrap();
+
+        let ids: Vec<&str> = detailed.iter().map(|d| d.document_id.as_str()).collect();
+        assert_eq!(ids, vec!["doc-first", "doc-second"]);
+        assert_eq!(detailed[0].fused_rank, 1);
+        assert_eq!(detailed[1].fused_rank, 2);
+    }
+
+    #[test]
+    fn detailed_empty_ranking_reranks_to_empty() {
+        let conn = build_test_db(&json!({ "documents": {} }));
+        let ranking = HybridRanking { fused: Vec::new(), best_chunks: HashMap::new() };
+
+        let detailed =
+            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking).unwrap();
+
+        assert!(detailed.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Closes #50. Follow-up to #41 (PR #49); stacked on `feature/cross-encoder-rerank` and should merge after #49 (retarget to main if #49 merges first).

Phase 3 shipped reranking opt-in because three queries whose relevant meeting ranked top-3 under fusion fell out of the top 10. This PR diagnoses those dropouts, fixes their shared cause by blending the fusion prior into the reranked order, and with the quality objection gone makes reranking the `--hybrid` default.

## The diagnosis

Per-candidate analysis (via the new `--dump-candidates` output) showed the three dropouts were one failure mode, not three one-offs: on queries where the cross-encoder is unconfident, its best candidate scores only 0.40-0.62, versus the 0.8+ it assigns to answers it recognizes. In that flat-score regime its ordering is noise-dominated: it buried documents fusion had ranked top-3 while promoting candidates from fused ranks 13-48. Pure reranking discards the fusion prior entirely, so nothing anchored the ordering when the cross-encoder had no signal.

## The fix

Final ordering becomes `rerank_score + 30 × RRF score`. The weight scales the RRF range (tops out near 2/61) to roughly the cross-encoder's [0, 1] range and was picked by sweeping w offline over a dump of all 93 golden-set queries. The user-facing score is unchanged: still the cross-encoder relevance probability in [0, 1], with `--min-score` filtering on it; the blend affects ordering only.

## Benchmarks

Frozen snapshot (872 docs), 93-query golden set, k=10, ID matching. Sweep table (offline over the dump), verified by a recorded `--compare hybrid,rerank-jina` run of the production path (binary 9e7512b), which reproduced the w=30 row exactly:

| Ordering | hit-rate@10 | recall@10 | MRR@10 | fusion-top-3 dropouts |
|---|---|---|---|---|
| hybrid (RRF only) | 0.860 | 0.759 | 0.722 | — |
| rerank, no prior (PR #49) | 0.903 | 0.749 | 0.769 | 3 |
| **rerank + prior, w=30 (this PR)** | **0.935** | **0.798** | **0.804** | **0** |

The blend beats both plain fusion and unblended reranking on every aggregate and every stratum: exact-term returns to hit 1.00 / MRR 1.000 (fixing PR #49's two slips), mixed reaches 0.92 / 0.768, paraphrase 0.92 / 0.754. Against hybrid at k=10 it goes 22W / 9L / 62T with no fusion-top-3 document leaving the top 10. Latency is unchanged from PR #49 (~2.2 s per query reranked, ~75 ms with `--fast`).

Recorded runs appended to the benchmarks ledger (2026-07-11, modes `hybrid` and `rerank-jina`, binary 9e7512b) with per-query output under `runs/`.

## What changed

- `query/rerank.rs`: `rerank_hybrid_detailed` exposes each candidate's fusion components (fused rank, RRF score, passage, rerank score); final sort uses `blended_score()` with `FUSION_BLEND_WEIGHT = 30`.
- CLI: `--hybrid` now reranks by default. `--rerank` is replaced by `--fast`, which skips the cross-encoder for fusion-only ordering; `--min-score` requires `--hybrid` and conflicts with `--fast`.
- Benchmark: `--dump-candidates <path>` (rerank modes only, conflicts with `--compare`) writes per-query candidates as JSONL for offline ranking experiments. Dumps carry meeting content and belong outside the repo, next to the golden set.
- Docs: README reflects the new default; the roadmap records the diagnosis and results, and its rule 2 is rewritten: regressions are diagnostic signals to investigate for a systematic cause, not automatic vetoes, while iterating pre-adoption; the strict no-regression standard is reserved for modes in real daily use. This phase is the case study: treating the three dropouts as information rather than a veto produced a configuration better than either the regressed or the protected one.
