### PR TITLE
#93: Test macOS and Windows in CI, without making every PR wait on them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The integration suites spawn a 50 MB `grans.exe` once per test, and on
-      # Windows that cost about 2.5s per spawn against 0.037s on ubuntu. A slow
-      # runner does not explain it: the 824 in-process unit tests ran at parity
-      # (16.2s vs 13.2s) while every suite that spawns the binary ran 38-85x
-      # slower. Defender scanning each CreateProcess is the suspected mechanism,
-      # so this tests that theory. RUNNER_TEMP is included because the suites
-      # build a SQLite database per test under TempDir.
+      # The integration suites spawn `grans.exe` once per test, and on this
+      # runner that costs far more than it should. Excluding the workspace and
+      # cargo home buys back about 28% of it (2.57s to 1.84s per spawn, against
+      # 0.037s on ubuntu), so Defender is part of the story but not most of it.
+      # RUNNER_TEMP is included because the suites build a SQLite database per
+      # test under TempDir.
+      #
+      # The rest is unexplained and specific to the runner: the same binary
+      # spawns in 19ms on a local Windows machine, so it is not the image size,
+      # onnxruntime init, or Windows process creation as such.
       #
       # Left to fail loudly. If this stops working on the runner image, Windows
       # quietly returns to seven minutes, and a silent regression is worse than
@@ -72,7 +75,9 @@ jobs:
         shell: pwsh
         run: |
           Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE, "$env:USERPROFILE\.cargo", $env:RUNNER_TEMP
-          Add-MpPreference -ExclusionProcess cargo.exe, rustc.exe, grans.exe
+          # Excludes files these processes touch. It does not exclude scanning
+          # of the processes themselves at launch -- the paths above cover that.
+          Add-MpPreference -ExclusionProcess cargo.exe, rustc.exe
 
       # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,16 @@ jobs:
               - '.github/workflows/ci.yml'
 
   test:
-    name: Tests
+    name: Tests (${{ matrix.os }})
     needs: [changes]
     if: needs.changes.outputs.rust == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Each leg is here to report on its own platform, so one failing leg
+      # must not cancel the others.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -201,13 +207,22 @@ jobs:
             Use `gh pr comment` only if you need a top-level summary.
             Only post GitHub comments — don't submit review text as messages.
 
+  # The one check name branch protection can require: it is stable across
+  # changes to the matrix, and `needs.test.result` aggregates every leg.
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
     needs: [test]
     if: always()
     steps:
-      - run: |
-          if [ "${{ needs.test.result }}" = "failure" ]; then
-            exit 1
-          fi
+      - name: Report aggregate test result
+        run: |
+          result="${{ needs.test.result }}"
+          # `skipped` is a non-Rust PR the paths filter excluded. Anything
+          # other than that or a clean pass has to hold the merge, cancelled
+          # runs included -- this job is the gate, so it cannot wave through
+          # a result it never saw.
+          case "$result" in
+            success | skipped) ;;
+            *) echo "Tests: $result"; exit 1 ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,27 @@ jobs:
       # must not cancel the others.
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # `scope` is what each platform is here to prove.
+        #
+        # Every platform-gated line in this repo sits in src/ -- the macOS
+        # keychain path and local-store cutoff in api/auth.rs, the Windows
+        # os_crypt/DPAPI path in api/token_store.rs, the cfg(unix) branches in
+        # api/credential_store.rs -- so its tests are all unit tests in the bin
+        # target, and `--bins` compiles and runs every one of them. Nothing in
+        # tests/*.rs is platform-gated at all.
+        #
+        # Those integration suites cost 225s on the Windows leg against 16s on
+        # ubuntu, because each of their 75 tests spawns `grans.exe` and a spawn
+        # costs ~2s on that runner. Paying it three times over on every push
+        # bought no platform coverage, so ubuntu carries them for the PR and
+        # platform-tests.yml runs them everywhere once the branch is merged.
+        include:
+          - os: ubuntu-latest
+            scope: ""
+          - os: macos-latest
+            scope: "--bins"
+          - os: windows-latest
+            scope: "--bins"
     env:
       # Full debuginfo writes a 194 MB PDB beside the binary and leaves a 2.4 GB
       # target/. Line tables cut those to 103 MB and 1.7 GB: less to link, and
