### PR TITLE
#86: Decrypt Granola token store on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,15 +190,24 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -239,6 +248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -386,6 +404,16 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -546,6 +574,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -849,10 +878,12 @@ dependencies = [
 name = "grans"
 version = "0.0.0-dev"
 dependencies = [
+ "aes",
  "aes-gcm",
  "anyhow",
  "assert_cmd",
  "base64 0.22.1",
+ "cbc",
  "chrono",
  "clap",
  "colored",
@@ -863,14 +894,17 @@ dependencies = [
  "log",
  "open",
  "ort",
+ "pbkdf2",
  "predicates",
  "rand 0.8.5",
  "reqwest",
  "rusqlite",
  "rusqlite_migration",
+ "security-framework",
  "self-replace",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "strip-ansi-escapes",
  "tempfile",
@@ -925,6 +959,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ureq 2.12.1",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1195,6 +1238,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -1564,6 +1608,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2060,6 +2114,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "self-replace"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2209,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2550,9 +2638,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ self-replace = "1.5"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["color"] }
 aes-gcm = "0.10"
+aes = { version = "0.8", default-features = false }
+sha1 = { version = "0.10", default-features = false }
+pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
+cbc = "0.1"
 
 [dev-dependencies]
 assert_cmd = "2.1.2"
@@ -47,3 +51,6 @@ codegen-units = 4   # More parallelism (release default is 1)
 
 [target."cfg(windows)".dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Security_Cryptography", "Win32_Foundation"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = "3"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ grans sync panels --retry             # Retry previously failed panel fetches
 grans --token <TOKEN> sync
 ```
 
+On macOS, the decryption key lives in the login Keychain, so the first sync shows a Keychain access prompt ("grans wants to use your confidential information stored in 'Granola Safe Storage'"). Choose "Always Allow" to skip it on later runs, or pass `--token` to avoid reading the Keychain at all.
+
 To get the token from a machine with Granola installed:
 
 ```bash

--- a/src/api/token_store.rs
+++ b/src/api/token_store.rs
@@ -2,36 +2,44 @@
 //!
 //! Recent Granola versions no longer keep the Supabase auth token in a
 //! plaintext `supabase.json`. Instead they use the standard Chromium/Electron
-//! `os_crypt` + safeStorage scheme, with three layers:
+//! safeStorage scheme, with three layers:
 //!
 //! ```text
-//! Local State -> os_crypt.encrypted_key  (OS-wrapped AES-256 master key)
-//! storage.dek                            (master-key-encrypted data key)
-//! supabase.json.enc                      (data-key-encrypted token JSON)
+//! safeStorage key   (from the OS credential store)
+//! storage.dek       (safeStorage-encrypted data key, base64-encoded plaintext)
+//! supabase.json.enc (data-key-encrypted token JSON)
 //! ```
 //!
-//! The master key is unwrapped by the OS credential store (DPAPI on Windows,
-//! keyed to the current user), so any process running as that user can decrypt
-//! the token without a password. Both inner layers are AES-256-GCM with a
-//! 12-byte nonce; the GCM auth tag makes a wrong framing fail loudly rather
-//! than returning garbage.
+//! Only the innermost unseal of `storage.dek` is platform-specific; everything
+//! after it (base64-decoding the data key, then AES-256-GCM decrypting
+//! `supabase.json.enc`) is shared:
+//!
+//! - **Windows** (`os_crypt`): `Local State` holds a DPAPI-wrapped AES-256
+//!   master key, keyed to the current user. `storage.dek` is a `"v10"`-prefixed
+//!   AES-256-GCM blob whose auth tag makes a wrong framing fail loudly.
+//! - **macOS** (safeStorage): a password lives in the login Keychain (service
+//!   `"Granola Safe Storage"`, account `"Granola"`). An AES-128 key is derived
+//!   from it via PBKDF2-HMAC-SHA1, and `storage.dek` is a `"v10"`-prefixed
+//!   AES-128-CBC blob with an all-spaces IV and PKCS#7 padding (no auth tag).
 
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
 use anyhow::{bail, Context, Result};
 use base64::Engine;
 use log::debug;
-use serde::Deserialize;
+use sha1::Sha1;
 use std::path::Path;
 
 const NONCE_LEN: usize = 12;
 
-#[derive(Deserialize)]
+#[cfg(windows)]
+#[derive(serde::Deserialize)]
 struct LocalState {
     os_crypt: OsCrypt,
 }
 
-#[derive(Deserialize)]
+#[cfg(windows)]
+#[derive(serde::Deserialize)]
 struct OsCrypt {
     encrypted_key: String,
 }
@@ -39,16 +47,13 @@ struct OsCrypt {
 /// Decrypt the Granola token store in `granola_dir` and return the raw JSON
 /// string that the plaintext `supabase.json` used to contain.
 pub fn decrypt_token_json(granola_dir: &Path) -> Result<String> {
-    let master = master_key(granola_dir)?;
-
-    let dek_blob = std::fs::read(granola_dir.join("storage.dek"))
-        .context("Failed to read storage.dek")?;
-    // storage.dek is a "v10"-prefixed os_crypt blob whose plaintext is the
-    // base64-encoded data key.
-    let dek_plaintext = gcm_open(&master, &dek_blob, 3).context("Failed to decrypt storage.dek")?;
+    // storage.dek unseals to the base64-encoded data key; the unseal step is
+    // platform-specific, everything after it is not.
+    let dek_plaintext = unseal_dek(granola_dir)?;
     let data_key = base64::engine::general_purpose::STANDARD
         .decode(dek_plaintext.trim_ascii())
         .context("storage.dek plaintext was not valid base64")?;
+    debug!("Recovered safeStorage data key ({} bytes)", data_key.len());
 
     let token_blob = std::fs::read(granola_dir.join("supabase.json.enc"))
         .context("Failed to read supabase.json.enc")?;
@@ -59,7 +64,53 @@ pub fn decrypt_token_json(granola_dir: &Path) -> Result<String> {
     String::from_utf8(token_plaintext).context("Decrypted token payload was not valid UTF-8")
 }
 
+/// Read `storage.dek` and unseal it to the base64 data-key plaintext using the
+/// Windows os_crypt master key (`Local State` + DPAPI).
+#[cfg(windows)]
+fn unseal_dek(granola_dir: &Path) -> Result<Vec<u8>> {
+    let master = master_key(granola_dir)?;
+    let dek_blob = std::fs::read(granola_dir.join("storage.dek"))
+        .context("Failed to read storage.dek")?;
+    // storage.dek is a "v10"-prefixed os_crypt GCM blob.
+    gcm_open(&master, &dek_blob, 3).context("Failed to decrypt storage.dek")
+}
+
+/// Read `storage.dek` and unseal it to the base64 data-key plaintext using the
+/// macOS safeStorage key (Keychain password + PBKDF2 + AES-128-CBC).
+#[cfg(target_os = "macos")]
+fn unseal_dek(granola_dir: &Path) -> Result<Vec<u8>> {
+    let key = derive_cbc_key(&keychain_password()?);
+    let dek_blob = std::fs::read(granola_dir.join("storage.dek"))
+        .context("Failed to read storage.dek")?;
+    // storage.dek is a "v10"-prefixed safeStorage CBC blob.
+    cbc_open(&key, &dek_blob, 3).context("Failed to decrypt storage.dek")
+}
+
+/// Reading Granola's encrypted token store is not implemented on this platform.
+/// This bail runs before any credential-store or `storage.dek` access so users
+/// see the `--token` guidance instead of a confusing parse error.
+#[cfg(not(any(windows, target_os = "macos")))]
+fn unseal_dek(_granola_dir: &Path) -> Result<Vec<u8>> {
+    bail!(
+        "Reading Granola's encrypted token store is currently implemented only on \
+         Windows and macOS. On this platform, pass a token explicitly with --token."
+    )
+}
+
+/// Read Electron's safeStorage password from the macOS login Keychain.
+///
+/// The first read triggers a Keychain access prompt; approving "Always Allow"
+/// suppresses it on later runs.
+#[cfg(target_os = "macos")]
+fn keychain_password() -> Result<Vec<u8>> {
+    security_framework::passwords::get_generic_password("Granola Safe Storage", "Granola").context(
+        "Failed to read the 'Granola Safe Storage' password from the macOS Keychain. \
+         Ensure Granola is installed and allow access when prompted, or pass --token.",
+    )
+}
+
 /// Read and OS-unwrap the AES-256 master key from Granola's `Local State`.
+#[cfg(windows)]
 fn master_key(granola_dir: &Path) -> Result<Vec<u8>> {
     let content = std::fs::read_to_string(granola_dir.join("Local State"))
         .context("Failed to read Local State")?;
@@ -96,6 +147,48 @@ fn gcm_open(key: &[u8], blob: &[u8], prefix_len: usize) -> Result<Vec<u8>> {
     Aes256Gcm::new(key)
         .decrypt(Nonce::from_slice(nonce), ciphertext)
         .map_err(|_| anyhow::anyhow!("AES-GCM authentication failed (wrong key or corrupt data)"))
+}
+
+/// Derive the AES-128 safeStorage key from a Keychain password using Electron's
+/// fixed PBKDF2 parameters (HMAC-SHA1, salt "saltysalt", 1003 iterations).
+///
+/// Compiled on every platform so the derivation stays unit-testable; only the
+/// macOS unseal path calls it in a real build.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn derive_cbc_key(password: &[u8]) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    pbkdf2::pbkdf2_hmac::<Sha1>(password, b"saltysalt", 1003, &mut key);
+    key
+}
+
+/// Decrypt a safeStorage AES-128-CBC blob laid out as `[prefix][ciphertext]`
+/// with a fixed all-spaces IV and PKCS#7 padding. Unlike the GCM layout there
+/// is no nonce or auth tag, so a wrong key surfaces as a padding error rather
+/// than an authentication failure (and can occasionally decode to garbage).
+///
+/// Compiled on every platform so the CBC layer stays unit-testable; only the
+/// macOS unseal path calls it in a real build.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn cbc_open(key: &[u8], blob: &[u8], prefix_len: usize) -> Result<Vec<u8>> {
+    use aes::Aes128;
+    use cbc::cipher::block_padding::Pkcs7;
+    use cbc::cipher::{BlockDecryptMut, KeyIvInit};
+
+    type Aes128CbcDec = cbc::Decryptor<Aes128>;
+
+    let ciphertext = blob
+        .get(prefix_len..)
+        .context("Encrypted blob shorter than its version prefix")?;
+
+    let iv = [b' '; 16];
+    let cipher = Aes128CbcDec::new_from_slices(key, &iv)
+        .map_err(|_| anyhow::anyhow!("AES-128 key must be 16 bytes, got {}", key.len()))?;
+
+    let mut buf = ciphertext.to_vec();
+    let plaintext = cipher
+        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .map_err(|_| anyhow::anyhow!("AES-CBC decryption failed (wrong key or corrupt data)"))?;
+    Ok(plaintext.to_vec())
 }
 
 /// Unwrap a key blob using the OS credential store.
@@ -137,14 +230,6 @@ fn os_unwrap(blob: &[u8]) -> Result<Vec<u8>> {
     // SAFETY: freeing the buffer Windows allocated for us.
     unsafe { LocalFree(output.pbData as _) };
     Ok(key)
-}
-
-#[cfg(not(windows))]
-fn os_unwrap(_blob: &[u8]) -> Result<Vec<u8>> {
-    bail!(
-        "Reading Granola's encrypted token store is currently implemented only on \
-         Windows. On this platform, pass a token explicitly with --token."
-    )
 }
 
 #[cfg(test)]
@@ -200,5 +285,79 @@ mod tests {
     fn gcm_open_rejects_bad_key_length() {
         let blob = seal(&[9u8; 32], &[1u8; NONCE_LEN], b"x", b"");
         assert!(gcm_open(&[0u8; 16], &blob, 0).is_err());
+    }
+
+    /// Encrypt with the same AES-128-CBC framing macOS safeStorage uses (fixed
+    /// all-spaces IV, PKCS#7 padding), so we can exercise cbc_open without a
+    /// live Keychain.
+    fn cbc_seal(key: &[u8; 16], plaintext: &[u8], prefix: &[u8]) -> Vec<u8> {
+        use aes::Aes128;
+        use cbc::cipher::block_padding::Pkcs7;
+        use cbc::cipher::{BlockEncryptMut, KeyIvInit};
+
+        type Aes128CbcEnc = cbc::Encryptor<Aes128>;
+
+        let iv = [b' '; 16];
+        let mut buf = vec![0u8; plaintext.len() + 16];
+        let ciphertext = Aes128CbcEnc::new_from_slices(key, &iv)
+            .unwrap()
+            .encrypt_padded_b2b_mut::<Pkcs7>(plaintext, &mut buf)
+            .unwrap();
+        [prefix, ciphertext].concat()
+    }
+
+    #[test]
+    fn cbc_open_round_trips_with_v10_prefix() {
+        let key = [0x11u8; 16];
+        let blob = cbc_seal(&key, b"the data key", b"v10");
+
+        let out = cbc_open(&key, &blob, 3).unwrap();
+        assert_eq!(out, b"the data key");
+    }
+
+    #[test]
+    fn cbc_open_round_trips_without_prefix() {
+        let key = [0x22u8; 16];
+        let blob = cbc_seal(&key, b"{\"workos_tokens\":{}}", b"");
+
+        let out = cbc_open(&key, &blob, 0).unwrap();
+        assert_eq!(out, b"{\"workos_tokens\":{}}");
+    }
+
+    #[test]
+    fn cbc_open_rejects_bad_key_length() {
+        let blob = cbc_seal(&[0x22u8; 16], b"x", b"");
+        assert!(cbc_open(&[0u8; 15], &blob, 0).is_err());
+    }
+
+    #[test]
+    fn cbc_open_rejects_short_prefix() {
+        assert!(cbc_open(&[0u8; 16], b"v1", 3).is_err());
+    }
+
+    #[test]
+    fn cbc_open_rejects_non_block_aligned_ciphertext() {
+        // 6 bytes after the prefix is not a whole AES block, so unpadding fails.
+        assert!(cbc_open(&[0u8; 16], b"v10short!", 3).is_err());
+    }
+
+    #[test]
+    fn derive_cbc_key_matches_known_vector() {
+        // PBKDF2-HMAC-SHA1("peanuts", "saltysalt", 1003, 16 bytes) is Chromium's
+        // documented safeStorage vector; pins salt, iteration count, and digest.
+        let key = derive_cbc_key(b"peanuts");
+        assert_eq!(
+            key,
+            [217, 160, 157, 73, 155, 78, 27, 116, 97, 242, 142, 103, 151, 44, 109, 189]
+        );
+    }
+
+    #[test]
+    fn derive_cbc_key_round_trips_through_cbc_open() {
+        let key = derive_cbc_key(b"Granola Safe Storage password");
+        let blob = cbc_seal(&key, b"YmFzZTY0IGRhdGEga2V5", b"v10");
+
+        let out = cbc_open(&key, &blob, 3).unwrap();
+        assert_eq!(out, b"YmFzZTY0IGRhdGEga2V5");
     }
 }


### PR DESCRIPTION
Fixes #86.

## Problem

`grans sync` failed on macOS with a confusing error:

```
Error: Failed to read encrypted Granola token store in ...
Caused by:
    0: Failed to parse Local State
    1: missing field `os_crypt` at line 1 column 57
```

The encrypted token store only implemented the Windows `os_crypt` path. `decrypt_token_json` unconditionally parsed Granola's `Local State` expecting `os_crypt.encrypted_key`, a Windows-only convention. On macOS the safeStorage key lives in the Keychain, so `Local State` has no `os_crypt` field and parsing failed before the unsupported-platform bail could run.

## Fix

Restructured `token_store.rs` so only the innermost unseal of `storage.dek` is platform-specific; base64-decoding the data key and AES-256-GCM decrypting `supabase.json.enc` stay shared.

- **Windows**: unchanged behavior (`Local State` + DPAPI + GCM).
- **macOS**: read the `"Granola Safe Storage"` Keychain password, derive an AES-128 key via PBKDF2-HMAC-SHA1 (salt `"saltysalt"`, 1003 iterations), and AES-128-CBC decrypt `storage.dek` (all-spaces IV, PKCS#7 padding, no auth tag).
- **Other platforms**: the unsupported-platform bail now runs before any credential-store or file access, so Linux users get the clean `--token` guidance instead of a parse error.

Dependencies: `security-framework` (macOS-only) for the Keychain read; `aes`/`cbc`/`pbkdf2`/`sha1` (all platforms, pinned to the cipher-0.4 generation so `aes` unifies with the copy already pulled in by `aes-gcm`).

## Testing

The CBC and PBKDF2 helpers compile on every platform so they stay unit-testable off a Mac:

- `derive_cbc_key_matches_known_vector` pins the derivation to Chromium's documented safeStorage vector (`peanuts` / `saltysalt` / 1003), catching any drift in salt, iteration count, or digest.
- `cbc_open` round-trips a sealed fixture, and rejects bad key length, short prefixes, and non-block-aligned ciphertext.
- Full suite green on Windows (769 bin unit tests + 75 integration tests).
- Verified the Windows encrypted-store path still decrypts end to end (`grans sync` completes).

Cross-target typechecking from the Windows dev box (a full cross-build is blocked by C build scripts): extracted the macOS-specific logic into a scratch crate and confirmed it typechecks against `x86_64-apple-darwin` (including the `security_framework` Keychain call), and the all-platform crypto + bail path typecheck against `x86_64-unknown-linux-gnu`.

## Needs a Mac to verify (per the issue)

The scheme is inferred from Chromium/Electron's standard safeStorage implementation, not a live macOS Granola install. Still to confirm on a Mac:

- Keychain item name: `security find-generic-password -s "Granola Safe Storage"` finds it (if Granola registered a different app name, the service string differs).
- First `grans sync` triggers a Keychain access prompt; "Always Allow" suppresses it afterward.
- End to end: `grans sync` with no `--token` completes on macOS.