### PR TITLE
Pin actions by SHA and drop write permission from changelog generation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+updates:
+  # Actions are pinned by SHA, which costs us Dependabot security alerts:
+  # advisory matching needs a semver version to compare against, and a SHA
+  # gives it nothing. Nothing will tell us a pin has turned out to be
+  # vulnerable, so these scheduled bumps are what keeps the pins from going
+  # stale until an advisory lands on one.
+  #
+  # The cooldown is the part doing real work. A compromised upstream that
+  # ships a malicious *new* release defeats SHA pinning entirely, since we
+  # adopt it on the next bump either way. Waiting before adopting is the
+  # defense: these compromises are usually public within a day or two.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         with:
           filters: |
@@ -37,11 +37,14 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run tests
         run: cargo test
@@ -61,12 +64,12 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
@@ -133,12 +136,12 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Security Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_commit_signing: "true"

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
@@ -42,7 +42,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Label Issue with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--allowed-tools "Bash(gh issue edit*)"'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Only the release job needs to write. Everything else reads.
 permissions:
-  contents: write
+  contents: read
 
 # Only one release workflow can run at a time. Cancel in-progress runs
 # when a new push arrives on the same day.
@@ -125,28 +126,24 @@ jobs:
           path: target/x86_64-pc-windows-msvc/ci-release/grans.exe
           retention-days: 1
 
