### PR TITLE
#91: Stop trying to read Granola's local store on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,12 +1114,10 @@ dependencies = [
 name = "grans"
 version = "0.0.0-dev"
 dependencies = [
- "aes",
  "aes-gcm",
  "anyhow",
  "assert_cmd",
  "base64 0.22.1",
- "cbc",
  "chrono",
  "clap",
  "colored",
@@ -1131,17 +1129,14 @@ dependencies = [
  "log",
  "open",
  "ort",
- "pbkdf2",
  "predicates",
  "rand 0.8.5",
  "reqwest",
  "rusqlite",
  "rusqlite_migration",
- "security-framework",
  "self-replace",
  "serde",
  "serde_json",
- "sha1",
  "sha2",
  "strip-ansi-escapes",
  "tempfile",
@@ -1961,16 +1956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2630,17 +2615,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,6 @@ self-replace = "1.5"
 log = "0.4"
 env_logger = { version = "0.11", default-features = false, features = ["color"] }
 aes-gcm = "0.10"
-aes = { version = "0.8", default-features = false }
-sha1 = { version = "0.10", default-features = false }
-pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
-cbc = "0.1"
 url = "2.5.8"
 uuid = { version = "1.24.0", features = ["v4"] }
 keyring = { version = "4.1.5", features = ["apple-native-keyring-store"] }
@@ -54,6 +50,3 @@ codegen-units = 4   # More parallelism (release default is 1)
 
 [target."cfg(windows)".dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Security_Cryptography", "Win32_Foundation"] }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "3"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ grans sync panels --retry             # Retry previously failed panel fetches
 
 1. `--token <TOKEN>`, or the `GRANS_TOKEN` environment variable
 2. grans's own stored credentials, from `grans auth login`
-3. The token Granola's desktop app stored locally
+3. The token Granola's desktop app stored locally (not on macOS, see below)
 
 ### Signing in
 
@@ -181,14 +181,16 @@ or self-updated grans may ask for keychain access again.
 
 ### Reading Granola's local token
 
-Without `grans auth login`, grans falls back to the token Granola's desktop app
-stored, decrypting the `supabase.json.enc` store that recent versions use
-(falling back to the legacy plaintext `supabase.json`).
+On Windows and Linux, and without `grans auth login`, grans falls back to the
+token Granola's desktop app stored, decrypting the `supabase.json.enc` store
+that recent versions use (falling back to the legacy plaintext
+`supabase.json`).
 
-**This no longer works on current macOS builds.** Granola moved its
-data-encryption key into the macOS data-protection keychain, gated on Granola's
-own code signature, so no other program can read it. Use `grans auth login`
-instead. The fallback still works on Windows.
+**There is no such fallback on macOS.** Granola keeps its data-encryption key
+in the macOS data-protection keychain, gated on Granola's own code signature,
+so no other program can read it. grans does not try: with no session of its
+own it tells you to run `grans auth login`, which is the only thing that
+works there.
 
 To print whichever token grans resolves:
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -281,7 +281,7 @@ flowchart LR
 ```
 
 The `grans sync` command:
-1. Authenticates using the token from Granola's local config (the encrypted `supabase.json.enc` store on recent versions, or the legacy plaintext `supabase.json`)
+1. Authenticates with grans's own stored credentials from `grans auth login`, falling back off macOS to the token in Granola's local config (the encrypted `supabase.json.enc` store on recent versions, or the legacy plaintext `supabase.json`)
 2. Fetches data from Granola API endpoints (`get-documents`, `get-people`, etc.)
 3. Upserts records into the local SQLite database
 4. Tracks last sync time per entity type in the `metadata` table

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,8 +1,8 @@
 //! Deciding which token grans authenticates with.
 //!
 //! The sources themselves live elsewhere: [`super::credential_store`] holds
-//! grans's own session and [`super::local_store`] reads the one Granola's desktop
-//! app stored. This module is the order they are tried in.
+//! grans's own session and, off macOS, `super::local_store` reads the one
+//! Granola's desktop app stored. This module is the order they are tried in.
 
 use anyhow::{bail, Result};
 use chrono::Utc;
@@ -10,7 +10,9 @@ use log::debug;
 
 use super::credential_store::CredentialStore;
 use super::credentials::GranolaCredentials;
-use super::{granola_auth, local_store};
+use super::granola_auth;
+#[cfg(not(target_os = "macos"))]
+use super::local_store;
 
 /// Environment variable supplying a token when `--token` is absent.
 pub const TOKEN_ENV_VAR: &str = "GRANS_TOKEN";
@@ -35,9 +37,10 @@ pub fn token_override(flag: Option<&str>, env_value: Option<String>) -> Option<S
 /// own stored credentials, refreshing them when the access token has expired,
 /// then the token Granola's desktop app stored locally.
 ///
-/// That last step no longer works on current macOS builds, where Granola's
-/// data-encryption key sits behind its own code signature, but it is still the
-/// only source on Windows for anyone who has not run `grans auth login`.
+/// That last step exists everywhere except macOS, where Granola's
+/// data-encryption key sits in the data-protection keychain behind its own
+/// code signature. Nothing grans can do reaches it, so the chain there ends by
+/// asking the user to sign in instead.
 pub fn resolve_token(override_token: Option<&str>) -> Result<String> {
     match override_token {
         Some(token) if token.is_empty() => {
@@ -51,7 +54,8 @@ pub fn resolve_token(override_token: Option<&str>) -> Result<String> {
     }
 }
 
-/// Use grans's own credentials if it has any, otherwise Granola's local store.
+/// Use grans's own credentials if it has any, otherwise whatever this platform
+/// can fall back to.
 fn stored_or_local_token() -> Result<String> {
     let store = CredentialStore::open()?;
 
@@ -60,11 +64,30 @@ fn stored_or_local_token() -> Result<String> {
             debug!("Using grans's own stored credentials");
             token_from_credentials(credentials, &store)
         }
-        None => {
-            debug!("No stored credentials; reading Granola's local token store");
-            local_store::get_auth_token()
-        }
+        None => local_store_token(),
     }
+}
+
+/// Fall back to the token Granola's desktop app stored on this machine.
+#[cfg(not(target_os = "macos"))]
+fn local_store_token() -> Result<String> {
+    debug!("No stored credentials; reading Granola's local token store");
+    local_store::get_auth_token()
+}
+
+/// macOS has no such fallback to try.
+///
+/// Granola's data-encryption key lives in the data-protection keychain, which
+/// hands it only to Granola's own code signature. Attempting the read anyway
+/// would fail with a keychain error naming Granola rather than the one thing
+/// that fixes it.
+#[cfg(target_os = "macos")]
+fn local_store_token() -> Result<String> {
+    bail!(
+        "Not signed in. Run `grans auth login`.\n\n\
+         grans cannot borrow the token Granola's desktop app stored: on macOS \
+         that key is reachable only by Granola itself."
+    )
 }
 
 /// Return the stored access token, refreshing it first if it has expired.
@@ -191,6 +214,17 @@ mod tests {
     #[test]
     fn test_token_override_absent_without_flag_or_env() {
         assert_eq!(token_override(None, None), None);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_names_the_remedy_instead_of_reading_granolas_store() {
+        // Granola's key is unreachable here, so the chain has to end with the
+        // one thing that fixes it rather than a keychain error about Granola.
+        let error = local_store_token().unwrap_err().to_string();
+
+        assert!(error.contains("grans auth login"));
+        assert!(!error.contains("Keychain"));
     }
 
     // --- refresh chain ---

--- a/src/api/local_store.rs
+++ b/src/api/local_store.rs
@@ -1,10 +1,10 @@
 //! Reading the auth token Granola's desktop app stored on this machine.
 //!
-//! This is grans's fallback when it has no session of its own. It no longer
-//! works on current macOS builds, where Granola's data-encryption key sits in
-//! the data-protection keychain behind Granola's code signature, but it is
-//! still the only source on Windows for anyone who has not run
-//! `grans auth login`.
+//! This is grans's fallback when it has no session of its own, and the only
+//! source on Windows for anyone who has not run `grans auth login`. It is not
+//! compiled on macOS: Granola's data-encryption key sits in the
+//! data-protection keychain behind Granola's own code signature, so there is
+//! nothing there for grans to read.
 
 use std::env;
 use std::path::{Path, PathBuf};
@@ -190,9 +190,6 @@ fn granola_dir_candidates() -> Vec<PathBuf> {
     }
 
     if let Some(home) = dirs_home() {
-        // macOS
-        candidates.push(home.join("Library/Application Support/Granola"));
-
         // Linux / WSL fallback
         candidates.push(home.join(".config/Granola"));
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,7 +4,11 @@ pub mod credential_store;
 pub mod credentials;
 pub mod granola_auth;
 pub mod identity;
+// Granola's own token store is readable everywhere but macOS, where its
+// encryption key sits behind Granola's code signature. See `auth`.
+#[cfg(not(target_os = "macos"))]
 pub mod local_store;
+#[cfg(not(target_os = "macos"))]
 mod token_store;
 pub mod types;
 

--- a/src/api/token_store.rs
+++ b/src/api/token_store.rs
@@ -12,22 +12,18 @@
 //!
 //! Only the innermost unseal of `storage.dek` is platform-specific; everything
 //! after it (base64-decoding the data key, then AES-256-GCM decrypting
-//! `supabase.json.enc`) is shared:
+//! `supabase.json.enc`) is shared. Windows (`os_crypt`) is the one platform
+//! that implements it: `Local State` holds a DPAPI-wrapped AES-256 master key,
+//! keyed to the current user, and `storage.dek` is a `"v10"`-prefixed
+//! AES-256-GCM blob whose auth tag makes a wrong framing fail loudly.
 //!
-//! - **Windows** (`os_crypt`): `Local State` holds a DPAPI-wrapped AES-256
-//!   master key, keyed to the current user. `storage.dek` is a `"v10"`-prefixed
-//!   AES-256-GCM blob whose auth tag makes a wrong framing fail loudly.
-//! - **macOS** (safeStorage): a password lives in the login Keychain (service
-//!   `"Granola Safe Storage"`, account `"Granola"`). An AES-128 key is derived
-//!   from it via PBKDF2-HMAC-SHA1, and `storage.dek` is a `"v10"`-prefixed
-//!   AES-128-CBC blob with an all-spaces IV and PKCS#7 padding (no auth tag).
+//! This module is not compiled on macOS; see [`super::auth`] for why.
 
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
 use anyhow::{bail, Context, Result};
 use base64::Engine;
 use log::debug;
-use sha1::Sha1;
 use std::path::Path;
 
 const NONCE_LEN: usize = 12;
@@ -75,37 +71,15 @@ fn unseal_dek(granola_dir: &Path) -> Result<Vec<u8>> {
     gcm_open(&master, &dek_blob, 3).context("Failed to decrypt storage.dek")
 }
 
-/// Read `storage.dek` and unseal it to the base64 data-key plaintext using the
-/// macOS safeStorage key (Keychain password + PBKDF2 + AES-128-CBC).
-#[cfg(target_os = "macos")]
-fn unseal_dek(granola_dir: &Path) -> Result<Vec<u8>> {
-    let key = derive_cbc_key(&keychain_password()?);
-    let dek_blob = std::fs::read(granola_dir.join("storage.dek"))
-        .context("Failed to read storage.dek")?;
-    // storage.dek is a "v10"-prefixed safeStorage CBC blob.
-    cbc_open(&key, &dek_blob, 3).context("Failed to decrypt storage.dek")
-}
-
 /// Reading Granola's encrypted token store is not implemented on this platform.
 /// This bail runs before any credential-store or `storage.dek` access so users
 /// see the `--token` guidance instead of a confusing parse error.
-#[cfg(not(any(windows, target_os = "macos")))]
+#[cfg(not(windows))]
 fn unseal_dek(_granola_dir: &Path) -> Result<Vec<u8>> {
     bail!(
         "Reading Granola's encrypted token store is currently implemented only on \
-         Windows and macOS. On this platform, pass a token explicitly with --token."
-    )
-}
-
-/// Read Electron's safeStorage password from the macOS login Keychain.
-///
-/// The first read triggers a Keychain access prompt; approving "Always Allow"
-/// suppresses it on later runs.
-#[cfg(target_os = "macos")]
-fn keychain_password() -> Result<Vec<u8>> {
-    security_framework::passwords::get_generic_password("Granola Safe Storage", "Granola").context(
-        "Failed to read the 'Granola Safe Storage' password from the macOS Keychain. \
-         Ensure Granola is installed and allow access when prompted, or pass --token.",
+         Windows. On this platform, sign in with `grans auth login` or pass a token \
+         explicitly with --token."
     )
 }
 
@@ -147,48 +121,6 @@ fn gcm_open(key: &[u8], blob: &[u8], prefix_len: usize) -> Result<Vec<u8>> {
     Aes256Gcm::new(key)
         .decrypt(Nonce::from_slice(nonce), ciphertext)
         .map_err(|_| anyhow::anyhow!("AES-GCM authentication failed (wrong key or corrupt data)"))
-}
-
-/// Derive the AES-128 safeStorage key from a Keychain password using Electron's
-/// fixed PBKDF2 parameters (HMAC-SHA1, salt "saltysalt", 1003 iterations).
-///
-/// Compiled on every platform so the derivation stays unit-testable; only the
-/// macOS unseal path calls it in a real build.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn derive_cbc_key(password: &[u8]) -> [u8; 16] {
-    let mut key = [0u8; 16];
-    pbkdf2::pbkdf2_hmac::<Sha1>(password, b"saltysalt", 1003, &mut key);
-    key
-}
-
-/// Decrypt a safeStorage AES-128-CBC blob laid out as `[prefix][ciphertext]`
-/// with a fixed all-spaces IV and PKCS#7 padding. Unlike the GCM layout there
-/// is no nonce or auth tag, so a wrong key surfaces as a padding error rather
-/// than an authentication failure (and can occasionally decode to garbage).
-///
-/// Compiled on every platform so the CBC layer stays unit-testable; only the
-/// macOS unseal path calls it in a real build.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn cbc_open(key: &[u8], blob: &[u8], prefix_len: usize) -> Result<Vec<u8>> {
-    use aes::Aes128;
-    use cbc::cipher::block_padding::Pkcs7;
-    use cbc::cipher::{BlockDecryptMut, KeyIvInit};
-
-    type Aes128CbcDec = cbc::Decryptor<Aes128>;
-
-    let ciphertext = blob
-        .get(prefix_len..)
-        .context("Encrypted blob shorter than its version prefix")?;
-
-    let iv = [b' '; 16];
-    let cipher = Aes128CbcDec::new_from_slices(key, &iv)
-        .map_err(|_| anyhow::anyhow!("AES-128 key must be 16 bytes, got {}", key.len()))?;
-
-    let mut buf = ciphertext.to_vec();
-    let plaintext = cipher
-        .decrypt_padded_mut::<Pkcs7>(&mut buf)
-        .map_err(|_| anyhow::anyhow!("AES-CBC decryption failed (wrong key or corrupt data)"))?;
-    Ok(plaintext.to_vec())
 }
 
 /// Unwrap a key blob using the OS credential store.
@@ -287,77 +219,4 @@ mod tests {
         assert!(gcm_open(&[0u8; 16], &blob, 0).is_err());
     }
 
-    /// Encrypt with the same AES-128-CBC framing macOS safeStorage uses (fixed
-    /// all-spaces IV, PKCS#7 padding), so we can exercise cbc_open without a
-    /// live Keychain.
-    fn cbc_seal(key: &[u8; 16], plaintext: &[u8], prefix: &[u8]) -> Vec<u8> {
-        use aes::Aes128;
-        use cbc::cipher::block_padding::Pkcs7;
-        use cbc::cipher::{BlockEncryptMut, KeyIvInit};
-
-        type Aes128CbcEnc = cbc::Encryptor<Aes128>;
-
-        let iv = [b' '; 16];
-        let mut buf = vec![0u8; plaintext.len() + 16];
-        let ciphertext = Aes128CbcEnc::new_from_slices(key, &iv)
-            .unwrap()
-            .encrypt_padded_b2b_mut::<Pkcs7>(plaintext, &mut buf)
-            .unwrap();
-        [prefix, ciphertext].concat()
-    }
-
-    #[test]
-    fn cbc_open_round_trips_with_v10_prefix() {
-        let key = [0x11u8; 16];
-        let blob = cbc_seal(&key, b"the data key", b"v10");
-
-        let out = cbc_open(&key, &blob, 3).unwrap();
-        assert_eq!(out, b"the data key");
-    }
-
-    #[test]
-    fn cbc_open_round_trips_without_prefix() {
-        let key = [0x22u8; 16];
-        let blob = cbc_seal(&key, b"{\"workos_tokens\":{}}", b"");
-
-        let out = cbc_open(&key, &blob, 0).unwrap();
-        assert_eq!(out, b"{\"workos_tokens\":{}}");
-    }
-
-    #[test]
-    fn cbc_open_rejects_bad_key_length() {
-        let blob = cbc_seal(&[0x22u8; 16], b"x", b"");
-        assert!(cbc_open(&[0u8; 15], &blob, 0).is_err());
-    }
-
-    #[test]
-    fn cbc_open_rejects_short_prefix() {
-        assert!(cbc_open(&[0u8; 16], b"v1", 3).is_err());
-    }
-
-    #[test]
-    fn cbc_open_rejects_non_block_aligned_ciphertext() {
-        // 6 bytes after the prefix is not a whole AES block, so unpadding fails.
-        assert!(cbc_open(&[0u8; 16], b"v10short!", 3).is_err());
-    }
-
-    #[test]
-    fn derive_cbc_key_matches_known_vector() {
-        // PBKDF2-HMAC-SHA1("peanuts", "saltysalt", 1003, 16 bytes) is Chromium's
-        // documented safeStorage vector; pins salt, iteration count, and digest.
-        let key = derive_cbc_key(b"peanuts");
-        assert_eq!(
-            key,
-            [217, 160, 157, 73, 155, 78, 27, 116, 97, 242, 142, 103, 151, 44, 109, 189]
-        );
-    }
-
-    #[test]
-    fn derive_cbc_key_round_trips_through_cbc_open() {
-        let key = derive_cbc_key(b"Granola Safe Storage password");
-        let blob = cbc_seal(&key, b"YmFzZTY0IGRhdGEga2V5", b"v10");
-
-        let out = cbc_open(&key, &blob, 3).unwrap();
-        assert_eq!(out, b"YmFzZTY0IGRhdGEga2V5");
-    }
 }


### PR DESCRIPTION
Closes #91.

`grans sync` on a Mac that has never run `grans auth login` fell through to Granola's own token store and failed there:

```
Failed to read the 'Granola Safe Storage' password from the macOS Keychain.
Ensure Granola is installed and allow access when prompted, or pass --token.
```

Granola's data-encryption key lives in the macOS data-protection keychain, gated on Granola's code signature, so that read can never succeed. Both suggestions in the message are dead ends, and it never names `grans auth login`, which is the fix.

## What changed

The token chain now ends after grans's own credentials on macOS:

```
Not signed in. Run `grans auth login`.

grans cannot borrow the token Granola's desktop app stored: on macOS that key
is reachable only by Granola itself.
```

`local_store` and `token_store` are no longer compiled there. Windows and Linux keep the fallback unchanged.

With the macOS path unreachable, its decryption code went too: `keychain_password`, `cbc_open`, `derive_cbc_key`, their tests, and the `security-framework`, `aes`, `cbc`, `pbkdf2`, and `sha1` dependencies (removed via `cargo remove`). The Windows os_crypt path and the shared AES-256-GCM layer under both are untouched. Net 182 lines and 5 dependencies out, 8 in.

## Verification

899 tests pass on Windows.

The macOS branch is the part CI cannot reach: the only test job is `ubuntu-latest`, and `release.yml` builds macOS but does not test it. A true cross-compile from this dev machine failed for want of an Apple `cc`, so I compiled the branch by flipping the cfg predicate to `windows` temporarily. That exercises the same paths (both modules gated out, the `bail!` arm and its test compiled in); all built and passed, then the predicate went back and the suite was re-run.

That is a proxy, not the real target. **Worth a `cargo test` on a Mac before merge.**

Adding macOS and Windows to the CI matrix is tracked separately in #93, since it will likely surface unrelated platform failures.

https://claude.ai/code/session_012c8WU6fhQDaVekXJX5hGhH

