### PR TITLE
#57: Shape hybrid search output into per-meeting cards with match evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ grans search "budget" --context 2 --limit 3
 grans search "budget" --semantic --limit 5
 grans search "budget" --limit 0  # No limit
 
+# Show more match snippets per meeting (default 1)
+grans search "budget" --matches 3
+
 # Search with context (utterances for transcripts, sections for panels, paragraphs for notes)
 # --context implies keyword search (context-window mode), even from a bare search
 grans search "action items" --context 3
@@ -191,7 +194,9 @@ grans search "budget" --include-deleted
 grans search "old project" --semantic --include-deleted
 ```
 
-Hybrid search runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either mode surfaces, and one ranked well by both rises to the top. The top 50 fused candidates are then scored by a cross-encoder reranker (`jina-reranker-v1-turbo-en`) for how well each meeting actually answers the query, and the final order blends that judgment with the fusion ranking and a small boost for meetings whose title matches the query (damped when many meetings share the title, as recurring series do). Results show the reranker's relevance score between 0 and 1, and `--min-score` drops results below a threshold; it conflicts with `--fast`, `--keyword`, `--semantic`, `--context`, and `--speaker`, since only the rerank stage produces that score. Hybrid search supports `--in`, `--meeting`, date filters, and `--limit`, and conflicts with `--semantic`, `--context`, and `--speaker`; `--hybrid` still works as an explicit (redundant) way to ask for it.
+Hybrid search runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either mode surfaces, and one ranked well by both rises to the top. The top 50 fused candidates are then scored by a cross-encoder reranker (`jina-reranker-v1-turbo-en`) for how well each meeting actually answers the query, and the final order blends that judgment with the fusion ranking and a small boost for meetings whose title matches the query (damped when many meetings share the title, as recurring series do).
+
+Each result is a card showing why the meeting matched: the source of the best match (`AI notes` with its section heading, `your notes`, or `transcript` with time and speaker), a snippet with the query terms highlighted, and a `+N more matches` line when the meeting matched in more places. `--matches N` shows up to N snippets per meeting (default 1). When a meeting matched semantically but contains none of the query's literal words, the card shows the best-matching passage without highlights; a meeting that matched only by its title says `title match`. The relevance score is not shown in the card view; `--json` carries it (`score`), along with which retrievers surfaced each meeting (`signals`), the full match list, and snippet highlight offsets. `--min-score` still drops results below a relevance threshold; it conflicts with `--fast`, `--keyword`, `--semantic`, `--context`, and `--speaker`, since only the rerank stage produces that score. Hybrid search supports `--in`, `--meeting`, date filters, and `--limit` (which counts meetings), and conflicts with `--semantic`, `--context`, and `--speaker`; `--hybrid` still works as an explicit (redundant) way to ask for it.
 
 Reranking takes roughly 2.2 seconds per query on CPU, most of it model inference. `--fast` skips the rerank stage and returns fusion-order results (no relevance scores) in about 75 milliseconds, and now works directly on a bare search instead of requiring `--hybrid`. It conflicts with `--keyword`, `--semantic`, `--context`, and `--speaker`.
 

--- a/docs/search-roadmap.md
+++ b/docs/search-roadmap.md
@@ -10,6 +10,7 @@ A staged plan to evolve `grans search` from two separate modes (FTS5 keyword, se
 - **Hybrid search** (Phase 2, #40, promoted to the bare `grans search` default via #52 on 2026-07-11): runs both retrievers, truncates each ranked list to a 100-document candidate pool, and fuses by reciprocal rank fusion (k=60) in `query/fusion.rs` + `query/hybrid.rs`. Output is the fused meeting list, reranked by default (see next bullet); `--keyword` and `--semantic` remain the forcing modes (escape hatches to a single retriever), and `--hybrid` is still accepted but redundant.
 - **Reranking** (Phase 3, #41 + follow-up, part of hybrid search by default): a cross-encoder (fastembed `TextRerank`, jina-reranker-v1-turbo-en) scores the top 50 fused candidates as title + best-chunk passages; the ordering formula lives in `query/adjust.rs` (see next bullet). The sigmoid relevance probability is the user-facing score; `--min-score` filters on it; `--fast` skips the stage for fusion-only ordering (~63 ms instead of ~2 s per query).
 - **Ordering adjustments** (Phase 5 part 1, #43): the rerank-stage ordering is `rerank_score + 30 × RRF score + 0.2 × title_signal` (`query/adjust.rs`), where `title_signal` is the fraction of query content tokens found in the meeting title, damped by `log2(1 + series size)` so recurring series sharing one title (the largest spans 123 meetings) don't drown the query. Adjustments are ordering-only: they reorder the fixed 50-candidate pool and never touch the user-facing score. Weights live in `RankingConfig` (defaults are the sweep winners); `benchmark quality` has a hidden `--title-boost-weight` override so one binary can record before/after runs, and non-default weights are appended to the ledger note. A recency prior was swept alongside and rejected (results below).
+- **Shaped output** (#57 part 1): hybrid results render as per-meeting cards with match evidence. Evidence degrades in tiers (`query/evidence.rs`): lexical match sites located with the same Rust-side matchers the `--context` path uses (FTS5 `snippet()`/`highlight()` were considered but the notes/panels FTS indexes are whole-blob, so they cannot yield section labels); the reranker's best chunk when no query term appears literally; a bare `title match` card otherwise. Shaping is presentation-only, runs on the displayed page (not the candidate pool), and never reorders (pinned by test). The numeric score left human output (the ordering blend made the score column non-monotonic, which read as broken); `--json` carries score, signals, and highlight offsets. Keyword/semantic/context modes still render their old flat output; unifying them onto cards is #57 part 2.
 - The modes are mutually exclusive; `commands/search.rs` dispatches on a `SearchMode` enum.
 - **Evaluation** (Phase 0, #38): `grans benchmark quality --file <golden-set.json> --mode fts|semantic` scores any retrieval mode; `--compare fts,semantic` runs several with a per-query rank-of-first-relevant table and win/loss/tie summary. Results match labels by document ID (`relevant_meeting_ids`), falling back to exact title for the v1 file. Reports hit-rate@k, recall@k, MRR@k, and per-mode latency, with per-stratum breakdowns. `--record` appends the run to the results ledger. For rerank modes, `--dump-candidates <path>` writes each query's candidates (fused rank, RRF score, passage, rerank score) as JSONL for offline ranking experiments; dumps carry meeting content and stay outside the repo. Implemented in `commands/benchmark/`.
 
@@ -24,7 +25,7 @@ query
         ↓
  cross-encoder reranker + weighted fusion prior     → top N
         ↓
- per-meeting grouping, recency tiebreak, snippets
+ per-meeting cards with match snippets
 ```
 
 ## How improvement is tracked
