### PR TITLE
#77: grep's --limit hint says "results" where its headers say "meetings"

### DIFF
--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -123,7 +123,7 @@ fn render_grep_meeting_list(
             }
             print_shaped_cards(shaped, ctx);
             if total > shaped.len() {
-                println!("Use --limit 0 to show all {} results.", total);
+                println!("Use --limit 0 to show all {} meetings.", total);
             }
         }
     }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -264,7 +264,7 @@ fn grep_tty_header_reports_complete_count_when_limited() {
         .stdout(predicate::str::contains(
             "Found 2 meeting(s) matching \"prototype\" (showing 1):",
         ))
-        .stdout(predicate::str::contains("Use --limit 0 to show all 2 results."));
+        .stdout(predicate::str::contains("Use --limit 0 to show all 2 meetings."));
 }
 
 #[test]


### PR DESCRIPTION
grep's header and JSON output count meetings, but the truncation hint printed "results" instead. This changes the hint to match.

Before:

```
Use --limit 0 to show all 12 results.
```

After:

```
Use --limit 0 to show all 12 meetings.
```

Updated the integration test that pins this line (`tests/search.rs`, `grep_tty_header_reports_complete_count_when_limited`) to expect "meetings" first, confirmed it failed against the old wording, then made the one-word fix in `src/commands/grep.rs` (`render_grep_meeting_list`) and confirmed the test passes.

No README changes were needed; the README only shows an example command, not the hint text itself.

Closes #77.

## Test plan

- `cargo test --bin grans`: 757 passed
- `cargo test --test date_filter`: 8 passed
- `cargo test --test end_to_end`: 37 passed
- `cargo test --test errors`: 3 passed
- `cargo test --test people_junction`: 6 passed
- `cargo test --test search`: 21 passed (includes the pinned test)

https://claude.ai/code/session_01TmhUwR8kAqCjZFvf3vFJXQ