-  release:
-    name: Create Release
-    needs: [version, build-linux, build-macos, build-windows]
+  # Isolated from the release job on purpose. This installs the Claude CLI
+  # from npm at run time and hands it an OAuth token, so it is the least
+  # trustworthy step in the workflow. Running it without contents: write means
+  # a compromise here cannot create tags or releases; the worst it can do is
+  # write bad prose into the release notes.
+  changelog:
+    name: Generate Changelog
+    needs: [version]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      notes: ${{ steps.changelog.outputs.response }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: artifacts
-
-      - name: Prepare release files
-        run: |
-          mkdir release
-          mv artifacts/grans-linux-x86_64/grans release/grans-linux-x86_64
-          mv artifacts/grans-macos-aarch64/grans release/grans-macos-aarch64
-          mv artifacts/grans-windows-x86_64.exe/grans.exe release/grans-windows-x86_64.exe
-          chmod +x release/grans-linux-x86_64 release/grans-macos-aarch64
 
       - name: Get changelog commits
         id: commits
@@ -156,24 +153,19 @@ jobs:
           # Find the previous v* tag (excluding today's tag if it exists)
           PREV_TAG=$(git tag -l 'v*' --sort=-version:refname | grep -v "^${TAG}$" | head -1 || true)
 
+          echo "commits<<EOF" >> $GITHUB_OUTPUT
           if [ -n "$PREV_TAG" ]; then
-            echo "prev_tag=${PREV_TAG}" >> $GITHUB_OUTPUT
-            echo "commits<<EOF" >> $GITHUB_OUTPUT
             git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
           else
-            echo "prev_tag=" >> $GITHUB_OUTPUT
-            echo "commits<<EOF" >> $GITHUB_OUTPUT
             git log --pretty=format:"- %s (%h)" -20 >> $GITHUB_OUTPUT
-            echo "" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
           fi
+          echo "" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate changelog with Claude
         id: changelog
@@ -206,6 +198,31 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+  release:
+    name: Create Release
+    needs: [version, build-linux, build-macos, build-windows, changelog]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+
+      - name: Prepare release files
+        run: |
+          mkdir release
+          mv artifacts/grans-linux-x86_64/grans release/grans-linux-x86_64
+          mv artifacts/grans-macos-aarch64/grans release/grans-macos-aarch64
+          mv artifacts/grans-windows-x86_64.exe/grans.exe release/grans-windows-x86_64.exe
+          chmod +x release/grans-linux-x86_64 release/grans-macos-aarch64
+
       # Delete today's tag/release if this is a same-day rebuild
       - name: Delete existing same-day release
         env:
@@ -219,7 +236,7 @@ jobs:
       - name: Create CalVer release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHANGELOG: ${{ steps.changelog.outputs.response }}
+          CHANGELOG: ${{ needs.changelog.outputs.notes }}
           CALVER: ${{ needs.version.outputs.calver }}
           TAG: ${{ needs.version.outputs.tag }}
           SHA_SHORT: ${{ needs.version.outputs.sha_short }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       tag: ${{ steps.version.outputs.tag }}
       sha_short: ${{ steps.version.outputs.sha_short }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Compute CalVer and short SHA
         id: version
@@ -47,11 +47,14 @@ jobs:
     needs: [version]
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
         env:
@@ -60,7 +63,7 @@ jobs:
         run: cargo build --profile ci-release --features cuda
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grans-linux-x86_64
           path: target/ci-release/grans
@@ -71,13 +74,15 @@ jobs:
     needs: [version]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: aarch64-apple-darwin
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
         env:
@@ -86,7 +91,7 @@ jobs:
         run: cargo build --profile ci-release --target aarch64-apple-darwin --features coreml
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grans-macos-aarch64
           path: target/aarch64-apple-darwin/ci-release/grans
@@ -97,13 +102,15 @@ jobs:
     needs: [version]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
+          toolchain: stable
           targets: x86_64-pc-windows-msvc
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build
         env:
@@ -112,7 +119,7 @@ jobs:
         run: cargo build --profile ci-release --target x86_64-pc-windows-msvc --features directml
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grans-windows-x86_64.exe
           path: target/x86_64-pc-windows-msvc/ci-release/grans.exe
@@ -123,13 +130,13 @@ jobs:
     needs: [version, build-linux, build-macos, build-windows]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 
@@ -164,7 +171,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Why

The [Release run](https://github.com/dmwyatt/granz/actions/runs/30206723809) carried a Node 20 deprecation warning on all five jobs. Fixing that meant touching every `uses:` line, so this also addresses how those refs are pinned and what the release workflow can reach.

## Pinning

Every action moves from a floating tag to a commit SHA with the version in a trailing comment. Floating tags are mutable refs: a compromised maintainer account can repoint `v4` at malicious code and every consumer runs it on the next trigger, retroactively, with nobody merging anything. That is how the tj-actions/changed-files compromise spread. [GitHub's guidance](https://docs.github.com/en/actions/reference/security/secure-use) is that a full-length SHA is the only immutable way to reference an action.

The versions chosen also clear the Node 20 warning. The artifact actions needed more than one major to get there, so the obvious bump would not have been enough:

| Action | Was | Now | First node24 major |
|---|---|---|---|
| `actions/checkout` | v4 | v7.0.1 | v5 |
| `actions/upload-artifact` | v4 | v7.0.1 | **v6** |
| `actions/download-artifact` | v4 | v8.0.1 | **v7** |
| `actions/setup-node` | v4 | v7.0.0 | v5 |
| `dorny/paths-filter` | v3 | v4.0.2 | v4 |
| `Swatinem/rust-cache` | v2 | v2.9.1 | already node24 |

`dtolnay/rust-toolchain` is a special case: its ref name *is* its configuration, since the `stable` branch ships an `action.yml` with `default: stable`. That still resolves through a SHA, but a bare SHA tells a reader nothing about which toolchain gets installed, so `toolchain: stable` is now explicit.

Breaking changes checked against current usage: `download-artifact@v8` now errors on digest mismatch and skips decompressing non-zipped downloads (uploads here use the default `archive: true`, so both are fine); `setup-node@v5` auto-caches when `package.json` declares `packageManager` (there is no root `package.json`); `checkout@v7` blocks fork refs under `pull_request_target` (CI uses plain `pull_request`).

## Dependabot

SHA pins do not get security alerts, because advisory matching needs a semver version to compare against. Scheduled version updates are the substitute. They are weaker, telling us we are current rather than that we are vulnerable, but they keep a pin from sitting untouched indefinitely.

The `cooldown` is the more useful half. SHA pinning does nothing against an upstream that ships a backdoor in a *new* release, since we adopt it on the next bump either way. Holding a release for a week before proposing it is the actual defense there, because these compromises usually surface within a day or two.

## Release workflow split

The changelog step installs the Claude CLI from npm at run time and hands it an OAuth token. It was doing that in the same job that later runs `gh release create` with `contents: write`. Separate steps are not a boundary, since they share a runner and a filesystem.

It now runs as its own job with `contents: read`, passing notes back through a job output. Workflow-level permission drops to `read`, with only the release job requesting `write`. The failure mode goes from "creates arbitrary tags and releases" to "writes bad prose into the release notes", which the existing `_No changelog generated_` fallback already tolerates. It also runs in parallel with the builds now, so it costs no wall clock.

The npm install stays unpinned on purpose: pinning would strand the CLI at a version nothing updates, since a global install has no manifest for Dependabot to track. Containing what it can reach beats freezing what it is.

Two smaller things carried along: Node bumps 20 to 24 in that step (20 went EOL in April), and the `prev_tag` step output, which nothing has ever read, is dropped rather than moved into the new job.

## What this does not fix

Pinning is not transitive. `anthropics/claude-code-action` is a composite action, so it invokes further actions pinned however that repo pins them. The SHA here fixes the entry point, not the tree below it.

## Verification

Not runnable locally, so: all five workflows parse as YAML; every `steps.*` reference resolves to a step id within its own job and every `needs.*.outputs.*` resolves to a declared output of a declared dependency; all 15 `run:` blocks pass `bash -n`. The release path itself only exercises on a push to `main`.
