### PR TITLE
#74: Reject unknown --in targets at parse time

### DIFF
--- a/src/cli/args/mod.rs
+++ b/src/cli/args/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::models::SpeakerFilter;
+use crate::query::filter::SearchTarget;
 
 fn parse_speaker_filter(s: &str) -> Result<SpeakerFilter, String> {
     SpeakerFilter::parse(s).ok_or_else(|| format!("invalid speaker filter '{}': expected 'me' or 'other'", s))
@@ -54,9 +55,9 @@ pub enum Commands {
         /// Search query; words match in any order, "quoted phrases" must match exactly
         query: String,
 
-        /// Search targets: titles, transcripts, notes, panels (comma-separated)
-        #[arg(long, rename_all = "lowercase", default_value = crate::query::filter::DEFAULT_SEARCH_TARGETS)]
-        r#in: String,
+        /// Where to search (comma-separated)
+        #[arg(long, value_delimiter = ',', default_value = crate::query::filter::DEFAULT_SEARCH_TARGETS)]
+        r#in: Vec<SearchTarget>,
 
         /// Skip the cross-encoder rerank stage
         /// (fusion order only; faster, but no relevance scores)
@@ -118,9 +119,9 @@ pub enum Commands {
         /// Words to look up; words match in any order, "quoted phrases" must match exactly
         query: String,
 
-        /// Search targets: titles, transcripts, notes, panels (comma-separated)
-        #[arg(long, rename_all = "lowercase", default_value = crate::query::filter::DEFAULT_SEARCH_TARGETS)]
-        r#in: String,
+        /// Where to search (comma-separated)
+        #[arg(long, value_delimiter = ',', default_value = crate::query::filter::DEFAULT_SEARCH_TARGETS)]
+        r#in: Vec<SearchTarget>,
 
         /// Maximum match snippets shown per meeting (0 = headers only)
         #[arg(long, default_value = "1")]

--- a/src/cli/args/tests.rs
+++ b/src/cli/args/tests.rs
@@ -106,7 +106,7 @@ fn grep_parses_with_lookup_flags() {
     };
     assert_eq!(query, "kumquat");
     assert_eq!(*speaker, Some(SpeakerFilter::Me));
-    assert_eq!(r#in, "titles,transcripts");
+    assert_eq!(r#in, &vec![SearchTarget::Titles, SearchTarget::Transcripts]);
     assert_eq!(meeting.as_deref(), Some("standup"));
     assert_eq!(*context, 2);
     assert_eq!(*matches, 3);
@@ -118,6 +118,61 @@ fn grep_parses_with_lookup_flags() {
 fn grep_visible_alias_g_parses() {
     let cli = Cli::try_parse_from(["grans", "g", "kumquat"]).unwrap();
     assert!(matches!(cli.command, Commands::Grep { .. }));
+}
+
+fn grep_in_targets(cli: &Cli) -> &[SearchTarget] {
+    match &cli.command {
+        Commands::Grep { r#in, .. } => r#in,
+        _ => panic!("expected grep subcommand"),
+    }
+}
+
+#[test]
+fn grep_in_defaults_to_every_target() {
+    // Omitting --in searches every source (#74 preserves this default).
+    let cli = Cli::try_parse_from(["grans", "grep", "budget"]).unwrap();
+    assert_eq!(grep_in_targets(&cli), SearchTarget::all().as_slice());
+}
+
+#[test]
+fn grep_in_parses_a_valid_comma_separated_list() {
+    let cli =
+        Cli::try_parse_from(["grans", "grep", "budget", "--in", "titles,transcripts"]).unwrap();
+    assert_eq!(
+        grep_in_targets(&cli),
+        &[SearchTarget::Titles, SearchTarget::Transcripts]
+    );
+}
+
+#[test]
+fn grep_in_rejects_an_unknown_target() {
+    // `transcript` (singular typo) must fail loudly instead of collapsing to
+    // an empty target set that greps nothing (#74). The error names the bad
+    // value and lists the valid ones.
+    let err = Cli::try_parse_from(["grans", "grep", "budget", "--in", "transcript"])
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("transcript"), "error should name the bad value: {msg}");
+    assert!(
+        msg.contains("titles") && msg.contains("transcripts") && msg.contains("notes")
+            && msg.contains("panels"),
+        "error should list the valid targets: {msg}"
+    );
+}
+
+#[test]
+fn grep_in_rejects_an_unknown_target_inside_a_valid_list() {
+    // `titles,transcript` must not silently search titles only (#74); one
+    // bad token fails the whole list.
+    let result = Cli::try_parse_from(["grans", "grep", "budget", "--in", "titles,transcript"]);
+    assert!(result.is_err(), "an unknown token anywhere must fail the list");
+}
+
+#[test]
+fn search_in_rejects_an_unknown_target() {
+    // The rejection applies to search's --in as well.
+    let result = Cli::try_parse_from(["grans", "search", "budget", "--in", "transcript"]);
+    assert!(result.is_err(), "search --in must reject unknown targets");
 }
 
 #[test]

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -142,7 +142,7 @@ fn retrieve_hybrid(
     index: &EmbeddingIndex,
     query: &str,
 ) -> Result<Vec<RankedDoc>> {
-    let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
+    let targets = SearchTarget::all();
     let fused =
         crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, None, false)?
             .fused;
@@ -167,7 +167,7 @@ fn retrieve_hybrid_rerank_detailed(
     ctx: &RankingContext,
     cfg: &RankingConfig,
 ) -> Result<Vec<RerankCandidate>> {
-    let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
+    let targets = SearchTarget::all();
     let ranking =
         crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, None, false)?;
     crate::query::rerank::rerank_hybrid_detailed(conn, reranker, query, &ranking, ctx, cfg)

--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -148,20 +148,20 @@ mod tests {
 
     #[test]
     fn speaker_with_targets_excluding_transcripts_is_an_error() {
-        let targets = SearchTarget::parse_list("titles,notes");
+        let targets = vec![SearchTarget::Titles, SearchTarget::Notes];
         let err = check_speaker_targets(true, &targets).unwrap_err();
         assert!(err.to_string().contains("transcripts"));
     }
 
     #[test]
     fn speaker_with_transcripts_included_is_accepted() {
-        let targets = SearchTarget::parse_list("notes,transcripts");
+        let targets = vec![SearchTarget::Notes, SearchTarget::Transcripts];
         assert!(check_speaker_targets(true, &targets).is_ok());
     }
 
     #[test]
     fn no_speaker_accepts_any_targets() {
-        let targets = SearchTarget::parse_list("notes");
+        let targets = vec![SearchTarget::Notes];
         assert!(check_speaker_targets(false, &targets).is_ok());
     }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -16,17 +16,19 @@ use crate::commands::search_common::{print_shaped_cards, shape_and_page};
 use crate::models::Document;
 use crate::output::format::OutputMode;
 use crate::query::dates::DateRange;
-use crate::query::filter::{SearchTarget, DEFAULT_SEARCH_TARGETS};
+use crate::query::filter::{targets_to_flag_value, SearchTarget, DEFAULT_SEARCH_TARGETS};
 
 /// Threshold for prompting before embedding during a search.
 const EMBED_WARN_THRESHOLD: usize = 200;
 
-/// Raw filter values as given on the command line. The grep cross-link
-/// echoes them verbatim so the suggested command reproduces the count the
-/// footer claims; only filters that change the match count belong here.
+/// Filter values that affect the match count, kept so the grep cross-link
+/// can reproduce that count. Dates and the meeting filter are echoed as the
+/// user typed them; `in_targets` is the parsed target list, re-joined into
+/// the flag when the suggested command is built. Only filters that change
+/// the match count belong here.
 pub struct FilterEcho {
-    /// Raw `--in` value.
-    pub in_targets: String,
+    /// Parsed `--in` targets.
+    pub in_targets: Vec<SearchTarget>,
     pub meeting: Option<String>,
     pub date: Option<String>,
     pub from: Option<String>,
@@ -37,7 +39,7 @@ pub struct FilterEcho {
 impl Default for FilterEcho {
     fn default() -> Self {
         FilterEcho {
-            in_targets: DEFAULT_SEARCH_TARGETS.to_string(),
+            in_targets: SearchTarget::all(),
             meeting: None,
             date: None,
             from: None,
@@ -78,7 +80,7 @@ impl SearchOptions {
         echo: FilterEcho,
     ) -> Self {
         SearchOptions {
-            targets: SearchTarget::parse_list(&echo.in_targets),
+            targets: echo.in_targets.clone(),
             meeting_filter: echo.meeting.clone(),
             rerank: !fast,
             min_score,
@@ -192,8 +194,9 @@ fn ranked_header(shown: usize, query: &str) -> String {
 /// change what counts as a match.
 fn grep_command_echo(query: &str, filters: &FilterEcho) -> String {
     let mut cmd = format!("grans grep \"{}\"", query);
-    if filters.in_targets != DEFAULT_SEARCH_TARGETS {
-        cmd.push_str(&format!(" --in {}", filters.in_targets));
+    let in_flag = targets_to_flag_value(&filters.in_targets);
+    if in_flag != DEFAULT_SEARCH_TARGETS {
+        cmd.push_str(&format!(" --in {}", in_flag));
     }
     if let Some(meeting) = &filters.meeting {
         cmd.push_str(&format!(" --meeting \"{}\"", meeting));
@@ -333,7 +336,7 @@ mod tests {
             false,
             10,
             1,
-            echo_with(|e| e.in_targets = "titles,notes".to_string()),
+            echo_with(|e| e.in_targets = vec![SearchTarget::Titles, SearchTarget::Notes]),
         );
         assert_eq!(opts.targets.len(), 2);
         assert!(opts.targets.contains(&SearchTarget::Titles));
@@ -418,7 +421,7 @@ mod tests {
 
     #[test]
     fn grep_command_echo_echoes_a_non_default_in_list() {
-        let echo = echo_with(|e| e.in_targets = "titles,notes".to_string());
+        let echo = echo_with(|e| e.in_targets = vec![SearchTarget::Titles, SearchTarget::Notes]);
         assert_eq!(
             grep_command_echo("budget", &echo),
             "grans grep \"budget\" --in titles,notes"
@@ -467,7 +470,7 @@ mod tests {
     #[test]
     fn grep_command_echo_combines_every_count_affecting_filter() {
         let echo = FilterEcho {
-            in_targets: "transcripts".to_string(),
+            in_targets: vec![SearchTarget::Transcripts],
             meeting: Some("Weekly Standup".to_string()),
             date: Some("last-week".to_string()),
             from: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
             include_deleted,
         } => {
             let opts = commands::grep::GrepOptions {
-                targets: query::filter::SearchTarget::parse_list(r#in),
+                targets: r#in.clone(),
                 meeting_filter: meeting.clone(),
                 limit: *limit,
                 matches: *matches,

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -1,10 +1,17 @@
+use clap::ValueEnum;
+
 use crate::models::Document;
 
 /// The default `--in` target list for search and grep: every source.
 pub const DEFAULT_SEARCH_TARGETS: &str = "titles,transcripts,notes,panels";
 
 /// Where to search for text matches in meetings.
-#[derive(Debug, Clone, PartialEq)]
+///
+/// Parsed directly by clap as a `ValueEnum`, so `--in` rejects unknown
+/// targets at parse time and names the valid ones, rather than silently
+/// dropping typos.
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[value(rename_all = "lowercase")]
 pub enum SearchTarget {
     Titles,
     Transcripts,
@@ -13,16 +20,26 @@ pub enum SearchTarget {
 }
 
 impl SearchTarget {
-    pub fn parse_list(s: &str) -> Vec<SearchTarget> {
-        s.split(',')
-            .filter_map(|part| match part.trim().to_lowercase().as_str() {
-                "titles" => Some(SearchTarget::Titles),
-                "transcripts" => Some(SearchTarget::Transcripts),
-                "notes" => Some(SearchTarget::Notes),
-                "panels" => Some(SearchTarget::Panels),
-                _ => None,
-            })
-            .collect()
+    /// Every target, in canonical `--in` order. Matches
+    /// [`DEFAULT_SEARCH_TARGETS`] and is the set used when `--in` is omitted.
+    pub fn all() -> Vec<SearchTarget> {
+        vec![
+            SearchTarget::Titles,
+            SearchTarget::Transcripts,
+            SearchTarget::Notes,
+            SearchTarget::Panels,
+        ]
+    }
+
+    /// The canonical `--in` token for this target (the same spelling clap
+    /// accepts on the command line).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SearchTarget::Titles => "titles",
+            SearchTarget::Transcripts => "transcripts",
+            SearchTarget::Notes => "notes",
+            SearchTarget::Panels => "panels",
+        }
     }
 
     /// Map a search target to the corresponding chunk source type string.
@@ -35,6 +52,12 @@ impl SearchTarget {
             SearchTarget::Panels => Some("panel_section"),
         }
     }
+}
+
+/// Re-join parsed targets into an `--in` flag value, so a suggested command
+/// can echo the active filter as the user could re-type it.
+pub fn targets_to_flag_value(targets: &[SearchTarget]) -> String {
+    targets.iter().map(|t| t.as_str()).collect::<Vec<_>>().join(",")
 }
 
 /// Compute a source type filter for semantic search from search targets.
@@ -73,24 +96,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_search_target_parse_list() {
-        let targets = SearchTarget::parse_list("titles,notes");
-        assert_eq!(targets.len(), 2);
-        assert!(targets.contains(&SearchTarget::Titles));
-        assert!(targets.contains(&SearchTarget::Notes));
+    fn test_all_matches_the_default_target_string() {
+        // `all()` and DEFAULT_SEARCH_TARGETS must stay in lockstep so the
+        // clap default and the footer's "is this the default?" check agree.
+        assert_eq!(targets_to_flag_value(&SearchTarget::all()), DEFAULT_SEARCH_TARGETS);
     }
 
     #[test]
-    fn test_search_target_parse_all() {
-        let targets = SearchTarget::parse_list("titles,transcripts,notes,panels");
-        assert_eq!(targets.len(), 4);
-        assert!(targets.contains(&SearchTarget::Panels));
+    fn test_as_str_round_trips_through_value_enum() {
+        // Every target's `as_str` spelling is one clap accepts back.
+        for target in SearchTarget::all() {
+            let parsed = SearchTarget::from_str(target.as_str(), false).unwrap();
+            assert_eq!(parsed, target);
+        }
     }
 
     #[test]
-    fn test_search_target_parse_unknown() {
-        let targets = SearchTarget::parse_list("titles,unknown");
-        assert_eq!(targets.len(), 1);
+    fn test_targets_to_flag_value_preserves_order() {
+        let flag = targets_to_flag_value(&[SearchTarget::Notes, SearchTarget::Titles]);
+        assert_eq!(flag, "notes,titles");
     }
 
     #[test]

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -207,7 +207,7 @@ mod tests {
     }
 
     fn all_targets() -> Vec<SearchTarget> {
-        SearchTarget::parse_list("titles,transcripts,notes,panels")
+        SearchTarget::all()
     }
 
     #[test]
@@ -238,7 +238,7 @@ mod tests {
     fn titles_only_targets_exclude_semantic_results() {
         let conn = build_test_db(&hybrid_state());
         let index = hybrid_index();
-        let targets = SearchTarget::parse_list("titles");
+        let targets = vec![SearchTarget::Titles];
 
         let fused =
             hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &targets, None, None, false)


### PR DESCRIPTION
## Problem

`SearchTarget::parse_list` split `--in` on commas and `filter_map`ped unknown tokens to `None`, so a typo vanished silently. `grans grep "budget" --in transcript` (singular) collapsed to an empty target set, built no FTS union, and printed `No meetings found matching "budget".` That reads as a fact about the corpus but is a fact about the typo, and since #65 made grep's count an honesty contract, this was the one input that quietly broke it. `--in titles,transcript` silently searched titles only.

## Fix

Fix it at the boundary instead of validating downstream:

- `SearchTarget` is now a clap `ValueEnum` (`rename_all = "lowercase"`), and both `search` and `grep` declare `--in` with `value_delimiter = ','`, so clap parses `Vec<SearchTarget>` directly and rejects an unknown target at parse time, naming the bad value and listing the valid ones.
- `parse_list` is deleted. `main.rs` threads the parsed target list straight into `GrepOptions`/`SearchOptions`; nothing reconstructs it from a raw string.
- The grep cross-link footer in `commands/search.rs` re-joins the parsed targets into the flag string (`targets_to_flag_value`) instead of echoing a raw `--in` string, so the suggested command still reproduces the count the footer claims.
- The default (`--in` omitted) is unchanged: every source (`titles,transcripts,notes,panels`). The existing `--speaker` requires-transcripts error in grep is unchanged.

The test that documented the silent drop is replaced with CLI parse tests that pin the rejection (unknown token alone and inside a valid list, on both verbs), that valid lists still parse, and that the default is the full target set.

## Before / after

Before, the typo produced a corpus-shaped no-op (exit 0):

```
$ grans grep "budget" --in transcript
No meetings found matching "budget".
```

After, it fails at parse time (exit 2) and even suggests the correction:

```
$ grans grep "budget" --in transcript
error: invalid value 'transcript' for '--in <IN>'
  [possible values: titles, transcripts, notes, panels]

  tip: a similar value exists: 'transcripts'

For more information, try '--help'.
```

`--help` now lists the valid targets automatically via `ValueEnum`:

```
      --in <IN>
          Where to search (comma-separated)

          [default: titles,transcripts,notes,panels]
          [possible values: titles, transcripts, notes, panels]
```

Valid input is unchanged: `grans grep "test" --in titles` and the bare-default path still work.

## Tests

- `cargo test --bin grans`: 762 passing (757 baseline + 5 net new; `parse_list`'s 3 unit tests replaced by `all`/`as_str`/`targets_to_flag_value` tests, plus 5 new CLI parse tests). Note: the `update::tests` env-var tests share process env and race under the default parallel runner (pre-existing, unrelated to this change); `--test-threads=1` is green.
- Integration suites run explicitly per #56 (this crate has no lib target): `date_filter` 8, `end_to_end` 37, `errors` 3, `people_junction` 6, `search` 21, all passing.

## Notes

Stacked on #79 (issue #76, which moved the args tests into `src/cli/args/tests.rs`). Base is `chore/76-extract-args-tests`; GitHub will retarget this to `main` when #79 merges and its branch is deleted.

Closes #74

https://claude.ai/code/session_01TmhUwR8kAqCjZFvf3vFJXQ