@@ -64,12 +84,12 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # Without --no-fail-fast, cargo stops after the first test binary that
-      # fails, so one broken unit test in src/ means the 75 integration tests
-      # across tests/*.rs never launch and the red leg reports nothing about
-      # them. A failing run costs more wall clock this way; it buys a complete
-      # failure list instead of another round trip to find the rest.
+      # fails. On the ubuntu leg that means one broken unit test in src/ hides
+      # all 75 integration tests in tests/*.rs, and the red leg reports nothing
+      # about them. A failing run costs more wall clock this way; it buys a
+      # complete failure list instead of another round trip to find the rest.
       - name: Run tests
-        run: cargo test --no-fail-fast
+        run: cargo test --no-fail-fast ${{ matrix.scope }}
 
   code-review:
     name: Code Review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,37 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # Full debuginfo writes a 194 MB PDB beside the binary and leaves a 2.4 GB
+      # target/. Line tables cut those to 103 MB and 1.7 GB: less to link, and
+      # far less for the cache step to pack and upload. Measured on Windows,
+      # where the .exe itself barely moves (52 -> 50 MB) because MSVC keeps
+      # debuginfo in the PDB rather than the image.
+      #
+      # The `file:line` a CI failure report is read for survives, because the
+      # location in a panic message comes from the panic site, not debuginfo.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The integration suites spawn a 50 MB `grans.exe` once per test, and on
+      # Windows that cost about 2.5s per spawn against 0.037s on ubuntu. A slow
+      # runner does not explain it: the 824 in-process unit tests ran at parity
+      # (16.2s vs 13.2s) while every suite that spawns the binary ran 38-85x
+      # slower. Defender scanning each CreateProcess is the suspected mechanism,
+      # so this tests that theory. RUNNER_TEMP is included because the suites
+      # build a SQLite database per test under TempDir.
+      #
+      # Left to fail loudly. If this stops working on the runner image, Windows
+      # quietly returns to seven minutes, and a silent regression is worse than
+      # a red step naming the reason.
+      - name: Exclude the build and test paths from Defender
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE, "$env:USERPROFILE\.cargo", $env:RUNNER_TEMP
+          Add-MpPreference -ExclusionProcess cargo.exe, rustc.exe, grans.exe
 
       # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,13 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      # Without --no-fail-fast, cargo stops after the first test binary that
+      # fails, so one broken unit test in src/ means the 75 integration tests
+      # across tests/*.rs never launch and the red leg reports nothing about
+      # them. A failing run costs more wall clock this way; it buys a complete
+      # failure list instead of another round trip to find the rest.
       - name: Run tests
-        run: cargo test
+        run: cargo test --no-fail-fast
 
   code-review:
     name: Code Review

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,17 @@ jobs:
         with:
           toolchain: stable
 
+      # A run can only restore caches from its own ref or from the default
+      # branch, and this workflow is pull_request-only, so it never ran on main
+      # and left no cache for a new PR to find. Every first push to a branch
+      # paid a cold compile: 2m54s on Windows against the 36s it takes warm.
+      #
+      # `shared-key` replaces the per-job component of the key, so the
+      # post-merge platform-tests.yml run on main seeds the cache these legs
+      # restore. Its full-suite build is a superset of what `--bins` needs here.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: grans-tests
 
       # Without --no-fail-fast, cargo stops after the first test binary that
       # fails. On the ubuntu leg that means one broken unit test in src/ hides

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,27 +56,6 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # The integration suites spawn `grans.exe` once per test, and on this
-      # runner each spawn costs ~1.84s against ubuntu's 0.037s. Path exclusions
-      # got that down from 2.57s and no further, so this turns real-time
-      # scanning off outright: path exclusions do not reliably suppress the scan
-      # Defender runs when a process launches, which is the cost here.
-      #
-      # An ephemeral runner building our own code has little to protect, and the
-      # alternative is paying minutes per iteration.
-      #
-      # Asserted rather than assumed. If the runner image ever stops honouring
-      # this, Windows quietly returns to six minutes, and a silent regression is
-      # worse than a red step naming the reason.
-      - name: Turn off Defender real-time scanning
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Set-MpPreference -DisableRealtimeMonitoring $true
-          if (-not (Get-MpPreference).DisableRealtimeMonitoring) {
-            throw "Defender real-time monitoring is still enabled"
-          }
-
       # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,27 +57,25 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The integration suites spawn `grans.exe` once per test, and on this