@@ -148,6 +149,7 @@ Implementation is tracked on GitHub: parent issue #37 with one sub-issue per pha
 - Phase 3 (#41): cross-encoder reranking
 - Phase 4 (#42): embedding-side experiments (contextual chunk headers, chunking variants)
 - Phase 5 (#43): ranking polish (recency tiebreak, title boost, per-meeting grouping)
+- Result shaping (#57): per-meeting cards with match evidence, spun out of Phase 5
 
 One experiment result worth keeping here because it contradicts the model card's guidance: nomic task prefixes (`search_query:`/`search_document:`) were tested 2026-07 on the current chunking and made no measurable difference. Re-test only if chunking changes materially; Phase 4 kept the chunking unchanged, so the result stands.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -79,6 +79,11 @@ pub enum Commands {
         #[arg(long, conflicts_with_all = ["fast", "keyword", "semantic", "context", "speaker"])]
         min_score: Option<f32>,
 
+        /// Maximum match snippets shown per meeting in hybrid results
+        /// (0 = headers only)
+        #[arg(long, default_value = "1", conflicts_with_all = ["keyword", "semantic", "context", "speaker"])]
+        matches: usize,
+
         /// Context window size: utterances for transcripts, sections for panels, paragraphs for notes (0 = disabled; implies keyword search)
         #[arg(long, default_value = "0")]
         context: usize,

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -398,6 +398,7 @@ mod tests {
                 window_start_idx: None,
                 window_end_idx: None,
                 match_context: None,
+                section_heading: None,
             },
             SemanticSearchResult {
                 document_id: "d2".into(),
@@ -407,6 +408,7 @@ mod tests {
                 window_start_idx: None,
                 window_end_idx: None,
                 match_context: None,
+                section_heading: None,
             },
         ];
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -41,6 +41,8 @@ pub enum SearchMode {
         min_score: Option<f32>,
         yes: bool,
         limit: usize,
+        /// Match snippets shown per meeting card.
+        matches: usize,
     },
 }
 
@@ -63,6 +65,7 @@ impl SearchMode {
         speaker: Option<&SpeakerFilter>,
         yes: bool,
         limit: usize,
+        matches: usize,
     ) -> Self {
         if semantic {
             SearchMode::Semantic {
@@ -94,6 +97,7 @@ impl SearchMode {
                 min_score,
                 yes,
                 limit,
+                matches,
             }
         }
     }
@@ -156,6 +160,7 @@ pub fn search(
             min_score,
             yes,
             limit,
+            matches,
         } => hybrid_search(
             conn,
             query,
@@ -165,6 +170,7 @@ pub fn search(
             min_score,
             yes,
             limit,
+            matches,
             date_range,
             include_deleted,
             ctx,
@@ -233,7 +239,7 @@ fn keyword_search(
 
 /// Run keyword and semantic retrieval, fuse the rankings, rerank the top
 /// candidates (unless skipped via --fast), and display the resulting
-/// meetings.
+/// meetings as shaped cards with match evidence.
 #[allow(clippy::too_many_arguments)]
 fn hybrid_search(
     conn: &Connection,
@@ -244,6 +250,7 @@ fn hybrid_search(
     min_score: Option<f32>,
     yes: bool,
     limit: usize,
+    matches: usize,
     date_range: Option<DateRange>,
     include_deleted: bool,
     ctx: &RunContext,
@@ -267,7 +274,9 @@ fn hybrid_search(
         include_deleted,
     )?;
 
-    if rerank {
+    // Ranked (id, score) pairs; ordering is the pipeline's and is not
+    // touched again below.
+    let ordered: Vec<(String, Option<f32>)> = if rerank {
         let reranker =
             crate::embed::rerank::FastEmbedReranker::new(crate::embed::rerank::DEFAULT_RERANK_MODEL)?;
         let ranking_ctx = crate::query::adjust::RankingContext::load(conn)?;
@@ -283,31 +292,105 @@ fn hybrid_search(
         if let Some(min) = min_score {
             reranked.retain(|d| d.score >= min);
         }
+        reranked.into_iter().map(|d| (d.document_id, Some(d.score))).collect()
+    } else {
+        ranking.fused.iter().map(|d| (d.document_id.clone(), None)).collect()
+    };
 
-        let ids: Vec<String> = reranked.iter().map(|d| d.document_id.clone()).collect();
-        let docs = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
-        let scores: std::collections::HashMap<String, f32> =
-            reranked.into_iter().map(|d| (d.document_id, d.score)).collect();
-        let results: Vec<(Document, f32)> = docs
-            .into_iter()
-            .filter_map(|doc| {
-                let score = doc.id.as_ref().and_then(|id| scores.get(id)).copied()?;
-                Some((doc, score))
-            })
-            .collect();
+    let ids: Vec<String> = ordered.iter().map(|(id, _)| id.clone()).collect();
+    let docs = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
+    let mut doc_by_id: std::collections::HashMap<String, Document> =
+        docs.into_iter().filter_map(|d| d.id.clone().map(|id| (id, d))).collect();
+    let ordered_docs: Vec<(Document, Option<f32>)> = ordered
+        .into_iter()
+        .filter_map(|(id, score)| doc_by_id.remove(&id).map(|doc| (doc, score)))
+        .collect();
 
-        let results = filter_scored_by_meeting(results, meeting_filter);
-        render_scored_meeting_list(results, query, limit, ctx);
-        return Ok(());
-    }
+    let filter_lower = meeting_filter.map(str::to_lowercase);
+    let filtered: Vec<(Document, Option<f32>)> = ordered_docs
+        .into_iter()
+        .filter(|(doc, _)| {
+            filter_lower.as_deref().is_none_or(|f| matches_meeting_filter(doc, f))
+        })
+        .collect();
 
-    let ids: Vec<String> = ranking.fused.into_iter().map(|d| d.document_id).collect();
-    let results = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
+    let total = filtered.len();
+    let page = apply_limit(filtered, limit);
 
-    let results = filter_by_meeting(results, meeting_filter);
-    render_meeting_list(results, query, limit, ctx);
+    let tokens = crate::query::fts::parse_query(query);
+    let limits = crate::query::evidence::EvidenceLimits {
+        max_matches: matches,
+        ..Default::default()
+    };
+    let shaped = shape_page(conn, &page, &ranking, &tokens, &limits)?;
 
+    render_shaped_meeting_list(&shaped, query, total, limit, ctx);
     Ok(())
+}
+
+/// Shape one display page of ranked documents into meeting cards, in the
+/// order given.
+fn shape_page(
+    conn: &Connection,
+    page: &[(Document, Option<f32>)],
+    ranking: &crate::query::hybrid::HybridRanking,
+    tokens: &[crate::query::fts::FtsToken],
+    limits: &crate::query::evidence::EvidenceLimits,
+) -> Result<Vec<crate::query::shape::ShapedMeeting>> {
+    page.iter()
+        .map(|(doc, score)| {
+            let doc_id = doc.id.as_deref().unwrap_or_default();
+            let facts = crate::query::evidence::RankingFacts {
+                keyword: ranking.keyword_ids.contains(doc_id),
+                best_chunk: ranking.best_chunks.get(doc_id),
+                score: *score,
+            };
+            crate::query::evidence::shape_meeting(conn, doc, tokens, &facts, limits)
+        })
+        .collect()
+}
+
+/// Print shaped meeting cards, honoring the output mode.
+fn render_shaped_meeting_list(
+    shaped: &[crate::query::shape::ShapedMeeting],
+    query: &str,
+    total: usize,
+    limit: usize,
+    ctx: &RunContext,
+) {
+    match ctx.output_mode {
+        OutputMode::Json => {
+            println!(
+                "{}",
+                crate::output::json::format_shaped_meetings(shaped, query, total, limit)
+            );
+        }
+        OutputMode::Tty => {
+            if shaped.is_empty() {
+                println!("No meetings found matching \"{}\".", query);
+                return;
+            }
+            if total > shaped.len() {
+                println!(
+                    "Found {} meeting(s) matching \"{}\" (showing {}):\n",
+                    total,
+                    query,
+                    shaped.len()
+                );
+            } else {
+                println!("Found {} meeting(s) matching \"{}\":\n", shaped.len(), query);
+            }
+            for (i, meeting) in shaped.iter().enumerate() {
+                println!(
+                    "{}\n",
+                    crate::output::card::format_shaped_meeting(meeting, i + 1, &ctx.tz)
+                );
+            }
+            if total > shaped.len() {
+                println!("Use --limit 0 to show all {} results.", total);
+            }
+        }
+    }
 }
 
 /// True when the document's title or id contains the lowercased filter.
@@ -331,18 +414,6 @@ fn filter_by_meeting(results: Vec<Document>, meeting_filter: Option<&str>) -> Ve
     };
     let filter_lower = filter.to_lowercase();
     results.into_iter().filter(|doc| matches_meeting_filter(doc, &filter_lower)).collect()
-}
-
-/// [`filter_by_meeting`] for scored results.
-fn filter_scored_by_meeting(
-    results: Vec<(Document, f32)>,
-    meeting_filter: Option<&str>,
-) -> Vec<(Document, f32)> {
-    let Some(filter) = meeting_filter else {
-        return results;
-    };
-    let filter_lower = filter.to_lowercase();
-    results.into_iter().filter(|(doc, _)| matches_meeting_filter(doc, &filter_lower)).collect()
 }
 
 /// Print a ranked meeting list, honoring the output mode and result limit.
@@ -373,49 +444,6 @@ fn render_meeting_list(results: Vec<Document>, query: &str, limit: usize, ctx: &
             }
             for doc in &results {
                 println!("{}", crate::output::table::format_meeting_row(doc, &ctx.tz));
-            }
-            if total > results.len() {
-                println!("\nUse --limit 0 to show all {} results.", total);
-            }
-        }
-    }
-}
-
-/// Print a reranked meeting list with relevance scores, honoring the
-/// output mode and result limit.
-fn render_scored_meeting_list(
-    results: Vec<(Document, f32)>,
-    query: &str,
-    limit: usize,
-    ctx: &RunContext,
-) {
-    let total = results.len();
-    let results = apply_limit(results, limit);
-
-    match ctx.output_mode {
-        OutputMode::Json => {
-            println!("{}", crate::output::json::format_scored_meetings(&results));
-        }
-        OutputMode::Tty => {
-            if results.is_empty() {
-                println!("No meetings found matching \"{}\".", query);
-                return;
-            }
-            if total > results.len() {
-                println!(
-                    "Found {} meeting(s) matching \"{}\" (showing {}):\n",
-                    total,
-                    query,
-                    results.len()
-                );
-            } else {
-                println!("Found {} meeting(s) matching \"{}\":\n", results.len(), query);
-            }
-            for (doc, score) in &results {
-                println!(
-                    "{}",
-                    crate::output::table::format_scored_meeting_row(doc, *score, &ctx.tz)
-                );
             }
             if total > results.len() {
                 println!("\nUse --limit 0 to show all {} results.", total);
@@ -887,7 +915,7 @@ mod tests {
     #[test]
     fn from_cli_args_defaults_to_hybrid() {
         let mode = SearchMode::from_cli_args(
-            false, None, false, false, 0, "titles,notes", None, None, false, 10,
+            false, None, false, false, 0, "titles,notes", None, None, false, 10, 1,
         );
         match mode {
             SearchMode::Hybrid {
@@ -897,6 +925,7 @@ mod tests {
                 min_score,
                 yes,
                 limit,
+                matches,
             } => {
                 assert_eq!(targets.len(), 2);
                 assert!(targets.contains(&SearchTarget::Titles));
@@ -906,7 +935,67 @@ mod tests {
                 assert_eq!(min_score, None);
                 assert!(!yes);
                 assert_eq!(limit, 10);
+                assert_eq!(matches, 1);
             }
+            _ => panic!("Expected Hybrid variant"),
+        }
+    }
+
+    #[test]
+    fn shape_page_preserves_ranking_order_and_scores() {
+        // Shaping is presentation-only: the cards must come back in exactly
+        // the order the ranked page was handed in, whatever the db returns.
+        use crate::db::test_fixtures::build_test_db;
+        use serde_json::json;
+
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-a": {"id": "doc-a", "title": "Alpha", "created_at": "2026-01-01T10:00:00Z"},
+                "doc-b": {"id": "doc-b", "title": "Beta", "created_at": "2026-01-02T10:00:00Z"},
+                "doc-c": {"id": "doc-c", "title": "Gamma", "created_at": "2026-01-03T10:00:00Z"}
+            }
+        }));
+        let docs = crate::db::meetings::get_meetings_by_ids(
+            &conn,
+            &["doc-c".to_string(), "doc-a".to_string(), "doc-b".to_string()],
+        )
+        .unwrap();
+        let mut by_id: std::collections::HashMap<String, Document> =
+            docs.into_iter().map(|d| (d.id.clone().unwrap(), d)).collect();
+        let page: Vec<(Document, Option<f32>)> = vec![
+            (by_id.remove("doc-c").unwrap(), Some(0.5)),
+            (by_id.remove("doc-a").unwrap(), Some(0.9)),
+            (by_id.remove("doc-b").unwrap(), None),
+        ];
+        let ranking = crate::query::hybrid::HybridRanking {
+            fused: Vec::new(),
+            best_chunks: std::collections::HashMap::new(),
+            keyword_ids: std::collections::HashSet::new(),
+        };
+
+        let shaped = shape_page(
+            &conn,
+            &page,
+            &ranking,
+            &crate::query::fts::parse_query("alpha"),
+            &crate::query::evidence::EvidenceLimits::default(),
+        )
+        .unwrap();
+
+        let ids: Vec<&str> = shaped.iter().map(|m| m.document_id.as_str()).collect();
+        assert_eq!(ids, vec!["doc-c", "doc-a", "doc-b"]);
+        assert_eq!(shaped[0].score, Some(0.5));
+        assert_eq!(shaped[1].score, Some(0.9));
+        assert_eq!(shaped[2].score, None);
+    }
+
+    #[test]
+    fn from_cli_args_matches_threads_to_hybrid() {
+        let mode = SearchMode::from_cli_args(
+            false, None, false, false, 0, "titles", None, None, false, 10, 3,
+        );
+        match mode {
+            SearchMode::Hybrid { matches, .. } => assert_eq!(matches, 3),
             _ => panic!("Expected Hybrid variant"),
         }
     }
@@ -914,7 +1003,7 @@ mod tests {
     #[test]
     fn from_cli_args_keyword_flag_forces_keyword() {
         let mode = SearchMode::from_cli_args(
-            false, None, true, false, 0, "titles,notes", Some("standup"), None, false, 10,
+            false, None, true, false, 0, "titles,notes", Some("standup"), None, false, 10, 1,
         );
         match mode {
             SearchMode::Keyword {
@@ -935,7 +1024,7 @@ mod tests {
     #[test]
     fn from_cli_args_fast_skips_rerank() {
         let mode = SearchMode::from_cli_args(
-            true, None, false, false, 0, "titles", None, None, false, 10,
+            true, None, false, false, 0, "titles", None, None, false, 10, 1,
         );
         match mode {
             SearchMode::Hybrid { rerank, .. } => assert!(!rerank),
@@ -946,7 +1035,7 @@ mod tests {
     #[test]
     fn from_cli_args_min_score_threads_to_hybrid() {
         let mode = SearchMode::from_cli_args(
-            false, Some(0.4), false, false, 0, "titles", None, None, false, 10,
+            false, Some(0.4), false, false, 0, "titles", None, None, false, 10, 1,
         );
         match mode {
             SearchMode::Hybrid { min_score, .. } => assert_eq!(min_score, Some(0.4)),
@@ -956,7 +1045,7 @@ mod tests {
 
     #[test]
     fn from_cli_args_semantic_takes_priority() {
-        let mode = SearchMode::from_cli_args(false, None, false, true, 5, "titles", Some("standup"), None, true, 10);
+        let mode = SearchMode::from_cli_args(false, None, false, true, 5, "titles", Some("standup"), None, true, 10, 1);
         match mode {
             SearchMode::Semantic {
                 targets,
@@ -976,7 +1065,7 @@ mod tests {
 
     #[test]
     fn from_cli_args_context_forces_context_window() {
-        let mode = SearchMode::from_cli_args(false, None, false, false, 3, "titles,notes", Some("standup"), None, false, 10);
+        let mode = SearchMode::from_cli_args(false, None, false, false, 3, "titles,notes", Some("standup"), None, false, 10, 1);
         match mode {
             SearchMode::ContextWindow {
                 targets,
@@ -1000,7 +1089,7 @@ mod tests {
     fn from_cli_args_speaker_routes_bare_search_to_keyword() {
         let speaker = SpeakerFilter::Me;
         let mode = SearchMode::from_cli_args(
-            false, None, false, false, 0, "transcripts", None, Some(&speaker), false, 10,
+            false, None, false, false, 0, "transcripts", None, Some(&speaker), false, 10, 1,
         );
         match mode {
             SearchMode::Keyword { .. } => {}
@@ -1011,7 +1100,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_hybrid() {
         let mode =
-            SearchMode::from_cli_args(false, None, false, false, 0, "transcripts", Some("daily"), None, false, 10);
+            SearchMode::from_cli_args(false, None, false, false, 0, "transcripts", Some("daily"), None, false, 10, 1);
         match mode {
             SearchMode::Hybrid {
                 meeting_filter, ..
@@ -1025,7 +1114,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_keyword() {
         let mode =
-            SearchMode::from_cli_args(false, None, true, false, 0, "transcripts", Some("daily"), None, false, 10);
+            SearchMode::from_cli_args(false, None, true, false, 0, "transcripts", Some("daily"), None, false, 10, 1);
         match mode {
             SearchMode::Keyword {
                 meeting_filter, ..
@@ -1039,7 +1128,7 @@ mod tests {
     #[test]
     fn from_cli_args_meeting_filter_threads_to_context_window() {
         let mode =
-            SearchMode::from_cli_args(false, None, false, false, 5, "titles", Some("retro"), None, false, 10);
+            SearchMode::from_cli_args(false, None, false, false, 5, "titles", Some("retro"), None, false, 10, 1);
         match mode {
             SearchMode::ContextWindow {
                 meeting_filter, ..
@@ -1053,7 +1142,7 @@ mod tests {
     #[test]
     fn from_cli_args_speaker_filter_threads_to_context_window() {
         let speaker = SpeakerFilter::Me;
-        let mode = SearchMode::from_cli_args(false, None, false, false, 3, "transcripts", None, Some(&speaker), false, 10);
+        let mode = SearchMode::from_cli_args(false, None, false, false, 3, "transcripts", None, Some(&speaker), false, 10, 1);
         match mode {
             SearchMode::ContextWindow {
                 speaker_filter, ..
@@ -1067,7 +1156,7 @@ mod tests {
     #[test]
     fn from_cli_args_speaker_filter_threads_to_semantic() {
         let speaker = SpeakerFilter::Other;
-        let mode = SearchMode::from_cli_args(false, None, false, true, 0, "transcripts", None, Some(&speaker), false, 10);
+        let mode = SearchMode::from_cli_args(false, None, false, true, 0, "transcripts", None, Some(&speaker), false, 10, 1);
         match mode {
             SearchMode::Semantic {
                 speaker_filter, ..

--- a/src/embed/search.rs
+++ b/src/embed/search.rs
@@ -15,6 +15,8 @@ pub struct SemanticSearchResult {
     pub window_end_idx: Option<usize>,
     /// Human-readable context for where the match came from (e.g. "AI notes: Budget Review").
     pub match_context: Option<String>,
+    /// Raw panel section heading for `panel_section` chunks.
+    pub section_heading: Option<String>,
 }
 
 /// Compute cosine similarity between two vectors.
@@ -51,19 +53,24 @@ fn parse_window_indices(metadata_json: &Option<String>) -> (Option<usize>, Optio
     (None, None)
 }
 
-/// Extract human-readable context from a chunk's source type and metadata.
-fn extract_match_context(source_type: &str, metadata_json: &Option<String>) -> Option<String> {
+/// Extract the panel section heading from a chunk's metadata, when present.
+fn extract_section_heading(source_type: &str, metadata_json: &Option<String>) -> Option<String> {
+    if source_type != "panel_section" {
+        return None;
+    }
+    metadata_json
+        .as_ref()
+        .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
+        .and_then(|meta| meta.get("section_heading")?.as_str().map(|s| s.to_string()))
+}
+
+/// Format human-readable context from a chunk's source type and section heading.
+fn extract_match_context(source_type: &str, section_heading: Option<&str>) -> Option<String> {
     match source_type {
-        "panel_section" => {
-            let heading = metadata_json
-                .as_ref()
-                .and_then(|json| serde_json::from_str::<serde_json::Value>(json).ok())
-                .and_then(|meta| meta.get("section_heading")?.as_str().map(|s| s.to_string()));
-            Some(match heading {
-                Some(h) => format!("AI notes: {}", h),
-                None => "AI notes".to_string(),
-            })
-        }
+        "panel_section" => Some(match section_heading {
+            Some(h) => format!("AI notes: {}", h),
+            None => "AI notes".to_string(),
+        }),
         "notes_paragraph" => Some("your notes".to_string()),
         _ => None,
     }
@@ -95,7 +102,8 @@ pub fn rank_results(
         }
 
         let (window_start_idx, window_end_idx) = parse_window_indices(&sv.metadata_json);
-        let match_context = extract_match_context(&sv.source_type, &sv.metadata_json);
+        let section_heading = extract_section_heading(&sv.source_type, &sv.metadata_json);
+        let match_context = extract_match_context(&sv.source_type, section_heading.as_deref());
 
         let entry = doc_best
             .entry(&sv.document_id)
@@ -107,6 +115,7 @@ pub fn rank_results(
                 window_start_idx,
                 window_end_idx,
                 match_context,
+                section_heading,
             });
 
         if score > entry.score {
@@ -115,7 +124,9 @@ pub fn rank_results(
             entry.matched_text = sv.text.clone();
             entry.window_start_idx = window_start_idx;
             entry.window_end_idx = window_end_idx;
-            entry.match_context = extract_match_context(&sv.source_type, &sv.metadata_json);
+            entry.section_heading = extract_section_heading(&sv.source_type, &sv.metadata_json);
+            entry.match_context =
+                extract_match_context(&sv.source_type, entry.section_heading.as_deref());
         }
     }
 
@@ -375,28 +386,41 @@ mod tests {
 
     #[test]
     fn test_match_context_panel_section() {
-        let ctx = extract_match_context(
-            "panel_section",
-            &Some(serde_json::json!({"section_heading": "Budget Review"}).to_string()),
-        );
+        let ctx = extract_match_context("panel_section", Some("Budget Review"));
         assert_eq!(ctx, Some("AI notes: Budget Review".to_string()));
     }
 
     #[test]
     fn test_match_context_panel_section_no_heading() {
-        let ctx = extract_match_context("panel_section", &None);
+        let ctx = extract_match_context("panel_section", None);
         assert_eq!(ctx, Some("AI notes".to_string()));
     }
 
     #[test]
     fn test_match_context_notes_paragraph() {
-        let ctx = extract_match_context("notes_paragraph", &None);
+        let ctx = extract_match_context("notes_paragraph", None);
         assert_eq!(ctx, Some("your notes".to_string()));
     }
 
     #[test]
     fn test_match_context_transcript_window() {
-        let ctx = extract_match_context("transcript_window", &None);
+        let ctx = extract_match_context("transcript_window", None);
         assert_eq!(ctx, None);
+    }
+
+    #[test]
+    fn test_section_heading_extraction() {
+        let heading = extract_section_heading(
+            "panel_section",
+            &Some(serde_json::json!({"section_heading": "Budget Review"}).to_string()),
+        );
+        assert_eq!(heading, Some("Budget Review".to_string()));
+        assert_eq!(extract_section_heading("panel_section", &None), None);
+        // Only panel sections carry headings, whatever the metadata says.
+        let heading = extract_section_heading(
+            "transcript_window",
+            &Some(serde_json::json!({"section_heading": "X"}).to_string()),
+        );
+        assert_eq!(heading, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn main() -> Result<()> {
             hybrid: _,
             fast,
             min_score,
+            matches,
             context,
             meeting,
             from,
@@ -128,6 +129,7 @@ fn main() -> Result<()> {
                 speaker.as_ref(),
                 *yes,
                 *limit,
+                *matches,
             );
             let date_range = query::dates::build_date_range(
                 from.as_deref(),

--- a/src/output/card.rs
+++ b/src/output/card.rs
@@ -1,0 +1,332 @@
+//! TTY rendering for shaped search results: one card per meeting with the
+//! match evidence underneath.
+//!
+//! Color degrades automatically: `--no-color` disables ANSI globally via
+//! `colored::control::set_override`, so the same renderer serves colored
+//! and plain output.
+
+use chrono::FixedOffset;
+use colored::Colorize;
+
+use crate::query::shape::{EvidenceSource, Excerpt, MatchEvidence, ShapedMeeting};
+
+/// Card body indent, sized to clear the rank gutter.
+const INDENT: &str = "    ";
+/// Snippet wrap width in characters, excluding the indent.
+const SNIPPET_WRAP: usize = 72;
+
+/// Human label for an evidence source.
+fn source_label(source: EvidenceSource) -> &'static str {
+    match source {
+        EvidenceSource::Transcript => "transcript",
+        EvidenceSource::Panel => "AI notes",
+        EvidenceSource::Notes => "your notes",
+    }
+}
+
+/// Render one shaped meeting as a card: header line, evidence blocks, and
+/// the collapse line when more matches exist than are shown.
+pub fn format_shaped_meeting(m: &ShapedMeeting, rank: usize, tz: &FixedOffset) -> String {
+    let mut lines = vec![header_line(m, rank, tz)];
+
+    for evidence in &m.matches {
+        lines.push(format!("{INDENT}{}", source_line(evidence, tz)));
+        lines.push(snippet_block(&evidence.excerpt));
+    }
+    if m.matches.is_empty() && m.signals.title {
+        lines.push(format!("{INDENT}{}", "title match".dimmed().italic()));
+    }
+    if let Some(line) = collapse_line(m) {
+        lines.push(format!("{INDENT}{}", line.dimmed()));
+    }
+
+    lines.join("\n")
+}
+
+/// `NN. <id> <date> <title>` — the same column order and styling as the
+/// unshaped meeting rows, with a rank gutter in front.
+fn header_line(m: &ShapedMeeting, rank: usize, tz: &FixedOffset) -> String {
+    let id: String = m.document_id.chars().take(8).collect();
+    let date = m
+        .created_at
+        .as_deref()
+        .map(|d| super::table::format_date_short(d, tz))
+        .unwrap_or_default();
+    let title = m.title.as_deref().unwrap_or("(untitled)");
+    format!(
+        "{} {} {} {}",
+        format!("{rank:>2}.").dimmed(),
+        id.dimmed(),
+        date.dimmed(),
+        title.bold()
+    )
+}
+
+/// `transcript › 10:14:07 You`, `AI notes › Migration Plan`, `your notes`.
+fn source_line(evidence: &MatchEvidence, tz: &FixedOffset) -> String {
+    let label = source_label(evidence.source).dimmed();
+    let mut details = Vec::new();
+    if let Some(ts) = evidence.timestamp.as_deref() {
+        details.push(super::table::format_time_only(ts, tz).dimmed().to_string());
+    }
+    match evidence.speaker.as_deref() {
+        Some("microphone") => details.push("You".cyan().to_string()),
+        Some("system") => details.push("Other".dimmed().to_string()),
+        _ => {}
+    }
+    if let Some(section) = evidence.section.as_deref() {
+        details.push(section.dimmed().to_string());
+    }
+
+    if details.is_empty() {
+        label.to_string()
+    } else {
+        format!("{} {} {}", label, "›".dimmed(), details.join(" "))
+    }
+}
+
+/// The quoted snippet, word-wrapped with a hanging indent, query terms
+/// emphasized.
+fn snippet_block(excerpt: &Excerpt) -> String {
+    let ranges = wrap_ranges(&excerpt.text, SNIPPET_WRAP);
+    let last = ranges.len().saturating_sub(1);
+    ranges
+        .iter()
+        .enumerate()
+        .map(|(i, &(start, end))| {
+            let body = render_span(excerpt, start, end);
+            let open = if i == 0 { "\"" } else { " " };
+            let close = if i == last { "\"" } else { "" };
+            format!("{INDENT}{open}{body}{close}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Render `excerpt.text[start..end]` (char indices) with the highlight
+/// spans that fall inside it emphasized.
+fn render_span(excerpt: &Excerpt, start: usize, end: usize) -> String {
+    let chars: Vec<char> = excerpt.text.chars().collect();
+    let mut out = String::new();
+    let mut pos = start;
+    for &(hs, he) in &excerpt.highlights {
+        let (hs, he) = (hs.max(start), he.min(end));
+        if hs >= he || hs < pos {
+            continue;
+        }
+        out.extend(&chars[pos..hs]);
+        let term: String = chars[hs..he].iter().collect();
+        out.push_str(&term.yellow().bold().to_string());
+        pos = he;
+    }
+    out.extend(&chars[pos..end]);
+    out
+}
+
+/// Word-wrap `text` at `width` characters, returning char ranges per line.
+/// Breaks at spaces (the space is consumed); a single overlong word breaks
+/// hard at the width.
+fn wrap_ranges(text: &str, width: usize) -> Vec<(usize, usize)> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while chars.len() - start > width {
+        let window_end = start + width;
+        let break_at = (start..window_end).rev().find(|&i| chars[i] == ' ');
+        match break_at {
+            Some(space) if space > start => {
+                ranges.push((start, space));
+                start = space + 1;
+            }
+            _ => {
+                ranges.push((start, window_end));
+                start = window_end;
+            }
+        }
+    }
+    ranges.push((start, chars.len()));
+    ranges
+}
+
+/// `+N more match(es) in <sources>` when matches were collapsed.
+fn collapse_line(m: &ShapedMeeting) -> Option<String> {
+    let hidden = m.total_matches.saturating_sub(m.matches.len());
+    if hidden == 0 {
+        return None;
+    }
+    let noun = if hidden == 1 { "match" } else { "matches" };
+    let sources = match m
+        .remaining_sources
+        .iter()
+        .map(|&s| source_label(s))
+        .collect::<Vec<_>>()
+        .as_slice()
+    {
+        [] => String::new(),
+        labels => format!(" in {}", labels.join(" and ")),
+    };
+    Some(format!("+{hidden} more {noun}{sources}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::shape::Signals;
+    use chrono::FixedOffset;
+
+    fn utc() -> FixedOffset {
+        FixedOffset::east_opt(0).unwrap()
+    }
+
+    fn strip(s: &str) -> String {
+        strip_ansi_escapes::strip_str(s)
+    }
+
+    fn base_meeting() -> ShapedMeeting {
+        ShapedMeeting {
+            document_id: "abcdef01-2345-6789".to_string(),
+            title: Some("Weekly Infra Sync".to_string()),
+            created_at: Some("2026-05-12T14:30:00Z".to_string()),
+            score: Some(0.63),
+            signals: Signals { keyword: true, semantic: true, title: false },
+            total_matches: 1,
+            matches: vec![MatchEvidence {
+                source: EvidenceSource::Panel,
+                excerpt: Excerpt {
+                    text: "created database snapshots before the migration".to_string(),
+                    highlights: vec![(8, 16), (38, 47)],
+                },
+                speaker: None,
+                timestamp: None,
+                section: Some("Migration Plan".to_string()),
+            }],
+            remaining_sources: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn card_header_carries_rank_id_date_and_title() {
+        let out = strip(&format_shaped_meeting(&base_meeting(), 3, &utc()));
+        let header = out.lines().next().unwrap();
+        assert_eq!(header, " 3. abcdef01 2026-05-12 14:30 Weekly Infra Sync");
+    }
+
+    #[test]
+    fn card_shows_no_numeric_score() {
+        let out = strip(&format_shaped_meeting(&base_meeting(), 1, &utc()));
+        assert!(!out.contains("0.63"), "score leaked into card:\n{out}");
+    }
+
+    #[test]
+    fn panel_evidence_shows_source_and_section() {
+        let out = strip(&format_shaped_meeting(&base_meeting(), 1, &utc()));
+        assert!(out.contains("    AI notes › Migration Plan"), "got:\n{out}");
+    }
+
+    #[test]
+    fn snippet_renders_quoted() {
+        let out = strip(&format_shaped_meeting(&base_meeting(), 1, &utc()));
+        assert!(
+            out.contains("    \"created database snapshots before the migration\""),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn highlights_are_emphasized_in_color_mode() {
+        colored::control::set_override(true);
+        let m = base_meeting();
+        let out = format_shaped_meeting(&m, 1, &utc());
+        colored::control::unset_override();
+        // The highlighted term carries ANSI styling; its neighbors do not.
+        assert!(out.contains("\u{1b}["), "no ANSI emitted:\n{out:?}");
+        assert!(strip(&out).contains("database"));
+    }
+
+    #[test]
+    fn transcript_evidence_shows_time_and_speaker() {
+        let mut m = base_meeting();
+        m.matches = vec![MatchEvidence {
+            source: EvidenceSource::Transcript,
+            excerpt: Excerpt { text: "say the migration runs".to_string(), highlights: vec![] },
+            speaker: Some("microphone".to_string()),
+            timestamp: Some("2026-05-12T14:31:07Z".to_string()),
+            section: None,
+        }];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains("    transcript › 14:31:07 You"), "got:\n{out}");
+    }
+
+    #[test]
+    fn notes_evidence_has_bare_source_line() {
+        let mut m = base_meeting();
+        m.matches[0].source = EvidenceSource::Notes;
+        m.matches[0].section = None;
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains("    your notes\n"), "got:\n{out}");
+    }
+
+    #[test]
+    fn title_only_card_says_so() {
+        let mut m = base_meeting();
+        m.matches.clear();
+        m.total_matches = 0;
+        m.signals.title = true;
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains("    title match"), "got:\n{out}");
+    }
+
+    #[test]
+    fn collapse_line_reports_hidden_matches_and_sources() {
+        let mut m = base_meeting();
+        m.total_matches = 4;
+        m.remaining_sources = vec![EvidenceSource::Notes, EvidenceSource::Transcript];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(
+            out.contains("    +3 more matches in your notes and transcript"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn collapse_line_singular_without_sources() {
+        let mut m = base_meeting();
+        m.total_matches = 2;
+        m.remaining_sources = vec![EvidenceSource::Panel];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains("    +1 more match in AI notes"), "got:\n{out}");
+    }
+
+    #[test]
+    fn long_snippets_wrap_with_hanging_indent() {
+        let mut m = base_meeting();
+        m.matches[0].excerpt = Excerpt {
+            text: "alpha beta gamma delta ".repeat(8).trim_end().to_string(),
+            highlights: vec![],
+        };
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        let snippet_lines: Vec<&str> =
+            out.lines().filter(|l| l.contains("alpha")).collect();
+        assert!(snippet_lines.len() > 1, "expected wrapping:\n{out}");
+        assert!(snippet_lines[0].starts_with("    \""));
+        assert!(snippet_lines[1].starts_with("     "));
+        assert!(out.trim_end().ends_with('"'));
+        for line in &snippet_lines {
+            assert!(line.chars().count() <= 4 + 1 + SNIPPET_WRAP + 1, "overlong: {line}");
+        }
+    }
+
+    #[test]
+    fn highlight_split_across_wrap_boundary_survives() {
+        // A highlight that would straddle a wrap point still renders all
+        // its characters (styling aside).
+        let word = "migration";
+        let text = format!("{} {}", "x".repeat(SNIPPET_WRAP - 4), word);
+        let start = text.chars().count() - word.len();
+        let mut m = base_meeting();
+        m.matches[0].excerpt =
+            Excerpt { text: text.clone(), highlights: vec![(start, start + word.len())] };
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains(word), "highlighted word lost:\n{out}");
+    }
+}

--- a/src/output/card.rs
+++ b/src/output/card.rs
@@ -163,7 +163,9 @@ fn collapse_line(m: &ShapedMeeting) -> Option<String> {
         .as_slice()
     {
         [] => String::new(),
-        labels => format!(" in {}", labels.join(" and ")),
+        [one] => format!(" in {one}"),
+        [a, b] => format!(" in {a} and {b}"),
+        [head @ .., last] => format!(" in {}, and {last}", head.join(", ")),
     };
     Some(format!("+{hidden} more {noun}{sources}"))
 }
@@ -284,6 +286,24 @@ mod tests {
         let out = strip(&format_shaped_meeting(&m, 1, &utc()));
         assert!(
             out.contains("    +3 more matches in your notes and transcript"),
+            "got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn collapse_line_lists_three_sources_with_commas() {
+        // --matches 0 collapses everything, so all three sources can appear.
+        let mut m = base_meeting();
+        m.matches.clear();
+        m.total_matches = 5;
+        m.remaining_sources = vec![
+            EvidenceSource::Panel,
+            EvidenceSource::Notes,
+            EvidenceSource::Transcript,
+        ];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(
+            out.contains("    +5 more matches in AI notes, your notes, and transcript"),
             "got:\n{out}"
         );
     }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -22,23 +22,6 @@ pub fn format_meeting_detail(doc: &Document) -> String {
     to_json(doc)
 }
 
-/// A document with its reranker relevance score.
-#[derive(Debug, Serialize)]
-struct ScoredMeetingJson<'a> {
-    score: f32,
-    #[serde(flatten)]
-    document: &'a Document,
-}
-
-/// Format reranked hybrid results as JSON: each document plus its score.
-pub fn format_scored_meetings(results: &[(Document, f32)]) -> String {
-    let items: Vec<ScoredMeetingJson> = results
-        .iter()
-        .map(|(doc, score)| ScoredMeetingJson { score: *score, document: doc })
-        .collect();
-    to_json(&items)
-}
-
 /// JSON-serializable context window.
 #[derive(Debug, Serialize)]
 pub struct ContextWindowJson {

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -187,6 +187,114 @@ pub struct SemanticSearchResponse<T> {
     pub results: Vec<T>,
 }
 
+/// One match's evidence in shaped search JSON.
+#[derive(Debug, Serialize)]
+pub struct ShapedMatchJson {
+    /// `transcript`, `panel`, or `notes`.
+    pub source: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    pub snippet: String,
+    /// Char ranges `[start, end)` into `snippet` where query terms occur.
+    pub highlights: Vec<(usize, usize)>,
+}
+
+/// One meeting in shaped search JSON.
+#[derive(Debug, Serialize)]
+pub struct ShapedMeetingJson {
+    pub id: String,
+    pub title: Option<String>,
+    pub created_at: Option<String>,
+    /// Cross-encoder relevance; absent under `--fast`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub score: Option<f32>,
+    /// Which retrievers surfaced the meeting: `keyword`, `semantic`, `title`.
+    pub signals: Vec<&'static str>,
+    pub total_matches: usize,
+    pub matches: Vec<ShapedMatchJson>,
+}
+
+/// Response envelope for shaped search results.
+#[derive(Debug, Serialize)]
+pub struct ShapedSearchResponse {
+    pub query: String,
+    pub total_meetings: usize,
+    pub limit: usize,
+    pub returned: usize,
+    pub meetings: Vec<ShapedMeetingJson>,
+}
+
+fn shaped_source_label(source: crate::query::shape::EvidenceSource) -> &'static str {
+    use crate::query::shape::EvidenceSource;
+    match source {
+        EvidenceSource::Transcript => "transcript",
+        EvidenceSource::Panel => "panel",
+        EvidenceSource::Notes => "notes",
+    }
+}
+
+impl ShapedMeetingJson {
+    fn from_shaped(m: &crate::query::shape::ShapedMeeting) -> Self {
+        let mut signals = Vec::new();
+        if m.signals.keyword {
+            signals.push("keyword");
+        }
+        if m.signals.semantic {
+            signals.push("semantic");
+        }
+        if m.signals.title {
+            signals.push("title");
+        }
+        ShapedMeetingJson {
+            id: m.document_id.clone(),
+            title: m.title.clone(),
+            created_at: m.created_at.clone(),
+            score: m.score,
+            signals,
+            total_matches: m.total_matches,
+            matches: m
+                .matches
+                .iter()
+                .map(|ev| ShapedMatchJson {
+                    source: shaped_source_label(ev.source),
+                    speaker: ev.speaker.as_deref().map(|s| match s {
+                        "microphone" => "me".to_string(),
+                        "system" => "other".to_string(),
+                        other => other.to_string(),
+                    }),
+                    timestamp: ev.timestamp.clone(),
+                    section: ev.section.clone(),
+                    snippet: ev.excerpt.text.clone(),
+                    highlights: ev.excerpt.highlights.clone(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Format shaped search results as JSON with metadata.
+pub fn format_shaped_meetings(
+    results: &[crate::query::shape::ShapedMeeting],
+    query: &str,
+    total_meetings: usize,
+    limit: usize,
+) -> String {
+    let meetings: Vec<ShapedMeetingJson> =
+        results.iter().map(ShapedMeetingJson::from_shaped).collect();
+    let response = ShapedSearchResponse {
+        query: query.to_string(),
+        total_meetings,
+        limit,
+        returned: meetings.len(),
+        meetings,
+    };
+    to_json(&response)
+}
+
 /// Format semantic search results as JSON with metadata.
 pub fn format_semantic_results(
     results: &[SemanticSearchResult],
@@ -297,4 +405,62 @@ pub fn format_templates(templates: &[&PanelTemplate]) -> String {
 /// Format a list of recipes as JSON.
 pub fn format_recipes(recipes: &[&Recipe]) -> String {
     to_json(&recipes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::shape::{
+        EvidenceSource, Excerpt, MatchEvidence, ShapedMeeting, Signals,
+    };
+
+    fn shaped() -> ShapedMeeting {
+        ShapedMeeting {
+            document_id: "doc-1".to_string(),
+            title: Some("Infra Sync".to_string()),
+            created_at: Some("2026-05-12T14:30:00Z".to_string()),
+            score: Some(0.63),
+            signals: Signals { keyword: true, semantic: false, title: true },
+            total_matches: 3,
+            matches: vec![MatchEvidence {
+                source: EvidenceSource::Transcript,
+                excerpt: Excerpt {
+                    text: "run the migration tonight".to_string(),
+                    highlights: vec![(8, 17)],
+                },
+                speaker: Some("microphone".to_string()),
+                timestamp: Some("2026-05-12T14:31:07Z".to_string()),
+                section: None,
+            }],
+            remaining_sources: vec![EvidenceSource::Notes],
+        }
+    }
+
+    #[test]
+    fn shaped_json_shape_and_signals() {
+        let out = format_shaped_meetings(&[shaped()], "migration", 12, 10);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["query"], "migration");
+        assert_eq!(v["total_meetings"], 12);
+        assert_eq!(v["returned"], 1);
+        let m = &v["meetings"][0];
+        assert_eq!(m["id"], "doc-1");
+        assert_eq!(m["signals"], serde_json::json!(["keyword", "title"]));
+        assert_eq!(m["total_matches"], 3);
+        let mt = &m["matches"][0];
+        assert_eq!(mt["source"], "transcript");
+        assert_eq!(mt["speaker"], "me");
+        assert_eq!(mt["snippet"], "run the migration tonight");
+        assert_eq!(mt["highlights"], serde_json::json!([[8, 17]]));
+        assert!(mt.get("section").is_none());
+    }
+
+    #[test]
+    fn shaped_json_omits_score_when_rerank_skipped() {
+        let mut m = shaped();
+        m.score = None;
+        let out = format_shaped_meetings(&[m], "q", 1, 0);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v["meetings"][0].get("score").is_none());
+    }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,4 @@
+pub mod card;
 pub mod format;
 pub mod json;
 pub mod progress;

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -48,12 +48,6 @@ fn colored_score(score: f32) -> String {
     }
 }
 
-/// Format a meeting row prefixed with its relevance score (reranked hybrid
-/// search results).
-pub fn format_scored_meeting_row(doc: &Document, score: f32, tz: &FixedOffset) -> String {
-    format!("{} {}", colored_score(score), format_meeting_row(doc, tz))
-}
-
 /// Format a meeting detail view for TTY.
 pub fn format_meeting_detail(doc: &Document, tz: &FixedOffset) -> String {
     let mut lines = Vec::new();

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -534,6 +534,7 @@ mod tests {
             window_start_idx: None,
             window_end_idx: None,
             match_context: None,
+            section_heading: None,
         };
 
         let output = format_semantic_result(&result, &conn, &utc());
@@ -558,6 +559,7 @@ mod tests {
             window_start_idx: None,
             window_end_idx: None,
             match_context: None,
+            section_heading: None,
         };
 
         let output = format_semantic_result(&result, &conn, &utc());

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -454,7 +454,7 @@ fn truncate_text(text: &str, max_len: usize) -> String {
     }
 }
 
-fn format_date_short(s: &str, tz: &FixedOffset) -> String {
+pub(super) fn format_date_short(s: &str, tz: &FixedOffset) -> String {
     // Try to parse and format nicely, fallback to raw string
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
         dt.with_timezone(tz).format("%Y-%m-%d %H:%M").to_string()
@@ -465,7 +465,7 @@ fn format_date_short(s: &str, tz: &FixedOffset) -> String {
     }
 }
 
-fn format_time_only(s: &str, tz: &FixedOffset) -> String {
+pub(super) fn format_time_only(s: &str, tz: &FixedOffset) -> String {
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
         dt.with_timezone(tz).format("%H:%M:%S").to_string()
     } else {

--- a/src/query/evidence.rs
+++ b/src/query/evidence.rs
@@ -1,0 +1,317 @@
+//! Lexical match evidence for one document: where in its panels, notes, and
+//! transcript the query terms actually occur.
+//!
+//! Match semantics mirror the `--context` path exactly: a site matches when
+//! it contains every query token (`matches_all_tokens`), panels split into
+//! sections on the most frequent heading level, notes split into paragraphs.
+//! Sites are collected in display priority order (AI-notes panels first as
+//! the most distilled source, then the user's notes, then the transcript)
+//! and only the first `max_matches` are excerpted.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use crate::models::Document;
+use crate::query::fts::{matches_all_tokens, FtsToken};
+use crate::query::shape::{excerpt_around_match, EvidenceSource, MatchEvidence};
+use crate::query::text::{split_into_paragraphs, split_markdown_sections, strip_panel_footer};
+
+/// Caps on how much evidence is excerpted per document.
+#[derive(Debug, Clone)]
+pub struct EvidenceLimits {
+    /// How many match sites to excerpt (the rest are only counted).
+    pub max_matches: usize,
+    /// Rough excerpt width in characters.
+    pub max_chars: usize,
+}
+
+impl Default for EvidenceLimits {
+    fn default() -> Self {
+        Self { max_matches: 1, max_chars: 160 }
+    }
+}
+
+/// All lexical match evidence for one document.
+#[derive(Debug)]
+pub struct DocumentEvidence {
+    /// Excerpted evidence, at most `max_matches` entries.
+    pub matches: Vec<MatchEvidence>,
+    /// Total match sites in the document, shown or not.
+    pub total: usize,
+    /// Sources of the sites beyond `matches`, deduped in display order.
+    pub remaining_sources: Vec<EvidenceSource>,
+}
+
+/// A match site before excerpting: the source, the matched text, and its
+/// display metadata.
+struct Site {
+    source: EvidenceSource,
+    text: String,
+    speaker: Option<String>,
+    timestamp: Option<String>,
+    section: Option<String>,
+}
+
+/// Collect every lexical match site for `doc` and excerpt the first
+/// `limits.max_matches` of them.
+pub fn collect_document_evidence(
+    conn: &Connection,
+    doc: &Document,
+    tokens: &[FtsToken],
+    limits: &EvidenceLimits,
+) -> Result<DocumentEvidence> {
+    let mut sites = Vec::new();
+
+    if let Some(doc_id) = doc.id.as_deref() {
+        collect_panel_sites(conn, doc_id, tokens, &mut sites)?;
+    }
+    collect_notes_sites(doc.notes_plain.as_deref(), tokens, &mut sites);
+    if let Some(doc_id) = doc.id.as_deref() {
+        collect_transcript_sites(conn, doc_id, tokens, &mut sites)?;
+    }
+
+    let total = sites.len();
+    let mut matches = Vec::new();
+    let mut remaining_sources = Vec::new();
+    for (i, site) in sites.into_iter().enumerate() {
+        if i < limits.max_matches {
+            matches.push(MatchEvidence {
+                source: site.source,
+                excerpt: excerpt_around_match(&site.text, tokens, limits.max_chars),
+                speaker: site.speaker,
+                timestamp: site.timestamp,
+                section: site.section,
+            });
+        } else if !remaining_sources.contains(&site.source) {
+            remaining_sources.push(site.source);
+        }
+    }
+
+    Ok(DocumentEvidence { matches, total, remaining_sources })
+}
+
+/// Panel sections whose body contains every token, in panel order.
+fn collect_panel_sites(
+    conn: &Connection,
+    doc_id: &str,
+    tokens: &[FtsToken],
+    sites: &mut Vec<Site>,
+) -> Result<()> {
+    for panel in crate::db::panels::load_panels(conn, doc_id)? {
+        let Some(markdown) = panel.content_markdown.as_deref().filter(|m| !m.is_empty()) else {
+            continue;
+        };
+        let cleaned = strip_panel_footer(markdown);
+        for (heading, body) in split_markdown_sections(cleaned) {
+            if matches_all_tokens(body, tokens) {
+                sites.push(Site {
+                    source: EvidenceSource::Panel,
+                    text: body.to_string(),
+                    speaker: None,
+                    timestamp: None,
+                    section: heading.map(String::from),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Notes paragraphs that contain every token, in document order.
+fn collect_notes_sites(notes_plain: Option<&str>, tokens: &[FtsToken], sites: &mut Vec<Site>) {
+    let Some(notes) = notes_plain.filter(|n| !n.trim().is_empty()) else {
+        return;
+    };
+    for para in split_into_paragraphs(notes) {
+        if matches_all_tokens(para, tokens) {
+            sites.push(Site {
+                source: EvidenceSource::Notes,
+                text: para.to_string(),
+                speaker: None,
+                timestamp: None,
+                section: None,
+            });
+        }
+    }
+}
+
+/// Transcript utterances that contain every token, in time order.
+fn collect_transcript_sites(
+    conn: &Connection,
+    doc_id: &str,
+    tokens: &[FtsToken],
+    sites: &mut Vec<Site>,
+) -> Result<()> {
+    for utt in crate::db::transcripts::load_transcript(conn, doc_id)? {
+        let Some(text) = utt.text.filter(|t| !t.is_empty()) else {
+            continue;
+        };
+        if matches_all_tokens(&text, tokens) {
+            sites.push(Site {
+                source: EvidenceSource::Transcript,
+                text,
+                speaker: utt.source,
+                timestamp: utt.start_timestamp,
+                section: None,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test_fixtures::build_test_db;
+    use crate::query::fts::parse_query;
+    use serde_json::json;
+
+    fn evidence_state() -> serde_json::Value {
+        json!({
+            "documents": {
+                "doc-1": {
+                    "id": "doc-1",
+                    "title": "Infra Sync",
+                    "created_at": "2026-01-20T10:00:00Z",
+                    "notes_plain": "Reviewed the kumquat rollout.\n\nUnrelated paragraph.\n\nSecond kumquat mention in notes."
+                }
+            },
+            "transcripts": {
+                "doc-1": [
+                    {"id": "u1", "document_id": "doc-1", "text": "Let's discuss the kumquat rollout.",
+                     "start_timestamp": "2026-01-20T10:01:00Z", "end_timestamp": "2026-01-20T10:01:05Z",
+                     "source": "microphone", "is_final": true},
+                    {"id": "u2", "document_id": "doc-1", "text": "Nothing relevant here.",
+                     "start_timestamp": "2026-01-20T10:02:00Z", "end_timestamp": "2026-01-20T10:02:05Z",
+                     "source": "system", "is_final": true},
+                    {"id": "u3", "document_id": "doc-1", "text": "Back to the kumquat question.",
+                     "start_timestamp": "2026-01-20T10:03:00Z", "end_timestamp": "2026-01-20T10:03:05Z",
+                     "source": "system", "is_final": true}
+                ]
+            },
+            "panels": {
+                "doc-1": [
+                    {"id": "panel-1", "document_id": "doc-1", "title": "Summary", "content_json": "{}",
+                     "content_markdown": "### Decisions\n\nShip the kumquat rollout next week.\n\n### Action Items\n\n- Unrelated item",
+                     "template_slug": "meeting-notes", "created_at": "2026-01-20T11:00:00Z"}
+                ]
+            }
+        })
+    }
+
+    fn load_doc(conn: &Connection, id: &str) -> Document {
+        crate::db::meetings::get_meetings_by_ids(conn, &[id.to_string()])
+            .unwrap()
+            .remove(0)
+    }
+
+    fn collect(
+        conn: &Connection,
+        doc: &Document,
+        query: &str,
+        max_matches: usize,
+    ) -> DocumentEvidence {
+        let limits = EvidenceLimits { max_matches, max_chars: 160 };
+        collect_document_evidence(conn, doc, &parse_query(query), &limits).unwrap()
+    }
+
+    #[test]
+    fn counts_every_match_site_across_sources() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "kumquat", 1);
+        // 1 panel section + 2 notes paragraphs + 2 utterances.
+        assert_eq!(ev.total, 5);
+        assert_eq!(ev.matches.len(), 1);
+    }
+
+    #[test]
+    fn panel_evidence_ranks_first_and_carries_its_section() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "kumquat", 1);
+        let m = &ev.matches[0];
+        assert_eq!(m.source, EvidenceSource::Panel);
+        assert_eq!(m.section.as_deref(), Some("Decisions"));
+        assert!(m.excerpt.text.contains("kumquat rollout next week"));
+        assert!(!m.excerpt.highlights.is_empty());
+    }
+
+    #[test]
+    fn evidence_orders_panels_then_notes_then_transcript() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "kumquat", 5);
+        let sources: Vec<EvidenceSource> = ev.matches.iter().map(|m| m.source).collect();
+        assert_eq!(
+            sources,
+            vec![
+                EvidenceSource::Panel,
+                EvidenceSource::Notes,
+                EvidenceSource::Notes,
+                EvidenceSource::Transcript,
+                EvidenceSource::Transcript,
+            ]
+        );
+        assert!(ev.remaining_sources.is_empty());
+    }
+
+    #[test]
+    fn transcript_evidence_carries_speaker_and_timestamp() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "kumquat", 5);
+        let transcript: Vec<_> = ev
+            .matches
+            .iter()
+            .filter(|m| m.source == EvidenceSource::Transcript)
+            .collect();
+        assert_eq!(transcript[0].speaker.as_deref(), Some("microphone"));
+        assert_eq!(transcript[0].timestamp.as_deref(), Some("2026-01-20T10:01:00Z"));
+        assert_eq!(transcript[1].speaker.as_deref(), Some("system"));
+    }
+
+    #[test]
+    fn remaining_sources_dedupe_in_display_order() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "kumquat", 1);
+        assert_eq!(
+            ev.remaining_sources,
+            vec![EvidenceSource::Notes, EvidenceSource::Transcript]
+        );
+    }
+
+    #[test]
+    fn no_match_yields_empty_evidence() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "zyzzyva", 3);
+        assert_eq!(ev.total, 0);
+        assert!(ev.matches.is_empty());
+        assert!(ev.remaining_sources.is_empty());
+    }
+
+    #[test]
+    fn multi_token_query_requires_all_tokens_in_one_site() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        // "kumquat" and "question" only co-occur in utterance u3.
+        let ev = collect(&conn, &doc, "kumquat question", 5);
+        assert_eq!(ev.total, 1);
+        assert_eq!(ev.matches[0].source, EvidenceSource::Transcript);
+        assert_eq!(ev.matches[0].timestamp.as_deref(), Some("2026-01-20T10:03:00Z"));
+    }
+
+    #[test]
+    fn document_without_notes_or_content_matches_nothing() {
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-2": {"id": "doc-2", "title": "Empty", "created_at": "2026-01-01T00:00:00Z"}
+            }
+        }));
+        let doc = load_doc(&conn, "doc-2");
+        let ev = collect(&conn, &doc, "kumquat", 3);
+        assert_eq!(ev.total, 0);
+    }
+}

--- a/src/query/evidence.rs
+++ b/src/query/evidence.rs
@@ -63,6 +63,17 @@ pub fn collect_document_evidence(
     tokens: &[FtsToken],
     limits: &EvidenceLimits,
 ) -> Result<DocumentEvidence> {
+    // An empty query matches nothing, mirroring the FTS empty-phrase
+    // behavior; without this, matches_all_tokens is vacuously true and
+    // every site in the document would count as a match.
+    if tokens.is_empty() {
+        return Ok(DocumentEvidence {
+            matches: Vec::new(),
+            total: 0,
+            remaining_sources: Vec::new(),
+        });
+    }
+
     let mut sites = Vec::new();
 
     if let Some(doc_id) = doc.id.as_deref() {
@@ -123,7 +134,9 @@ pub fn shape_meeting(
         title: doc.title.as_deref().map(|t| title_matches(t, tokens)).unwrap_or(false),
     };
 
-    let (matches, total, remaining_sources) = if !evidence.matches.is_empty() {
+    // Tier on whether lexical evidence exists, not on whether any was
+    // excerpted: --matches 0 keeps matches empty while total still counts.
+    let (matches, total, remaining_sources) = if evidence.total > 0 {
         (evidence.matches, evidence.total, evidence.remaining_sources)
     } else if let Some(m) = facts.best_chunk.and_then(|c| chunk_evidence(c, tokens, limits)) {
         (vec![m], 1, Vec::new())
@@ -468,6 +481,44 @@ mod tests {
         assert!(shaped.signals.keyword);
         assert!(!shaped.signals.semantic);
         assert_eq!(shaped.score, None);
+    }
+
+    #[test]
+    fn matches_zero_keeps_lexical_count_and_never_falls_back_to_the_chunk() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let chunk = best_chunk("some semantic chunk", "transcript_window", None);
+        let facts = RankingFacts { keyword: true, best_chunk: Some(&chunk), score: None };
+        let limits = EvidenceLimits { max_matches: 0, max_chars: 160 };
+
+        let shaped =
+            shape_meeting(&conn, &doc, &parse_query("kumquat"), &facts, &limits).unwrap();
+
+        // Headers-only: no snippets, but the real lexical count and its
+        // sources survive for the collapse line, and the semantic chunk
+        // does not stand in.
+        assert!(shaped.matches.is_empty());
+        assert_eq!(shaped.total_matches, 5);
+        assert_eq!(
+            shaped.remaining_sources,
+            vec![
+                EvidenceSource::Panel,
+                EvidenceSource::Notes,
+                EvidenceSource::Transcript
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_query_yields_no_lexical_evidence() {
+        // An empty query matches nothing lexically (mirroring the FTS
+        // empty-phrase behavior), rather than vacuously matching every
+        // site.
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "", 3);
+        assert_eq!(ev.total, 0);
+        assert!(ev.matches.is_empty());
     }
 
     #[test]

--- a/src/query/evidence.rs
+++ b/src/query/evidence.rs
@@ -13,7 +13,10 @@ use rusqlite::Connection;
 
 use crate::models::Document;
 use crate::query::fts::{matches_all_tokens, FtsToken};
-use crate::query::shape::{excerpt_around_match, EvidenceSource, MatchEvidence};
+use crate::query::hybrid::BestChunk;
+use crate::query::shape::{
+    excerpt_around_match, title_matches, EvidenceSource, MatchEvidence, ShapedMeeting, Signals,
+};
 use crate::query::text::{split_into_paragraphs, split_markdown_sections, strip_panel_footer};
 
 /// Caps on how much evidence is excerpted per document.
@@ -88,6 +91,77 @@ pub fn collect_document_evidence(
     }
 
     Ok(DocumentEvidence { matches, total, remaining_sources })
+}
+
+/// Ranking facts about one document from the hybrid pipeline.
+pub struct RankingFacts<'a> {
+    /// The FTS retriever surfaced this document.
+    pub keyword: bool,
+    /// The document's best semantic chunk, when one exists.
+    pub best_chunk: Option<&'a BestChunk>,
+    /// Cross-encoder relevance when the rerank stage ran.
+    pub score: Option<f32>,
+}
+
+/// Assemble the shaped card for one meeting.
+///
+/// Evidence degrades in tiers: lexical match sites first; when no query
+/// term appears literally in the content, the semantic best chunk stands in
+/// (no highlights); when there is no content evidence at all, the card is a
+/// bare title match.
+pub fn shape_meeting(
+    conn: &Connection,
+    doc: &Document,
+    tokens: &[FtsToken],
+    facts: &RankingFacts,
+    limits: &EvidenceLimits,
+) -> Result<ShapedMeeting> {
+    let evidence = collect_document_evidence(conn, doc, tokens, limits)?;
+    let signals = Signals {
+        keyword: facts.keyword,
+        semantic: facts.best_chunk.is_some(),
+        title: doc.title.as_deref().map(|t| title_matches(t, tokens)).unwrap_or(false),
+    };
+
+    let (matches, total, remaining_sources) = if !evidence.matches.is_empty() {
+        (evidence.matches, evidence.total, evidence.remaining_sources)
+    } else if let Some(m) = facts.best_chunk.and_then(|c| chunk_evidence(c, tokens, limits)) {
+        (vec![m], 1, Vec::new())
+    } else {
+        (Vec::new(), 0, Vec::new())
+    };
+
+    Ok(ShapedMeeting {
+        document_id: doc.id.clone().unwrap_or_default(),
+        title: doc.title.clone(),
+        created_at: doc.created_at.clone(),
+        score: facts.score,
+        signals,
+        total_matches: total,
+        matches,
+        remaining_sources,
+    })
+}
+
+/// Tier-2 evidence: the semantic best chunk, excerpted like any other site.
+fn chunk_evidence(
+    chunk: &BestChunk,
+    tokens: &[FtsToken],
+    limits: &EvidenceLimits,
+) -> Option<MatchEvidence> {
+    let source = match chunk.source_type.as_str() {
+        "transcript_window" => EvidenceSource::Transcript,
+        "panel_section" => EvidenceSource::Panel,
+        "notes_paragraph" => EvidenceSource::Notes,
+        _ => return None,
+    };
+    Some(MatchEvidence {
+        source,
+        excerpt: excerpt_around_match(&chunk.text, tokens, limits.max_chars),
+        speaker: None,
+        timestamp: None,
+        section: chunk.section_heading.clone(),
+    })
 }
 
 /// Panel sections whose body contains every token, in panel order.
@@ -313,5 +387,103 @@ mod tests {
         let doc = load_doc(&conn, "doc-2");
         let ev = collect(&conn, &doc, "kumquat", 3);
         assert_eq!(ev.total, 0);
+    }
+
+    // --- shape_meeting ---
+
+    fn best_chunk(text: &str, source_type: &str, section: Option<&str>) -> BestChunk {
+        BestChunk {
+            text: text.to_string(),
+            source_type: source_type.to_string(),
+            section_heading: section.map(String::from),
+        }
+    }
+
+    fn shape(
+        conn: &Connection,
+        doc: &Document,
+        query: &str,
+        facts: &RankingFacts,
+    ) -> ShapedMeeting {
+        shape_meeting(conn, doc, &parse_query(query), facts, &EvidenceLimits::default()).unwrap()
+    }
+
+    #[test]
+    fn lexical_evidence_outranks_the_semantic_chunk() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let chunk = best_chunk("some semantic chunk", "transcript_window", None);
+        let facts =
+            RankingFacts { keyword: true, best_chunk: Some(&chunk), score: Some(0.9) };
+
+        let shaped = shape(&conn, &doc, "kumquat", &facts);
+
+        assert_eq!(shaped.matches.len(), 1);
+        assert_eq!(shaped.matches[0].source, EvidenceSource::Panel);
+        assert_eq!(shaped.total_matches, 5);
+        assert!(shaped.signals.keyword && shaped.signals.semantic);
+        assert!(!shaped.signals.title);
+        assert_eq!(shaped.score, Some(0.9));
+    }
+
+    #[test]
+    fn semantic_only_match_falls_back_to_the_best_chunk() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        // No content in doc-1 contains "zyzzyva"; the chunk stands in.
+        let chunk = best_chunk(
+            "discussion of adjacent topics",
+            "panel_section",
+            Some("Decisions"),
+        );
+        let facts = RankingFacts { keyword: false, best_chunk: Some(&chunk), score: Some(0.4) };
+
+        let shaped = shape(&conn, &doc, "zyzzyva", &facts);
+
+        assert_eq!(shaped.matches.len(), 1);
+        assert_eq!(shaped.matches[0].source, EvidenceSource::Panel);
+        assert_eq!(shaped.matches[0].section.as_deref(), Some("Decisions"));
+        assert_eq!(shaped.matches[0].excerpt.text, "discussion of adjacent topics");
+        assert!(shaped.matches[0].excerpt.highlights.is_empty());
+        assert_eq!(shaped.total_matches, 1);
+        assert!(!shaped.signals.keyword);
+        assert!(shaped.signals.semantic);
+    }
+
+    #[test]
+    fn title_only_match_yields_a_bare_card() {
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-t": {"id": "doc-t", "title": "Kumquat Planning", "created_at": "2026-01-05T00:00:00Z"}
+            }
+        }));
+        let doc = load_doc(&conn, "doc-t");
+        let facts = RankingFacts { keyword: true, best_chunk: None, score: None };
+
+        let shaped = shape(&conn, &doc, "kumquat", &facts);
+
+        assert!(shaped.matches.is_empty());
+        assert_eq!(shaped.total_matches, 0);
+        assert!(shaped.signals.title);
+        assert!(shaped.signals.keyword);
+        assert!(!shaped.signals.semantic);
+        assert_eq!(shaped.score, None);
+    }
+
+    #[test]
+    fn shaped_meeting_carries_identity_fields() {
+        let conn = build_test_db(&evidence_state());
+        let doc = load_doc(&conn, "doc-1");
+        let facts = RankingFacts { keyword: true, best_chunk: None, score: Some(0.7) };
+
+        let shaped = shape(&conn, &doc, "kumquat", &facts);
+
+        assert_eq!(shaped.document_id, "doc-1");
+        assert_eq!(shaped.title.as_deref(), Some("Infra Sync"));
+        assert_eq!(shaped.created_at.as_deref(), Some("2026-01-20T10:00:00Z"));
+        assert_eq!(
+            shaped.remaining_sources,
+            vec![EvidenceSource::Notes, EvidenceSource::Transcript]
+        );
     }
 }

--- a/src/query/fts.rs
+++ b/src/query/fts.rs
@@ -15,7 +15,8 @@ pub enum FtsToken {
 }
 
 impl FtsToken {
-    fn text(&self) -> &str {
+    /// The token's text, phrase or term alike.
+    pub fn text(&self) -> &str {
         match self {
             FtsToken::Term(s) | FtsToken::Phrase(s) => s,
         }

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -5,7 +5,7 @@
 //! [`crate::query::fusion`]). Used by `grans search --hybrid` and the
 //! quality benchmark's hybrid mode.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use rusqlite::Connection;
@@ -19,13 +19,26 @@ use crate::query::fusion::{reciprocal_rank_fusion, FusedDoc, RRF_K};
 /// How many top documents each retriever contributes to fusion.
 pub const CANDIDATE_POOL: usize = 100;
 
+/// A document's best-matching chunk from the semantic pass.
+#[derive(Debug, Clone)]
+pub struct BestChunk {
+    pub text: String,
+    /// Chunk source: `transcript_window`, `panel_section`, or `notes_paragraph`.
+    pub source_type: String,
+    /// Panel section heading for `panel_section` chunks.
+    pub section_heading: Option<String>,
+}
+
 /// Hybrid retrieval output: the fused ranking plus each document's
-/// best-matching chunk text from the semantic pass. The rerank stage uses
-/// the chunk texts as passages; documents without embedded content (e.g.
-/// title-only FTS matches) have no entry.
+/// best-matching chunk from the semantic pass. The rerank stage uses the
+/// chunk texts as passages and shaped output uses them as semantic-only
+/// evidence; documents without embedded content (e.g. title-only FTS
+/// matches) have no entry. `keyword_ids` records which documents the FTS
+/// retriever surfaced.
 pub struct HybridRanking {
     pub fused: Vec<FusedDoc>,
-    pub best_chunks: HashMap<String, String>,
+    pub best_chunks: HashMap<String, BestChunk>,
+    pub keyword_ids: HashSet<String>,
 }
 
 /// Run FTS and semantic retrieval for `query` and fuse the rankings.
@@ -70,12 +83,21 @@ pub fn hybrid_ranked(
     let mut best_chunks = HashMap::with_capacity(semantic_results.len());
     for r in semantic_results {
         semantic_ids.push(r.document_id.clone());
-        best_chunks.insert(r.document_id, r.matched_text);
+        best_chunks.insert(
+            r.document_id,
+            BestChunk {
+                text: r.matched_text,
+                source_type: r.source_type,
+                section_heading: r.section_heading,
+            },
+        );
     }
 
+    let keyword_ids: HashSet<String> = fts_ids.iter().cloned().collect();
     Ok(HybridRanking {
         fused: fuse_candidates(fts_ids, semantic_ids),
         best_chunks,
+        keyword_ids,
     })
 }
 
@@ -216,10 +238,36 @@ mod tests {
             hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, false)
                 .unwrap();
 
-        assert_eq!(ranking.best_chunks.get("doc-both").map(String::as_str), Some("both chunk"));
-        assert_eq!(ranking.best_chunks.get("doc-sem").map(String::as_str), Some("strong chunk"));
+        assert_eq!(
+            ranking.best_chunks.get("doc-both").map(|c| c.text.as_str()),
+            Some("both chunk")
+        );
+        assert_eq!(
+            ranking.best_chunks.get("doc-sem").map(|c| c.text.as_str()),
+            Some("strong chunk")
+        );
+        assert_eq!(
+            ranking.best_chunks.get("doc-sem").map(|c| c.source_type.as_str()),
+            Some("transcript_window")
+        );
         // doc-fts has no chunks, so it has no passage entry.
         assert!(!ranking.best_chunks.contains_key("doc-fts"));
+    }
+
+    #[test]
+    fn ranking_records_which_documents_fts_surfaced() {
+        let conn = build_test_db(&hybrid_state());
+        let index = hybrid_index();
+
+        let ranking =
+            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, false)
+                .unwrap();
+
+        // Both kumquat-titled docs come from FTS; the semantic-only doc
+        // does not.
+        assert!(ranking.keyword_ids.contains("doc-both"));
+        assert!(ranking.keyword_ids.contains("doc-fts"));
+        assert!(!ranking.keyword_ids.contains("doc-sem"));
     }
 
     #[test]

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,5 +1,6 @@
 pub mod adjust;
 pub mod dates;
+pub mod evidence;
 pub mod filter;
 pub mod fts;
 pub mod fusion;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -6,4 +6,5 @@ pub mod fusion;
 pub mod hybrid;
 pub mod rerank;
 pub mod search;
+pub mod shape;
 pub mod text;

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -91,7 +91,7 @@ pub fn rerank_hybrid_detailed(
                 fused_score: fused.score,
                 passage: build_passage(
                     title.as_deref(),
-                    ranking.best_chunks.get(&fused.document_id).map(String::as_str),
+                    ranking.best_chunks.get(&fused.document_id).map(|c| c.text.as_str()),
                 ),
                 title: title.clone(),
                 created_at: created_at.clone(),
@@ -130,6 +130,7 @@ mod tests {
     use crate::db::test_fixtures::build_test_db;
     use crate::embed::rerank::MockReranker;
     use crate::query::fusion::FusedDoc;
+    use crate::query::hybrid::BestChunk;
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -153,6 +154,18 @@ mod tests {
             .collect()
     }
 
+    fn chunk(text: &str) -> BestChunk {
+        BestChunk {
+            text: text.to_string(),
+            source_type: "transcript_window".to_string(),
+            section_heading: None,
+        }
+    }
+
+    fn make_ranking(fused: Vec<FusedDoc>, best_chunks: HashMap<String, BestChunk>) -> HybridRanking {
+        HybridRanking { fused, best_chunks, keyword_ids: std::collections::HashSet::new() }
+    }
+
     #[test]
     fn hybrid_rerank_scores_titles_and_chunks() {
         // doc-chunk matches the query twice via its chunk; doc-title once
@@ -165,13 +178,10 @@ mod tests {
                 "doc-chunk": {"id": "doc-chunk", "title": "Planning", "created_at": "2026-01-03T10:00:00Z"}
             }
         }));
-        let ranking = HybridRanking {
-            fused: fused(&["doc-none", "doc-title", "doc-chunk"]),
-            best_chunks: HashMap::from([(
-                "doc-chunk".to_string(),
-                "kumquat kumquat".to_string(),
-            )]),
-        };
+        let ranking = make_ranking(
+            fused(&["doc-none", "doc-title", "doc-chunk"]),
+            HashMap::from([("doc-chunk".to_string(), chunk("kumquat kumquat"))]),
+        );
 
         let reranked = rerank_hybrid(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
 
@@ -191,17 +201,14 @@ mod tests {
                 "doc-chunk": {"id": "doc-chunk", "title": "Planning", "created_at": "2026-01-03T10:00:00Z"}
             }
         }));
-        let ranking = HybridRanking {
-            fused: vec![
+        let ranking = make_ranking(
+            vec![
                 FusedDoc { document_id: "doc-none".to_string(), score: 0.03 },
                 FusedDoc { document_id: "doc-title".to_string(), score: 0.02 },
                 FusedDoc { document_id: "doc-chunk".to_string(), score: 0.01 },
             ],
-            best_chunks: HashMap::from([(
-                "doc-chunk".to_string(),
-                "kumquat kumquat".to_string(),
-            )]),
-        };
+            HashMap::from([("doc-chunk".to_string(), chunk("kumquat kumquat"))]),
+        );
 
         let detailed =
             rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
@@ -232,16 +239,13 @@ mod tests {
                 "doc-deep": {"id": "doc-deep", "title": "Planning", "created_at": "2026-01-02T10:00:00Z"}
             }
         }));
-        let ranking = HybridRanking {
-            fused: vec![
+        let ranking = make_ranking(
+            vec![
                 FusedDoc { document_id: "doc-fused".to_string(), score: 0.1 },
                 FusedDoc { document_id: "doc-deep".to_string(), score: 0.0 },
             ],
-            best_chunks: HashMap::from([(
-                "doc-deep".to_string(),
-                "kumquat kumquat".to_string(),
-            )]),
-        };
+            HashMap::from([("doc-deep".to_string(), chunk("kumquat kumquat"))]),
+        );
 
         let detailed =
             rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
@@ -262,7 +266,7 @@ mod tests {
                 "doc-1": {"id": "doc-1", "title": "Kumquat sync", "created_at": "2026-01-02T10:00:00Z"}
             }
         }));
-        let ranking = HybridRanking { fused: fused(&["doc-1"]), best_chunks: HashMap::new() };
+        let ranking = make_ranking(fused(&["doc-1"]), HashMap::new());
 
         let detailed =
             rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
@@ -285,16 +289,16 @@ mod tests {
                 "doc-titled": {"id": "doc-titled", "title": "Kumquat retro", "created_at": "2026-01-02T10:00:00Z"}
             }
         }));
-        let ranking = HybridRanking {
-            fused: vec![
+        let ranking = make_ranking(
+            vec![
                 FusedDoc { document_id: "doc-plain".to_string(), score: 0.05 },
                 FusedDoc { document_id: "doc-titled".to_string(), score: 0.01 },
             ],
-            best_chunks: HashMap::from([
-                ("doc-plain".to_string(), "kumquat".to_string()),
-                ("doc-titled".to_string(), "kumquat".to_string()),
+            HashMap::from([
+                ("doc-plain".to_string(), chunk("kumquat")),
+                ("doc-titled".to_string(), chunk("kumquat")),
             ]),
-        };
+        );
         let ctx = RankingContext::default();
 
         let without = rerank_hybrid_detailed(
@@ -323,10 +327,7 @@ mod tests {
                 "doc-first": {"id": "doc-first", "title": "Kumquat sync", "created_at": "2026-01-02T10:00:00Z"}
             }
         }));
-        let ranking = HybridRanking {
-            fused: fused(&["doc-first", "doc-second"]),
-            best_chunks: HashMap::new(),
-        };
+        let ranking = make_ranking(fused(&["doc-first", "doc-second"]), HashMap::new());
 
         let detailed =
             rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
@@ -340,7 +341,7 @@ mod tests {
     #[test]
     fn detailed_empty_ranking_reranks_to_empty() {
         let conn = build_test_db(&json!({ "documents": {} }));
-        let ranking = HybridRanking { fused: Vec::new(), best_chunks: HashMap::new() };
+        let ranking = make_ranking(Vec::new(), HashMap::new());
 
         let detailed =
             rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
@@ -364,10 +365,10 @@ mod tests {
 
         let ids: Vec<String> = (0..60).map(|i| format!("doc-{i:02}")).collect();
         let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
-        let ranking = HybridRanking {
-            fused: fused(&id_refs),
-            best_chunks: HashMap::from([("doc-59".to_string(), "kumquat".to_string())]),
-        };
+        let ranking = make_ranking(
+            fused(&id_refs),
+            HashMap::from([("doc-59".to_string(), chunk("kumquat"))]),
+        );
 
         let reranked = rerank_hybrid(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
 

--- a/src/query/shape.rs
+++ b/src/query/shape.rs
@@ -1,0 +1,354 @@
+//! Shaping search results for display: per-meeting cards with match evidence.
+//!
+//! A shaped result is one meeting with one or more evidence snippets showing
+//! why it matched. This module holds the display-agnostic pieces: the card
+//! data types and the pure text machinery that windows a snippet around the
+//! first query-token match and locates highlight spans. Rendering lives in
+//! `output::card`; evidence collection against the database lives in
+//! `query::evidence`.
+
+use crate::query::fts::FtsToken;
+
+/// Where a piece of match evidence came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceSource {
+    Transcript,
+    /// A Granola AI-notes panel section.
+    Panel,
+    /// The user's own notes.
+    Notes,
+}
+
+/// A snippet of text with the query-term spans to emphasize.
+/// Highlight offsets are character ranges `[start, end)` into `text`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Excerpt {
+    pub text: String,
+    pub highlights: Vec<(usize, usize)>,
+}
+
+/// One place a meeting matched the query.
+#[derive(Debug, Clone)]
+pub struct MatchEvidence {
+    pub source: EvidenceSource,
+    pub excerpt: Excerpt,
+    /// Raw utterance source for transcripts (`"microphone"`/`"system"`).
+    pub speaker: Option<String>,
+    /// ISO start timestamp for transcript evidence.
+    pub timestamp: Option<String>,
+    /// Section heading for panel evidence.
+    pub section: Option<String>,
+}
+
+/// Which retrieval signals surfaced a meeting.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Signals {
+    pub keyword: bool,
+    pub semantic: bool,
+    pub title: bool,
+}
+
+/// One meeting shaped for display: identity, ranking facts, and evidence.
+/// An empty `matches` with `signals.title` set renders as a title-only match.
+#[derive(Debug, Clone)]
+pub struct ShapedMeeting {
+    pub document_id: String,
+    pub title: Option<String>,
+    pub created_at: Option<String>,
+    /// Cross-encoder relevance when the rerank stage ran.
+    pub score: Option<f32>,
+    pub signals: Signals,
+    /// Total lexical match sites in the meeting's content, independent of
+    /// how many are shown.
+    pub total_matches: usize,
+    pub matches: Vec<MatchEvidence>,
+}
+
+/// Window `text` around the first query-token match.
+///
+/// Whitespace is normalized (all runs collapse to single spaces), the window
+/// is truncated to roughly `max_chars` characters on word boundaries, and a
+/// `…` marks each truncated edge. Every token occurrence inside the window is
+/// reported as a highlight span. When no token occurs in the text (semantic
+/// evidence), the window starts at the beginning and highlights are empty.
+pub fn excerpt_around_match(text: &str, tokens: &[FtsToken], max_chars: usize) -> Excerpt {
+    let normalized: String = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let chars: Vec<char> = normalized.chars().collect();
+
+    let first_match = tokens
+        .iter()
+        .filter_map(|t| find_ignore_case(&chars, t.text()).first().copied())
+        .min_by_key(|&(start, _)| start);
+
+    let (window_start, window_end, leading, trailing) =
+        window_bounds(&chars, first_match, max_chars);
+
+    let mut text: String = String::new();
+    if leading {
+        text.push('…');
+    }
+    let body_offset = text.chars().count();
+    text.extend(&chars[window_start..window_end]);
+    if trailing {
+        text.push('…');
+    }
+
+    let window_chars = &chars[window_start..window_end];
+    let mut highlights = Vec::new();
+    for token in tokens {
+        for (start, end) in find_ignore_case(window_chars, token.text()) {
+            highlights.push((start + body_offset, end + body_offset));
+        }
+    }
+    highlights.sort_unstable();
+    highlights.dedup();
+
+    Excerpt { text, highlights }
+}
+
+/// True when every query token appears in the title (the FTS title-tier
+/// match criterion, mirrored for display).
+pub fn title_matches(title: &str, tokens: &[FtsToken]) -> bool {
+    !tokens.is_empty() && crate::query::fts::matches_all_tokens(title, tokens)
+}
+
+/// Choose window bounds around `matched` (a char span) in `chars`, capped at
+/// `max_chars` characters and snapped outward-in to word boundaries. Returns
+/// `(start, end, leading_ellipsis, trailing_ellipsis)`.
+fn window_bounds(
+    chars: &[char],
+    matched: Option<(usize, usize)>,
+    max_chars: usize,
+) -> (usize, usize, bool, bool) {
+    let len = chars.len();
+    if len <= max_chars {
+        return (0, len, false, false);
+    }
+
+    // Place the match about a third of the way into the window so trailing
+    // context (usually the more informative side) gets the larger share.
+    let ideal_start = match matched {
+        Some((match_start, _)) => match_start.saturating_sub(max_chars / 3),
+        None => 0,
+    };
+    let mut start = ideal_start.min(len - max_chars);
+    let mut end = start + max_chars;
+
+    if start > 0 {
+        // Snap forward to the char after the next space so the window opens
+        // on a whole word, but never past the match itself.
+        let limit = matched.map(|(s, _)| s).unwrap_or(end);
+        if let Some(pos) = (start..limit.min(end)).find(|&i| chars[i] == ' ') {
+            start = pos + 1;
+        }
+    }
+    if end < len {
+        // Snap back to the last space so the window closes on a whole word,
+        // but never before the end of the match.
+        let floor = matched.map(|(_, e)| e).unwrap_or(start).max(start + 1);
+        if let Some(pos) = (floor..end).rev().find(|&i| chars[i] == ' ') {
+            end = pos;
+        }
+    }
+
+    (start, end, start > 0, end < len)
+}
+
+/// Find every case-insensitive occurrence of `needle` in `haystack`,
+/// returned as char ranges `[start, end)` into `haystack`.
+fn find_ignore_case(haystack: &[char], needle: &str) -> Vec<(usize, usize)> {
+    let needle: Vec<char> = needle.to_lowercase().chars().collect();
+    if needle.is_empty() || haystack.is_empty() {
+        return Vec::new();
+    }
+
+    // Lowercase per char, remembering each lowered char's original index.
+    // One original char may lower to several chars (e.g. 'İ'), so spans are
+    // computed through the mapping rather than by position arithmetic.
+    let mut lowered: Vec<char> = Vec::with_capacity(haystack.len());
+    let mut origin: Vec<usize> = Vec::with_capacity(haystack.len());
+    for (i, &c) in haystack.iter().enumerate() {
+        for lc in c.to_lowercase() {
+            lowered.push(lc);
+            origin.push(i);
+        }
+    }
+
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while i + needle.len() <= lowered.len() {
+        if lowered[i..i + needle.len()] == needle[..] {
+            let start = origin[i];
+            let end = origin[i + needle.len() - 1] + 1;
+            spans.push((start, end));
+            i += needle.len();
+        } else {
+            i += 1;
+        }
+    }
+    spans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::fts::parse_query;
+
+    fn excerpt(text: &str, query: &str, max: usize) -> Excerpt {
+        excerpt_around_match(text, &parse_query(query), max)
+    }
+
+    fn highlighted<'a>(e: &'a Excerpt) -> Vec<&'a str> {
+        let chars: Vec<char> = e.text.chars().collect();
+        e.highlights
+            .iter()
+            .map(|&(s, t)| chars[s..t].iter().collect::<String>())
+            .map(|s| Box::leak(s.into_boxed_str()) as &str)
+            .collect()
+    }
+
+    // --- excerpt_around_match ---
+
+    #[test]
+    fn short_text_passes_through_whole() {
+        let e = excerpt("the quick brown fox", "fox", 80);
+        assert_eq!(e.text, "the quick brown fox");
+        assert_eq!(highlighted(&e), vec!["fox"]);
+    }
+
+    #[test]
+    fn whitespace_is_normalized() {
+        let e = excerpt("line one\n\nline   two", "two", 80);
+        assert_eq!(e.text, "line one line two");
+    }
+
+    #[test]
+    fn long_text_windows_around_the_match() {
+        let filler = "alpha beta gamma delta ".repeat(20);
+        let text = format!("{filler}needle in the haystack {filler}");
+        let e = excerpt(&text, "needle", 60);
+        assert!(e.text.starts_with('…'), "leading ellipsis: {}", e.text);
+        assert!(e.text.ends_with('…'), "trailing ellipsis: {}", e.text);
+        assert!(e.text.contains("needle in the haystack"));
+        assert!(e.text.chars().count() <= 62); // window + two ellipses
+        assert_eq!(highlighted(&e), vec!["needle"]);
+    }
+
+    #[test]
+    fn match_at_start_has_no_leading_ellipsis() {
+        let text = format!("needle first {}", "word ".repeat(50));
+        let e = excerpt(&text, "needle", 40);
+        assert!(e.text.starts_with("needle"));
+        assert!(e.text.ends_with('…'));
+    }
+
+    #[test]
+    fn window_opens_and_closes_on_word_boundaries() {
+        let filler = "abcdefgh ".repeat(30);
+        let text = format!("{filler}needle {filler}");
+        let e = excerpt(&text, "needle", 50);
+        let inner = e.text.trim_matches('…');
+        assert!(!inner.starts_with(' ') && !inner.ends_with(' '));
+        // No partial filler word at the edges.
+        for word in inner.split(' ') {
+            assert!(
+                word == "needle" || word == "abcdefgh",
+                "partial word at window edge: {word:?} in {:?}",
+                e.text
+            );
+        }
+    }
+
+    #[test]
+    fn no_token_in_text_windows_from_start_with_no_highlights() {
+        let text = "completely unrelated content ".repeat(10);
+        let e = excerpt(&text, "needle", 40);
+        assert!(e.text.starts_with("completely"));
+        assert!(e.text.ends_with('…'));
+        assert!(e.highlights.is_empty());
+    }
+
+    #[test]
+    fn all_token_occurrences_in_window_are_highlighted() {
+        let e = excerpt("rust code and rust tests", "rust", 80);
+        assert_eq!(highlighted(&e), vec!["rust", "rust"]);
+        assert_eq!(e.highlights, vec![(0, 4), (14, 18)]);
+    }
+
+    #[test]
+    fn multiple_tokens_all_highlight() {
+        let e = excerpt("the database migration ran fine", "database migration", 80);
+        assert_eq!(highlighted(&e), vec!["database", "migration"]);
+    }
+
+    #[test]
+    fn phrase_token_highlights_as_one_span() {
+        let e = excerpt("the database migration ran fine", "\"database migration\"", 80);
+        assert_eq!(highlighted(&e), vec!["database migration"]);
+    }
+
+    #[test]
+    fn highlight_is_case_insensitive_and_preserves_original_case() {
+        let e = excerpt("Database Migration plan", "database", 80);
+        assert_eq!(highlighted(&e), vec!["Database"]);
+    }
+
+    #[test]
+    fn earliest_token_occurrence_anchors_the_window() {
+        let filler = "filler ".repeat(40);
+        let text = format!("alpha here {filler} beta here");
+        let e = excerpt(&text, "beta alpha", 30);
+        // "alpha" occurs first, so the window anchors there.
+        assert!(e.text.contains("alpha"), "window: {:?}", e.text);
+        assert!(!e.text.contains("beta"));
+    }
+
+    #[test]
+    fn unicode_text_windows_without_panicking() {
+        let text = "café münchen straße ".repeat(20) + "needle";
+        let e = excerpt(&text, "needle", 40);
+        assert!(e.text.contains("needle"));
+        assert_eq!(highlighted(&e), vec!["needle"]);
+    }
+
+    #[test]
+    fn empty_query_yields_no_highlights() {
+        let e = excerpt("some text", "", 80);
+        assert_eq!(e.text, "some text");
+        assert!(e.highlights.is_empty());
+    }
+
+    #[test]
+    fn empty_text_yields_empty_excerpt() {
+        let e = excerpt("", "needle", 80);
+        assert_eq!(e.text, "");
+        assert!(e.highlights.is_empty());
+    }
+
+    // --- title_matches ---
+
+    #[test]
+    fn title_matches_when_all_tokens_present() {
+        let tokens = parse_query("infra sync");
+        assert!(title_matches("Weekly Infra Sync", &tokens));
+    }
+
+    #[test]
+    fn title_does_not_match_on_partial_tokens() {
+        let tokens = parse_query("infra budget");
+        assert!(!title_matches("Weekly Infra Sync", &tokens));
+    }
+
+    #[test]
+    fn empty_query_never_title_matches() {
+        assert!(!title_matches("Weekly Infra Sync", &[]));
+    }
+
+    // --- find_ignore_case (via excerpt highlights) ---
+
+    #[test]
+    fn overlapping_occurrences_do_not_overlap_spans() {
+        let e = excerpt("aaaa", "aa", 80);
+        assert_eq!(e.highlights, vec![(0, 2), (2, 4)]);
+    }
+}

--- a/src/query/shape.rs
+++ b/src/query/shape.rs
@@ -58,10 +58,13 @@ pub struct ShapedMeeting {
     /// Cross-encoder relevance when the rerank stage ran.
     pub score: Option<f32>,
     pub signals: Signals,
-    /// Total lexical match sites in the meeting's content, independent of
-    /// how many are shown.
+    /// Total match sites in the meeting's content, independent of how many
+    /// are shown.
     pub total_matches: usize,
     pub matches: Vec<MatchEvidence>,
+    /// Sources of the match sites beyond `matches`, deduped in display
+    /// order, for the "+N more matches in …" collapse line.
+    pub remaining_sources: Vec<EvidenceSource>,
 }
 
 /// Window `text` around the first query-token match.


### PR DESCRIPTION
Part 1 of #57 (part of #37). The default (hybrid) search output changes from a bare scored meeting list to per-meeting cards with match evidence. Keyword, semantic, and context modes are untouched; unifying them onto the same cards is #57 part 2.

## What changed

Each result now shows why the meeting matched: the source of the best match (`AI notes` with its section heading, `your notes`, or `transcript` with time and speaker), a snippet with the query terms highlighted, and a `+N more matches in ...` line when the meeting matched elsewhere. A new `--matches N` flag shows up to N snippets per meeting (default 1; 0 shows headers and counts only).

Evidence degrades in three tiers:

1. Lexical: match sites located with the same Rust-side matchers the `--context` path uses (per panel section, notes paragraph, transcript utterance), excerpted around the first query-term occurrence with all term occurrences highlighted. FTS5 `snippet()`/`highlight()` were considered but rejected: the notes and panels FTS indexes are whole-blob, so they cannot yield section labels, and the Rust matchers keep match semantics identical to the context view.
2. Semantic-only: when no query term appears literally, the reranker's best chunk stands in (it was already computed per candidate and then discarded before output). No highlights, honestly.
3. Title-only: an explicit `title match` label instead of an empty snippet.

The numeric score left human output. The displayed number was the raw cross-encoder probability while the ordering is `rerank + 30 x RRF + 0.2 x title`, so the score column was visibly non-monotonic and read as broken. `--json` carries `score` (omitted under `--fast`), plus which retrievers surfaced each meeting (`signals`), the full match list, and char-range highlight offsets, replacing the old dump of the entire meeting object. `--min-score` semantics are unchanged.

## Screenshots

Synthetic database (invented meetings); this repo is public, so no real data appears.

Before, on this exact query the score column reads 0.60, 0.52, 0.63 top to bottom:

![Before: scored meeting list with non-monotonic score column](https://bloopityseven.fly.dev/8601cee6-bf72-4e95-8cf7-16e9c6640c89.png)

After:

![After: per-meeting cards with highlighted snippets, source lines, title match, and collapse lines](https://bloopityseven.fly.dev/25441414-e1e6-4e4b-8d48-50d901f28e9f.png)

## Implementation

- `query/shape.rs` (new): pure snippet windowing (whitespace normalization, word-boundary windows around the first token hit, char-range highlight spans, Unicode-safe case folding) and the card data model.
- `query/evidence.rs` (new): per-document match-site collection reusing `load_panels`/`load_transcript`/`split_markdown_sections`/`split_into_paragraphs` and `matches_all_tokens`, plus the tier assembly (`shape_meeting`).
- `output/card.rs` (new): TTY renderer; `--no-color` degrades through the existing global `colored` override, so one renderer serves both.
- `query/hybrid.rs`: `HybridRanking` keeps each best chunk's source type and section heading (`BestChunk`) and records which documents FTS surfaced (`keyword_ids`). The reranker consumes the same chunk text as before.
- `commands/search.rs`: evidence is collected for the displayed page only, not the candidate pool. The dead scored-list path (`format_scored_meeting_row`, `ScoredMeetingJson`, `render_scored_meeting_list`) is deleted. The substantive new logic lives in the three new modules.

## Verification

- Shaping is presentation-only and never reorders: pinned by a `shape_page` regression test, and by a benchmark identity run. On a copy of the frozen snapshot, this branch and an `origin/main` build produce identical rerank-jina numbers on all 93 golden-set queries (hit-rate@10 93.5%, recall@10 80.5%, MRR@10 0.813, matching the Phase 5 ledger baseline per stratum). The run is recorded in the ledger (2026-07-11).
- Code review (subagent) found one real bug, fixed with regression tests: `--matches 0` gated the evidence tier on "no excerpts kept" instead of "no lexical evidence exists", faking a semantic hit or losing the match count. An empty query now also collects no lexical evidence instead of vacuously matching every site.
- 66 tests added (844 total). Keyword, semantic, and context searches verified byte-identical on real data; all three tiers and `--matches`/`--fast`/`--json` exercised end-to-end on a GPU build.
- README and roadmap updated.