-      # runner that costs far more than it should. Excluding the workspace and
-      # cargo home buys back about 28% of it (2.57s to 1.84s per spawn, against
-      # 0.037s on ubuntu), so Defender is part of the story but not most of it.
-      # RUNNER_TEMP is included because the suites build a SQLite database per
-      # test under TempDir.
+      # runner each spawn costs ~1.84s against ubuntu's 0.037s. Path exclusions
+      # got that down from 2.57s and no further, so this turns real-time
+      # scanning off outright: path exclusions do not reliably suppress the scan
+      # Defender runs when a process launches, which is the cost here.
       #
-      # The rest is unexplained and specific to the runner: the same binary
-      # spawns in 19ms on a local Windows machine, so it is not the image size,
-      # onnxruntime init, or Windows process creation as such.
+      # An ephemeral runner building our own code has little to protect, and the
+      # alternative is paying minutes per iteration.
       #
-      # Left to fail loudly. If this stops working on the runner image, Windows
-      # quietly returns to seven minutes, and a silent regression is worse than
-      # a red step naming the reason.
-      - name: Exclude the build and test paths from Defender
+      # Asserted rather than assumed. If the runner image ever stops honouring
+      # this, Windows quietly returns to six minutes, and a silent regression is
+      # worse than a red step naming the reason.
+      - name: Turn off Defender real-time scanning
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          Add-MpPreference -ExclusionPath $env:GITHUB_WORKSPACE, "$env:USERPROFILE\.cargo", $env:RUNNER_TEMP
-          # Excludes files these processes touch. It does not exclude scanning
-          # of the processes themselves at launch -- the paths above cover that.
-          Add-MpPreference -ExclusionProcess cargo.exe, rustc.exe
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          if (-not (Get-MpPreference).DisableRealtimeMonitoring) {
+            throw "Defender real-time monitoring is still enabled"
+          }
 
       # Pinned by SHA, so the toolchain no longer comes from the `stable` ref name.
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1,0 +1,66 @@
+name: Platform Tests
+
+# The full suite on every platform, once a change has landed.
+#
+# ci.yml runs the integration suites in tests/*.rs on ubuntu only, because each
+# of their 75 tests spawns `grans.exe` and that costs ~2s per spawn on the
+# Windows runner against 0.037s on ubuntu -- 225s of a 5m14s leg for tests that
+# contain no platform-gated code. Running them here keeps the coverage without
+# charging it to every push: a Windows or macOS regression in path handling or
+# terminal output surfaces against the commit that caused it, which is early
+# enough to matter and was the gap #93 was filed about.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/platform-tests.yml'
+  # A change to this workflow is exercised on the PR that makes it, rather than
+  # first running after the merge it could break.
+  pull_request:
+    paths:
+      - '.github/workflows/platform-tests.yml'
+  # The toolchain floats on `stable`, so a rustc release can break the build
+  # with no push to trigger the job.
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+jobs:
+  full-suite:
+    name: Full suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Each leg reports on its own platform, so one failure must not cancel
+      # the others.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # Must match ci.yml: rust-cache keys on these, and the two workflows share
+      # a cache so a PR does not start cold.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: grans-tests
+
+      - name: Run tests
+        run: cargo test --no-fail-fast

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -134,10 +134,19 @@ mod tests {
         let _ = clipboard_command();
     }
 
+    /// A command on PATH on every host of this platform, so `command_exists`
+    /// has something it is obliged to say yes to.
+    ///
+    /// `ls` is not that command on Windows: it is a PowerShell alias and a Git
+    /// Bash binary, neither of which `where.exe` resolves.
+    #[cfg(target_os = "windows")]
+    const KNOWN_COMMAND: &str = "cmd";
+    #[cfg(not(target_os = "windows"))]
+    const KNOWN_COMMAND: &str = "ls";
+
     #[test]
     fn test_command_exists_known() {
-        // `which` itself should always exist on unix
-        assert!(command_exists("ls"));
+        assert!(command_exists(KNOWN_COMMAND));
     }
 
     #[test]


### PR DESCRIPTION
Closes #93. Closes #56.

## The gap

The `test` job was a single `runs-on: ubuntu-latest`. Two platform paths were never compiled by CI: the macOS-gated keychain path and local-store cutoff (#89, #91), and the os_crypt/DPAPI path in `api/token_store.rs`. `release.yml` builds `aarch64-apple-darwin`, so a macOS break surfaced at release time instead of on the PR.

## What each leg is for

A plain three-OS matrix closed the gap but made every PR wait 7m21s on Windows. That spend bought no platform coverage, because of where the platform-gated code actually is: all of it is in `src/` (macOS keychain path and local-store cutoff in `api/auth.rs`, Windows os_crypt/DPAPI in `api/token_store.rs`, `cfg(unix)` branches in `api/credential_store.rs`), so all of its tests are unit tests in the bin target. **Nothing in `tests/*.rs` is platform-gated.**

Those integration suites cost 225s on Windows against 16s on ubuntu, because each of their 75 tests spawns `grans.exe` and a spawn costs ~2s on that runner. So ubuntu runs the full suite and macOS/Windows run `--bins`, which compiles and runs every platform-gated test without building the integration binaries at all.

The gating is doing real work, visible in the differing counts: **824 tests on Windows, 815 on macOS, 827 on ubuntu.** Windows picks up the DPAPI tests, ubuntu and macOS the `cfg(unix)` ones, macOS drops the `cfg(not(macos))` local-store ones.

`platform-tests.yml` then runs the full suite on all three platforms on push to `main`, so the integration suites' incidental Windows/macOS coverage (path handling, terminal output) still happens — against the commit responsible, rather than at release time. Also on a weekly cron, since the toolchain floats on `stable`.

## Result

| leg | before | after (warm) | scope |
|---|---|---|---|
| ubuntu | 2m08s | 0m49s | full suite |
| macOS | 2m06s | ~1m30s | `--bins` |
| windows | **7m21s** | **1m27s** | `--bins` |

PR gate: **7m21s to ~1m30s.**

## Two fixes that came out of measuring

**Every new PR was starting cold.** A run can only restore caches from its own ref or the default branch, and `ci.yml` is `pull_request`-only, so it had never run on `main` and left nothing for a new branch to restore. First push to any branch paid a 2m54s Windows compile instead of 36s. Both workflows now share a rust-cache `shared-key`, so the post-merge run on `main` seeds what PR legs restore.

**`cargo test` had no `--no-fail-fast`.** It stops after the first failing test binary, and the bin target runs first, so one broken unit test meant all 75 integration tests never launched and the red leg reported nothing about them. #56 records this masking a real failure during #52.

Debuginfo is also trimmed to `line-tables-only`: a 194 MB PDB becomes 103 MB and `target/` goes 2.4 GB to 1.7 GB, so there is less to link and much less to pack into the cache. Panic locations are unaffected, coming from the panic site rather than debuginfo.

## A dead end, recorded on purpose

Defender was the obvious suspect for the ~2s spawn cost and it is not the cause. Integration-suite totals across three runs: 208.7s with no intervention, 155.3s with path exclusions, 225.3s with real-time monitoring off entirely. Real-time off is a superset of the exclusions, so it should have been at or below 155.3s; run-to-run variance on that runner is roughly ±25% and swamps both settings. The commits that add and then remove this are kept so the measurement is in `git log` and nobody has to rediscover it.

The residual is unexplained and specific to the runner: the same binary spawns in 19ms on a local Windows machine, faster than the 37ms measured per spawn on the ubuntu runner.

## #56, folded in

The matrix could not come up green without it. `test_command_exists_known` asserted `command_exists("ls")`, but on Windows `command_exists` shells out to `where.exe`, which does not resolve `ls` (a PowerShell alias and a Git Bash binary). It passed locally only because Git Bash's coreutils `ls.exe` was on PATH; under PowerShell it failed. The known-present command is now chosen per platform, so the Windows leg still exercises the `where.exe` branch.

## Branch protection

Required status check moved from `Tests` to `CI Status`. `Tests` stopped existing once the legs carried their OS, so nothing would ever report it and every PR would block. `CI Status` aggregates `needs.test.result` across the matrix, runs on `always()`, and its name does not move when the matrix does. It now passes only on `success` or the `skipped` of a non-Rust PR; previously anything that was not `failure` passed, letting a cancelled run count as green.

https://claude.ai/code/session_012c8WU6fhQDaVekXJX5hGhH
