### PR TITLE
Stream Dropbox pulls with progress, and make sync failures diagnosable

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,12 +540,41 @@ Embeddings:                 52.8K               51.2K
 
 This helps you see at a glance whether your local database is ahead of or behind the remote copy, without downloading the full database.
 
+**Transfer progress:** `pull` streams the database to disk and shows a progress bar with throughput and an ETA. Databases with embeddings run to hundreds of megabytes, so a pull can take a while on a slow connection:
+
+```
+Downloading database (424.3 MB)...
+[grans] 114.55 MiB/424.25 MiB [========>                     ] 27% 4.21 MiB/s, ETA 1m
+```
+
+The bar is written to stderr and is skipped when output is redirected.
+
 **Conflict handling:** Sync refuses to overwrite newer files by default. Use `--force` to override:
 
 ```bash
 grans dropbox push --force   # Overwrite remote even if it's newer
 grans dropbox pull --force   # Overwrite local even if it's newer
 ```
+
+A pull downloads to a temporary file and checks the byte count against the size Dropbox reported before replacing your database, so an interrupted transfer leaves the existing copy in place.
+
+**Troubleshooting a failed sync:** run the command again with `--verbose` to log each request, its HTTP status, and the throughput achieved:
+
+```bash
+grans --verbose dropbox pull
+```
+
+```
+[DEBUG grans::sync::dropbox] POST https://api.dropboxapi.com/2/files/get_metadata (metadata for /grans.db)
+[DEBUG grans::sync::dropbox]   response: 200 OK in 270.7261ms
+[DEBUG grans::sync::dropbox] POST https://content.dropboxapi.com/2/files/download (download /grans.db)
+[DEBUG grans::sync::dropbox]   response: 200 OK in 712.5304ms
+[DEBUG grans::sync::dropbox]   body complete: 424.28 MB in 6.7065285s (63.26 MB/s)
+```
+
+A download that fails reports how far it got, which separates a connection that dropped mid-transfer from one that never delivered anything.
+
+Use `GRANS_LOG` for finer control, e.g. `GRANS_LOG=grans::sync=debug`.
 
 **What gets synced:**
 - Database (meeting data, transcripts, FTS indices, vector embeddings for semantic search)

--- a/README.md
+++ b/README.md
@@ -556,7 +556,17 @@ grans dropbox push --force   # Overwrite remote even if it's newer
 grans dropbox pull --force   # Overwrite local even if it's newer
 ```
 
-A pull downloads to a temporary file and checks the byte count against the size Dropbox reported before replacing your database, so an interrupted transfer leaves the existing copy in place.
+**Verification:** a pull downloads to a temporary file and has to clear three checks before anything replaces your database:
+
+| Check | Catches |
+|-------|---------|
+| Byte count against the size Dropbox reported | An interrupted or truncated transfer |
+| Dropbox `content_hash`, computed while streaming | Content that differs from the stored file |
+| `PRAGMA quick_check` plus a schema probe | A corrupt file, or one that is not a grans database |
+
+If any check fails the temp file is discarded and your existing database is left untouched. The download is also flushed to the device before the rename, so a crash cannot leave a database whose contents were never written.
+
+On a 424 MB database this costs about 1.3s; hashing runs alongside the transfer and adds no measurable time.
 
 **Troubleshooting a failed sync:** run the command again with `--verbose` to log each request, its HTTP status, and the throughput achieved:
 

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -6,7 +6,7 @@ use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
 use crate::db::info::{get_info_db_only, DbInfo};
-use crate::output::format::OutputMode;
+use crate::output::format::{format_size, OutputMode};
 
 /// Run info command
 pub fn run(conn: &Connection, db_path: &Path, ctx: &RunContext) -> Result<()> {
@@ -107,22 +107,6 @@ fn format_number(n: i64) -> String {
         result.insert(0, c);
     }
     result
-}
-
-fn format_size(bytes: u64) -> String {
-    const KB: u64 = 1024;
-    const MB: u64 = KB * 1024;
-    const GB: u64 = MB * 1024;
-
-    if bytes >= GB {
-        format!("{:.1} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.1} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.1} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{} B", bytes)
-    }
 }
 
 fn format_date(iso_date: &str, tz: &FixedOffset) -> String {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod search_common;
 pub mod sync;
 pub mod sync_granola;
 mod sync_panels;
+mod sync_status;
 mod sync_transcripts;
 pub mod templates;
 pub mod update;

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,10 +1,11 @@
 //! Sync command implementations.
 
-use std::io::{self, Write};
+use std::io::{self, BufWriter, IsTerminal, Write};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
+use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 
 use chrono::FixedOffset;
@@ -18,6 +19,7 @@ use crate::pkce::PkceChallenge;
 use crate::sync::oauth::{
     build_auth_url, exchange_code, refresh_access_token, PKCE_ENTROPY_BYTES,
 };
+use crate::sync::transfer::verify_transfer_size;
 use crate::sync::SyncError;
 
 /// Remote paths on Dropbox (within app folder)
@@ -102,7 +104,7 @@ fn push(force: bool) -> Result<()> {
 
     // Get access token
     let access_token = get_access_token(&config)?;
-    let client = DropboxClient::new(access_token);
+    let client = DropboxClient::new(access_token)?;
 
     // Get local database path
     let db_path = crate::db::connection::default_db_path()?;
@@ -195,7 +197,7 @@ fn pull(force: bool) -> Result<()> {
 
     // Get access token
     let access_token = get_access_token(&config)?;
-    let client = DropboxClient::new(access_token);
+    let client = DropboxClient::new(access_token)?;
 
     // Get local database path
     let db_path = crate::db::connection::default_db_path()?;
@@ -238,39 +240,101 @@ fn pull_file(
     // Check local file
     if !force && local_path.exists() {
         let local_mtime = get_file_mtime(local_path)?;
-        if let Some(remote_ts) = remote_mtime {
-            if local_mtime > remote_ts {
-                return Err(SyncError::ConflictLocalNewer {
-                    what: name.to_string(),
-                    local_time: format_timestamp(local_mtime),
-                    remote_time: format_timestamp(remote_ts),
-                }
-                .into());
+        if let Some(remote_ts) = remote_mtime
+            && local_mtime > remote_ts
+        {
+            return Err(SyncError::ConflictLocalNewer {
+                what: name.to_string(),
+                local_time: format_timestamp(local_mtime),
+                remote_time: format_timestamp(remote_ts),
             }
+            .into());
         }
     }
 
-    println!(
-        "Downloading {} ({:.2} MB)...",
-        name,
-        remote.size as f64 / 1_048_576.0
-    );
-
-    let content = client.download(remote_path)?;
+    println!("Downloading {} ({})...", name, format_size(remote.size));
 
     // Ensure parent directory exists
     if let Some(parent) = local_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    // Write to temp file first for atomic operation
+    // Download into a temp file so a failed transfer never replaces a good database.
     let temp_path = local_path.with_extension("db.tmp");
-    std::fs::write(&temp_path, &content)?;
-    std::fs::rename(&temp_path, local_path)?;
+    let downloaded = download_to_temp(client, remote_path, &temp_path, remote.size, name);
 
-    println!("  Downloaded to {}", local_path.display());
+    match downloaded {
+        Ok(()) => {
+            std::fs::rename(&temp_path, local_path)?;
+            println!("  Downloaded to {}", local_path.display());
+            Ok(())
+        }
+        Err(e) => {
+            let _ = std::fs::remove_file(&temp_path);
+            Err(e)
+        }
+    }
+}
+
+/// Stream a remote file to `temp_path`, showing a progress bar, and verify its size.
+fn download_to_temp(
+    client: &DropboxClient,
+    remote_path: &str,
+    temp_path: &Path,
+    expected_size: u64,
+    name: &str,
+) -> Result<()> {
+    let progress = DownloadProgress::new(expected_size);
+
+    let mut file = BufWriter::new(std::fs::File::create(temp_path)?);
+    let written =
+        client.download_to_writer(remote_path, &mut file, &mut |bytes| progress.set(bytes))?;
+    file.flush()?;
+    drop(file);
+
+    verify_transfer_size(written, expected_size, name)?;
 
     Ok(())
+}
+
+/// Byte-count progress bar, shown only when stderr is a terminal.
+struct DownloadProgress {
+    bar: Option<ProgressBar>,
+}
+
+impl DownloadProgress {
+    fn new(total: u64) -> Self {
+        if !io::stderr().is_terminal() {
+            return Self { bar: None };
+        }
+
+        let pb = ProgressBar::new(total);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "[grans] {bytes}/{total_bytes} [{bar:30}] {percent}% {bytes_per_sec}, ETA {eta}",
+                )
+                .unwrap_or_else(|_| ProgressStyle::default_bar())
+                .progress_chars("=> "),
+        );
+        Self { bar: Some(pb) }
+    }
+
+    fn set(&self, bytes: u64) {
+        if let Some(ref pb) = self.bar {
+            pb.set_position(bytes);
+        }
+    }
+}
+
+/// Clear the bar however the download ends, so a failure message is not printed
+/// underneath a stale progress line.
+impl Drop for DownloadProgress {
+    fn drop(&mut self) {
+        if let Some(ref pb) = self.bar {
+            pb.finish_and_clear();
+        }
+    }
 }
 
 /// File information for status display
@@ -347,7 +411,7 @@ fn status(output_mode: OutputMode, tz: &FixedOffset) -> Result<()> {
         if config.is_authenticated() {
             match get_access_token(&config) {
                 Ok(access_token) => {
-                    let client = DropboxClient::new(access_token);
+                    let client = DropboxClient::new(access_token)?;
                     let remote_meta = fetch_remote_metadata(&client);
                     let db_meta = client.get_metadata(REMOTE_DB_PATH).ok().flatten();
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufWriter, IsTerminal, Write};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 
 use chrono::FixedOffset;
@@ -18,7 +18,10 @@ use crate::pkce::PkceChallenge;
 use crate::sync::oauth::{
     build_auth_url, exchange_code, refresh_access_token, PKCE_ENTROPY_BYTES,
 };
-use crate::sync::transfer::verify_transfer_size;
+use crate::db::integrity::check_pulled_database;
+use crate::output::progress::create_spinner;
+use crate::sync::content_hash::HashingWriter;
+use crate::sync::transfer::{verify_content_hash, verify_transfer_size};
 use crate::sync::SyncError;
 
 /// Remote paths on Dropbox (within app folder)
@@ -258,9 +261,28 @@ fn pull_file(
         std::fs::create_dir_all(parent)?;
     }
 
-    // Download into a temp file so a failed transfer never replaces a good database.
+    // Verification needs the hash before the transfer starts; refusing early
+    // beats discovering it after moving hundreds of megabytes.
+    let expected_hash = remote
+        .content_hash
+        .as_deref()
+        .ok_or_else(|| SyncError::MissingContentHash {
+            path: remote_path.to_string(),
+        })?;
+
+    // Download into a temp file so nothing replaces a good database until every
+    // check has passed.
     let temp_path = local_path.with_extension("db.tmp");
-    let downloaded = download_to_temp(client, remote_path, &temp_path, remote.size, name);
+    let downloaded = download_and_verify(
+        client,
+        remote_path,
+        &temp_path,
+        &Expected {
+            size: remote.size,
+            hash: expected_hash,
+            name,
+        },
+    );
 
     match downloaded {
         Ok(()) => {
@@ -275,25 +297,69 @@ fn pull_file(
     }
 }
 
-/// Stream a remote file to `temp_path`, showing a progress bar, and verify its size.
-fn download_to_temp(
+/// What a download has to match before it is allowed to replace the database.
+struct Expected<'a> {
+    size: u64,
+    hash: &'a str,
+    name: &'a str,
+}
+
+/// Stream a remote file to `temp_path` and prove it is safe to install.
+///
+/// Checks run cheapest first, so a failure costs as little as possible: the byte
+/// count and content hash both come free with the transfer, while the integrity
+/// check has to read the file back.
+fn download_and_verify(
+    client: &DropboxClient,
+    remote_path: &str,
+    temp_path: &Path,
+    expected: &Expected<'_>,
+) -> Result<()> {
+    let (written, actual_hash) = stream_to_file(client, remote_path, temp_path, expected.size)?;
+
+    verify_transfer_size(written, expected.size, expected.name)?;
+    verify_content_hash(&actual_hash, expected.hash, expected.name)?;
+
+    let spinner = create_spinner(&format!("Checking {} integrity...", expected.name));
+    let result = check_pulled_database(temp_path);
+    spinner.finish_and_clear();
+
+    result.with_context(|| {
+        format!(
+            "the {} downloaded from Dropbox failed its integrity check; \
+             the local file was left untouched",
+            expected.name
+        )
+    })
+}
+
+/// Write the download to disk, hashing as it streams, and flush it to the device.
+///
+/// Returns the byte count and the Dropbox content hash of what was written.
+fn stream_to_file(
     client: &DropboxClient,
     remote_path: &str,
     temp_path: &Path,
     expected_size: u64,
-    name: &str,
-) -> Result<()> {
+) -> Result<(u64, String)> {
     let progress = DownloadProgress::new(expected_size);
 
-    let mut file = BufWriter::new(std::fs::File::create(temp_path)?);
+    let file = std::fs::File::create(temp_path)?;
+    let mut writer = HashingWriter::new(BufWriter::new(file));
+
     let written =
-        client.download_to_writer(remote_path, &mut file, &mut |bytes| progress.set(bytes))?;
-    file.flush()?;
-    drop(file);
+        client.download_to_writer(remote_path, &mut writer, &mut |bytes| progress.set(bytes))?;
 
-    verify_transfer_size(written, expected_size, name)?;
+    let (buffered, actual_hash) = writer.finish();
+    let file = buffered
+        .into_inner()
+        .map_err(|e| anyhow::anyhow!("flushing the download to disk: {}", e))?;
 
-    Ok(())
+    // Without this the rename can publish a file whose contents never reached
+    // the device, leaving a corrupt database after a crash.
+    file.sync_all()?;
+
+    Ok((written, actual_hash))
 }
 
 /// Byte-count progress bar, shown only when stderr is a terminal.

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -6,14 +6,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
 use indicatif::{ProgressBar, ProgressStyle};
-use serde::Serialize;
 
 use chrono::FixedOffset;
 
 use crate::cli::args::DropboxAction;
-use crate::output::format::OutputMode;
+use crate::output::format::{format_size, OutputMode};
 use crate::sync::config::{config_path, SyncConfig};
-use crate::sync::dropbox::{format_timestamp, parse_dropbox_time, DropboxClient, FileMetadata};
+use crate::sync::dropbox::{format_timestamp, parse_dropbox_time, DropboxClient};
 use crate::sync::metadata::SyncMetadata;
 use crate::pkce::PkceChallenge;
 use crate::sync::oauth::{
@@ -23,8 +22,8 @@ use crate::sync::transfer::verify_transfer_size;
 use crate::sync::SyncError;
 
 /// Remote paths on Dropbox (within app folder)
-const REMOTE_DB_PATH: &str = "/grans.db";
-const REMOTE_METADATA_PATH: &str = "/sync_metadata.json";
+pub(super) const REMOTE_DB_PATH: &str = "/grans.db";
+pub(super) const REMOTE_METADATA_PATH: &str = "/sync_metadata.json";
 
 /// Run Dropbox commands (init, push, pull, status, logout)
 pub fn run_dropbox(action: &DropboxAction, output_mode: OutputMode, tz: &FixedOffset) -> Result<()> {
@@ -32,7 +31,7 @@ pub fn run_dropbox(action: &DropboxAction, output_mode: OutputMode, tz: &FixedOf
         DropboxAction::Init => init()?,
         DropboxAction::Push { force } => push(*force)?,
         DropboxAction::Pull { force } => pull(*force)?,
-        DropboxAction::Status => status(output_mode, tz)?,
+        DropboxAction::Status => super::sync_status::status(output_mode, tz)?,
         DropboxAction::Logout => logout()?,
     }
     Ok(())
@@ -337,349 +336,6 @@ impl Drop for DownloadProgress {
     }
 }
 
-/// File information for status display
-#[derive(Debug, Clone, Serialize)]
-struct FileInfo {
-    exists: bool,
-    size_bytes: Option<u64>,
-    modified_time: Option<u64>,
-}
-
-impl FileInfo {
-    fn from_local(path: &Path) -> Self {
-        if !path.exists() {
-            return Self {
-                exists: false,
-                size_bytes: None,
-                modified_time: None,
-            };
-        }
-
-        let meta = std::fs::metadata(path).ok();
-        Self {
-            exists: true,
-            size_bytes: meta.as_ref().map(|m| m.len()),
-            modified_time: get_file_mtime(path).ok(),
-        }
-    }
-
-    fn from_remote(meta: Option<&FileMetadata>) -> Self {
-        match meta {
-            Some(m) => Self {
-                exists: true,
-                size_bytes: Some(m.size),
-                modified_time: parse_dropbox_time(&m.server_modified),
-            },
-            None => Self {
-                exists: false,
-                size_bytes: None,
-                modified_time: None,
-            },
-        }
-    }
-}
-
-/// Complete sync status data for JSON output
-#[derive(Debug, Serialize)]
-struct SyncStatusData {
-    authenticated: bool,
-    last_push_time: Option<u64>,
-    last_pull_time: Option<u64>,
-    local: Option<SyncMetadata>,
-    remote: Option<SyncMetadata>,
-    local_db: FileInfo,
-    remote_db: FileInfo,
-}
-
-fn status(output_mode: OutputMode, tz: &FixedOffset) -> Result<()> {
-    let config = SyncConfig::load()?;
-
-    // Get local database path
-    let db_path = crate::db::connection::default_db_path()?;
-
-    // Collect local metadata
-    let local_metadata = SyncMetadata::from_local_db(
-        db_path.exists().then_some(&db_path),
-    )
-    .ok();
-
-    // Local file info
-    let local_db_info = FileInfo::from_local(&db_path);
-
-    // Remote info (only if authenticated)
-    let (remote_metadata, remote_db_info) =
-        if config.is_authenticated() {
-            match get_access_token(&config) {
-                Ok(access_token) => {
-                    let client = DropboxClient::new(access_token)?;
-                    let remote_meta = fetch_remote_metadata(&client);
-                    let db_meta = client.get_metadata(REMOTE_DB_PATH).ok().flatten();
-
-                    (
-                        remote_meta,
-                        FileInfo::from_remote(db_meta.as_ref()),
-                    )
-                }
-                Err(_) => (
-                    None,
-                    FileInfo::from_remote(None),
-                ),
-            }
-        } else {
-            (
-                None,
-                FileInfo::from_remote(None),
-            )
-        };
-
-    let status_data = SyncStatusData {
-        authenticated: config.is_authenticated(),
-        last_push_time: config.last_push_time,
-        last_pull_time: config.last_pull_time,
-        local: local_metadata.clone(),
-        remote: remote_metadata.clone(),
-        local_db: local_db_info.clone(),
-        remote_db: remote_db_info.clone(),
-    };
-
-    match output_mode {
-        OutputMode::Json => {
-            println!("{}", serde_json::to_string_pretty(&status_data)?);
-        }
-        OutputMode::Tty => {
-            print_status_tty(&status_data, tz);
-        }
-    }
-
-    Ok(())
-}
-
-fn fetch_remote_metadata(client: &DropboxClient) -> Option<SyncMetadata> {
-    match client.download(REMOTE_METADATA_PATH) {
-        Ok(bytes) => {
-            let json = String::from_utf8(bytes).ok()?;
-            match serde_json::from_str(&json) {
-                Ok(meta) => Some(meta),
-                Err(e) => {
-                    eprintln!("Warning: Could not parse remote metadata: {}", e);
-                    None
-                }
-            }
-        }
-        Err(_) => None, // File doesn't exist or couldn't be downloaded
-    }
-}
-
-fn print_status_tty(data: &SyncStatusData, tz: &FixedOffset) {
-    use colored::Colorize;
-
-    println!("{}", "Sync Status".bold());
-    println!("{}", "───────────".dimmed());
-
-    // Authentication
-    if data.authenticated {
-        println!("Authentication: {}", "Connected".green());
-    } else {
-        println!("Authentication: {}", "Not connected".red());
-        println!(
-            "\nRun '{}' to connect to Dropbox.",
-            "grans dropbox init".cyan()
-        );
-        return;
-    }
-
-    // Last sync times
-    if let Some(ts) = data.last_push_time {
-        println!("Last push: {}", format_timestamp(ts).dimmed());
-    } else {
-        println!("Last push: {}", "Never".dimmed());
-    }
-    if let Some(ts) = data.last_pull_time {
-        println!("Last pull: {}", format_timestamp(ts).dimmed());
-    } else {
-        println!("Last pull: {}", "Never".dimmed());
-    }
-
-    println!();
-
-    // Column headers
-    let header = format!(
-        "{:28} {:>18}    {:>18}",
-        "",
-        "Local".bold(),
-        "Remote".bold()
-    );
-    println!("{}", header);
-    let separator = format!(
-        "{:28} {:>18}    {:>18}",
-        "",
-        "─────".dimmed(),
-        "──────".dimmed()
-    );
-    println!("{}", separator);
-
-    // Get local and remote stats
-    let local_idx = data.local.as_ref().and_then(|m| m.index_db.as_ref());
-    let remote_idx = data.remote.as_ref().and_then(|m| m.index_db.as_ref());
-
-    // Documents
-    print_comparison_row(
-        "Documents:",
-        local_idx.map(|i| format_number(i.document_count)),
-        remote_idx.map(|i| format_number(i.document_count)),
-    );
-
-    // With transcripts
-    print_comparison_row(
-        "With transcripts:",
-        local_idx.map(|i| format_number(i.documents_with_transcripts)),
-        remote_idx.map(|i| format_number(i.documents_with_transcripts)),
-    );
-
-    // Utterances
-    print_comparison_row(
-        "Utterances:",
-        local_idx.map(|i| format_number(i.transcript_utterance_count)),
-        remote_idx.map(|i| format_number(i.transcript_utterance_count)),
-    );
-
-    // People
-    print_comparison_row(
-        "People:",
-        local_idx.map(|i| format_number(i.people_count)),
-        remote_idx.map(|i| format_number(i.people_count)),
-    );
-
-    // Date range
-    let local_range = local_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
-    let remote_range =
-        remote_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
-    print_comparison_row("Date range:", local_range, remote_range);
-
-    // Schema version
-    let local_schema = local_idx.map(|i| i.schema_version);
-    let remote_schema = remote_idx.map(|i| i.schema_version);
-    let schema_mismatch =
-        local_schema.is_some() && remote_schema.is_some() && local_schema != remote_schema;
-    print_comparison_row_with_warning(
-        "Schema version:",
-        local_idx.map(|i| i.schema_version.to_string()),
-        remote_idx.map(|i| i.schema_version.to_string()),
-        schema_mismatch,
-    );
-
-    // Database size
-    print_comparison_row(
-        "Database size:",
-        data.local_db.size_bytes.map(format_size),
-        data.remote_db.size_bytes.map(format_size),
-    );
-
-    // Database modified
-    print_comparison_row(
-        "Database modified:",
-        data.local_db.modified_time.map(|ts| format_short_time(ts, tz)),
-        data.remote_db.modified_time.map(|ts| format_short_time(ts, tz)),
-    );
-
-    // Embeddings
-    let local_emb_count = local_idx.map(|i| i.embedding_count).unwrap_or(0);
-    let remote_emb_count = remote_idx.map(|i| i.embedding_count)
-        .or_else(|| data.remote.as_ref().and_then(|m| m.embeddings_db.as_ref()).map(|e| e.embedding_count))
-        .unwrap_or(0);
-    print_comparison_row(
-        "Embeddings:",
-        Some(format_number(local_emb_count)),
-        Some(format_number(remote_emb_count)),
-    );
-
-    // Embedding model
-    let local_model = local_idx.and_then(|i| i.embedding_model.clone());
-    let remote_model = remote_idx.and_then(|i| i.embedding_model.clone())
-        .or_else(|| data.remote.as_ref().and_then(|m| m.embeddings_db.as_ref()).and_then(|e| e.model.clone()));
-    print_comparison_row(
-        "Embedding model:",
-        local_model,
-        remote_model,
-    );
-
-    if schema_mismatch {
-        println!();
-        println!(
-            "{}",
-            "Warning: Schema version mismatch between local and remote databases.".yellow()
-        );
-    }
-}
-
-fn print_comparison_row(label: &str, local: Option<String>, remote: Option<String>) {
-    print_comparison_row_with_warning(label, local, remote, false);
-}
-
-fn print_comparison_row_with_warning(
-    label: &str,
-    local: Option<String>,
-    remote: Option<String>,
-    warn: bool,
-) {
-    use colored::Colorize;
-
-    let local_str = local.unwrap_or_else(|| "—".to_string());
-    let remote_str = remote.unwrap_or_else(|| "unknown".to_string());
-
-    if warn {
-        println!(
-            "{:28} {:>18}    {:>18} {}",
-            label,
-            local_str,
-            remote_str.yellow(),
-            "⚠".yellow()
-        );
-    } else {
-        println!("{:28} {:>18}    {:>18}", label, local_str, remote_str);
-    }
-}
-
-fn format_number(n: i64) -> String {
-    if n >= 1_000_000 {
-        format!("{:.1}M", n as f64 / 1_000_000.0)
-    } else if n >= 1_000 {
-        format!("{:.1}K", n as f64 / 1_000.0)
-    } else {
-        n.to_string()
-    }
-}
-
-fn format_size(bytes: u64) -> String {
-    if bytes >= 1_073_741_824 {
-        format!("{:.1} GB", bytes as f64 / 1_073_741_824.0)
-    } else if bytes >= 1_048_576 {
-        format!("{:.1} MB", bytes as f64 / 1_048_576.0)
-    } else if bytes >= 1024 {
-        format!("{:.1} KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{} B", bytes)
-    }
-}
-
-fn format_short_time(ts: u64, tz: &FixedOffset) -> String {
-    use chrono::DateTime;
-    let dt = DateTime::from_timestamp(ts as i64, 0)
-        .unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap());
-    dt.with_timezone(tz).format("%Y-%m-%d %H:%M").to_string()
-}
-
-fn format_date_range(earliest: &Option<String>, latest: &Option<String>) -> String {
-    match (earliest, latest) {
-        (Some(e), Some(l)) => {
-            let e_short = e.get(..7).unwrap_or(e);
-            let l_short = l.get(..7).unwrap_or(l);
-            format!("{} → {}", e_short, l_short)
-        }
-        _ => "—".to_string(),
-    }
-}
-
 fn logout() -> Result<()> {
     let mut config = SyncConfig::load()?;
 
@@ -703,7 +359,7 @@ fn logout() -> Result<()> {
 }
 
 /// Get a valid access token, refreshing if necessary.
-fn get_access_token(config: &SyncConfig) -> Result<String> {
+pub(super) fn get_access_token(config: &SyncConfig) -> Result<String> {
     let refresh_token = config
         .refresh_token
         .as_ref()
@@ -714,7 +370,7 @@ fn get_access_token(config: &SyncConfig) -> Result<String> {
 }
 
 /// Get file modification time as Unix timestamp.
-fn get_file_mtime(path: &Path) -> Result<u64> {
+pub(super) fn get_file_mtime(path: &Path) -> Result<u64> {
     let meta = std::fs::metadata(path)?;
     let mtime = meta.modified()?;
     Ok(mtime
@@ -748,79 +404,5 @@ mod tests {
         let result = get_file_mtime(Path::new("Cargo.toml"));
         assert!(result.is_ok());
         assert!(result.unwrap() > 0);
-    }
-
-    #[test]
-    fn test_format_number() {
-        assert_eq!(format_number(0), "0");
-        assert_eq!(format_number(999), "999");
-        assert_eq!(format_number(1000), "1.0K");
-        assert_eq!(format_number(1500), "1.5K");
-        assert_eq!(format_number(52847), "52.8K");
-        assert_eq!(format_number(1000000), "1.0M");
-        assert_eq!(format_number(1500000), "1.5M");
-    }
-
-    #[test]
-    fn test_format_size() {
-        assert_eq!(format_size(500), "500 B");
-        assert_eq!(format_size(1024), "1.0 KB");
-        assert_eq!(format_size(1048576), "1.0 MB");
-        assert_eq!(format_size(47185920), "45.0 MB");
-        assert_eq!(format_size(1073741824), "1.0 GB");
-    }
-
-    #[test]
-    fn test_format_date_range() {
-        assert_eq!(
-            format_date_range(
-                &Some("2023-06-01T00:00:00Z".to_string()),
-                &Some("2025-01-27T00:00:00Z".to_string())
-            ),
-            "2023-06 → 2025-01"
-        );
-        assert_eq!(format_date_range(&None, &None), "—");
-    }
-
-    #[test]
-    fn test_file_info_from_local_nonexistent() {
-        let info = FileInfo::from_local(Path::new("/nonexistent/path/file.db"));
-        assert!(!info.exists);
-        assert!(info.size_bytes.is_none());
-        assert!(info.modified_time.is_none());
-    }
-
-    #[test]
-    fn test_file_info_from_local_existing() {
-        let info = FileInfo::from_local(Path::new("Cargo.toml"));
-        assert!(info.exists);
-        assert!(info.size_bytes.is_some());
-        assert!(info.modified_time.is_some());
-    }
-
-    #[test]
-    fn test_sync_status_data_serialization() {
-        let data = SyncStatusData {
-            authenticated: true,
-            last_push_time: Some(1737973800),
-            last_pull_time: None,
-            local: None,
-            remote: None,
-            local_db: FileInfo {
-                exists: true,
-                size_bytes: Some(1048576),
-                modified_time: Some(1737973800),
-            },
-            remote_db: FileInfo {
-                exists: true,
-                size_bytes: Some(1048000),
-                modified_time: Some(1737970000),
-            },
-        };
-
-        let json = serde_json::to_string_pretty(&data).unwrap();
-        assert!(json.contains("authenticated"));
-        assert!(json.contains("local_db"));
-        assert!(json.contains("remote_db"));
     }
 }

--- a/src/commands/sync_status.rs
+++ b/src/commands/sync_status.rs
@@ -1,0 +1,418 @@
+//! Rendering for `grans dropbox status`.
+//!
+//! Compares the local database against the copy on Dropbox without downloading
+//! it, using the metadata file that `push` uploads alongside the database.
+
+use std::path::Path;
+
+use anyhow::Result;
+use chrono::FixedOffset;
+use serde::Serialize;
+
+use crate::output::format::{format_size, OutputMode};
+use crate::sync::config::SyncConfig;
+use crate::sync::dropbox::{format_timestamp, parse_dropbox_time, DropboxClient, FileMetadata};
+use crate::sync::metadata::SyncMetadata;
+
+use super::sync::{get_access_token, get_file_mtime, REMOTE_DB_PATH, REMOTE_METADATA_PATH};
+
+/// File information for status display
+#[derive(Debug, Clone, Serialize)]
+struct FileInfo {
+    exists: bool,
+    size_bytes: Option<u64>,
+    modified_time: Option<u64>,
+}
+
+impl FileInfo {
+    fn from_local(path: &Path) -> Self {
+        if !path.exists() {
+            return Self {
+                exists: false,
+                size_bytes: None,
+                modified_time: None,
+            };
+        }
+
+        let meta = std::fs::metadata(path).ok();
+        Self {
+            exists: true,
+            size_bytes: meta.as_ref().map(|m| m.len()),
+            modified_time: get_file_mtime(path).ok(),
+        }
+    }
+
+    fn from_remote(meta: Option<&FileMetadata>) -> Self {
+        match meta {
+            Some(m) => Self {
+                exists: true,
+                size_bytes: Some(m.size),
+                modified_time: parse_dropbox_time(&m.server_modified),
+            },
+            None => Self {
+                exists: false,
+                size_bytes: None,
+                modified_time: None,
+            },
+        }
+    }
+}
+
+/// Complete sync status data for JSON output
+#[derive(Debug, Serialize)]
+struct SyncStatusData {
+    authenticated: bool,
+    last_push_time: Option<u64>,
+    last_pull_time: Option<u64>,
+    local: Option<SyncMetadata>,
+    remote: Option<SyncMetadata>,
+    local_db: FileInfo,
+    remote_db: FileInfo,
+}
+
+pub(super) fn status(output_mode: OutputMode, tz: &FixedOffset) -> Result<()> {
+    let config = SyncConfig::load()?;
+
+    // Get local database path
+    let db_path = crate::db::connection::default_db_path()?;
+
+    // Collect local metadata
+    let local_metadata = SyncMetadata::from_local_db(
+        db_path.exists().then_some(&db_path),
+    )
+    .ok();
+
+    // Local file info
+    let local_db_info = FileInfo::from_local(&db_path);
+
+    // Remote info (only if authenticated)
+    let (remote_metadata, remote_db_info) =
+        if config.is_authenticated() {
+            match get_access_token(&config) {
+                Ok(access_token) => {
+                    let client = DropboxClient::new(access_token)?;
+                    let remote_meta = fetch_remote_metadata(&client);
+                    let db_meta = client.get_metadata(REMOTE_DB_PATH).ok().flatten();
+
+                    (
+                        remote_meta,
+                        FileInfo::from_remote(db_meta.as_ref()),
+                    )
+                }
+                Err(_) => (
+                    None,
+                    FileInfo::from_remote(None),
+                ),
+            }
+        } else {
+            (
+                None,
+                FileInfo::from_remote(None),
+            )
+        };
+
+    let status_data = SyncStatusData {
+        authenticated: config.is_authenticated(),
+        last_push_time: config.last_push_time,
+        last_pull_time: config.last_pull_time,
+        local: local_metadata.clone(),
+        remote: remote_metadata.clone(),
+        local_db: local_db_info.clone(),
+        remote_db: remote_db_info.clone(),
+    };
+
+    match output_mode {
+        OutputMode::Json => {
+            println!("{}", serde_json::to_string_pretty(&status_data)?);
+        }
+        OutputMode::Tty => {
+            print_status_tty(&status_data, tz);
+        }
+    }
+
+    Ok(())
+}
+
+fn fetch_remote_metadata(client: &DropboxClient) -> Option<SyncMetadata> {
+    match client.download(REMOTE_METADATA_PATH) {
+        Ok(bytes) => {
+            let json = String::from_utf8(bytes).ok()?;
+            match serde_json::from_str(&json) {
+                Ok(meta) => Some(meta),
+                Err(e) => {
+                    eprintln!("Warning: Could not parse remote metadata: {}", e);
+                    None
+                }
+            }
+        }
+        Err(_) => None, // File doesn't exist or couldn't be downloaded
+    }
+}
+
+fn print_status_tty(data: &SyncStatusData, tz: &FixedOffset) {
+    use colored::Colorize;
+
+    println!("{}", "Sync Status".bold());
+    println!("{}", "───────────".dimmed());
+
+    // Authentication
+    if data.authenticated {
+        println!("Authentication: {}", "Connected".green());
+    } else {
+        println!("Authentication: {}", "Not connected".red());
+        println!(
+            "\nRun '{}' to connect to Dropbox.",
+            "grans dropbox init".cyan()
+        );
+        return;
+    }
+
+    // Last sync times
+    if let Some(ts) = data.last_push_time {
+        println!("Last push: {}", format_timestamp(ts).dimmed());
+    } else {
+        println!("Last push: {}", "Never".dimmed());
+    }
+    if let Some(ts) = data.last_pull_time {
+        println!("Last pull: {}", format_timestamp(ts).dimmed());
+    } else {
+        println!("Last pull: {}", "Never".dimmed());
+    }
+
+    println!();
+
+    // Column headers
+    let header = format!(
+        "{:28} {:>18}    {:>18}",
+        "",
+        "Local".bold(),
+        "Remote".bold()
+    );
+    println!("{}", header);
+    let separator = format!(
+        "{:28} {:>18}    {:>18}",
+        "",
+        "─────".dimmed(),
+        "──────".dimmed()
+    );
+    println!("{}", separator);
+
+    // Get local and remote stats
+    let local_idx = data.local.as_ref().and_then(|m| m.index_db.as_ref());
+    let remote_idx = data.remote.as_ref().and_then(|m| m.index_db.as_ref());
+
+    // Documents
+    print_comparison_row(
+        "Documents:",
+        local_idx.map(|i| format_number(i.document_count)),
+        remote_idx.map(|i| format_number(i.document_count)),
+    );
+
+    // With transcripts
+    print_comparison_row(
+        "With transcripts:",
+        local_idx.map(|i| format_number(i.documents_with_transcripts)),
+        remote_idx.map(|i| format_number(i.documents_with_transcripts)),
+    );
+
+    // Utterances
+    print_comparison_row(
+        "Utterances:",
+        local_idx.map(|i| format_number(i.transcript_utterance_count)),
+        remote_idx.map(|i| format_number(i.transcript_utterance_count)),
+    );
+
+    // People
+    print_comparison_row(
+        "People:",
+        local_idx.map(|i| format_number(i.people_count)),
+        remote_idx.map(|i| format_number(i.people_count)),
+    );
+
+    // Date range
+    let local_range = local_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
+    let remote_range =
+        remote_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
+    print_comparison_row("Date range:", local_range, remote_range);
+
+    // Schema version
+    let local_schema = local_idx.map(|i| i.schema_version);
+    let remote_schema = remote_idx.map(|i| i.schema_version);
+    let schema_mismatch =
+        local_schema.is_some() && remote_schema.is_some() && local_schema != remote_schema;
+    print_comparison_row_with_warning(
+        "Schema version:",
+        local_idx.map(|i| i.schema_version.to_string()),
+        remote_idx.map(|i| i.schema_version.to_string()),
+        schema_mismatch,
+    );
+
+    // Database size
+    print_comparison_row(
+        "Database size:",
+        data.local_db.size_bytes.map(format_size),
+        data.remote_db.size_bytes.map(format_size),
+    );
+
+    // Database modified
+    print_comparison_row(
+        "Database modified:",
+        data.local_db.modified_time.map(|ts| format_short_time(ts, tz)),
+        data.remote_db.modified_time.map(|ts| format_short_time(ts, tz)),
+    );
+
+    // Embeddings
+    let local_emb_count = local_idx.map(|i| i.embedding_count).unwrap_or(0);
+    let remote_emb_count = remote_idx.map(|i| i.embedding_count)
+        .or_else(|| data.remote.as_ref().and_then(|m| m.embeddings_db.as_ref()).map(|e| e.embedding_count))
+        .unwrap_or(0);
+    print_comparison_row(
+        "Embeddings:",
+        Some(format_number(local_emb_count)),
+        Some(format_number(remote_emb_count)),
+    );
+
+    // Embedding model
+    let local_model = local_idx.and_then(|i| i.embedding_model.clone());
+    let remote_model = remote_idx.and_then(|i| i.embedding_model.clone())
+        .or_else(|| data.remote.as_ref().and_then(|m| m.embeddings_db.as_ref()).and_then(|e| e.model.clone()));
+    print_comparison_row(
+        "Embedding model:",
+        local_model,
+        remote_model,
+    );
+
+    if schema_mismatch {
+        println!();
+        println!(
+            "{}",
+            "Warning: Schema version mismatch between local and remote databases.".yellow()
+        );
+    }
+}
+
+fn print_comparison_row(label: &str, local: Option<String>, remote: Option<String>) {
+    print_comparison_row_with_warning(label, local, remote, false);
+}
+
+fn print_comparison_row_with_warning(
+    label: &str,
+    local: Option<String>,
+    remote: Option<String>,
+    warn: bool,
+) {
+    use colored::Colorize;
+
+    let local_str = local.unwrap_or_else(|| "—".to_string());
+    let remote_str = remote.unwrap_or_else(|| "unknown".to_string());
+
+    if warn {
+        println!(
+            "{:28} {:>18}    {:>18} {}",
+            label,
+            local_str,
+            remote_str.yellow(),
+            "⚠".yellow()
+        );
+    } else {
+        println!("{:28} {:>18}    {:>18}", label, local_str, remote_str);
+    }
+}
+
+fn format_number(n: i64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}
+
+fn format_short_time(ts: u64, tz: &FixedOffset) -> String {
+    use chrono::DateTime;
+    let dt = DateTime::from_timestamp(ts as i64, 0)
+        .unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap());
+    dt.with_timezone(tz).format("%Y-%m-%d %H:%M").to_string()
+}
+
+fn format_date_range(earliest: &Option<String>, latest: &Option<String>) -> String {
+    match (earliest, latest) {
+        (Some(e), Some(l)) => {
+            let e_short = e.get(..7).unwrap_or(e);
+            let l_short = l.get(..7).unwrap_or(l);
+            format!("{} → {}", e_short, l_short)
+        }
+        _ => "—".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_number() {
+        assert_eq!(format_number(0), "0");
+        assert_eq!(format_number(999), "999");
+        assert_eq!(format_number(1000), "1.0K");
+        assert_eq!(format_number(1500), "1.5K");
+        assert_eq!(format_number(52847), "52.8K");
+        assert_eq!(format_number(1000000), "1.0M");
+        assert_eq!(format_number(1500000), "1.5M");
+    }
+
+    #[test]
+    fn test_format_date_range() {
+        assert_eq!(
+            format_date_range(
+                &Some("2023-06-01T00:00:00Z".to_string()),
+                &Some("2025-01-27T00:00:00Z".to_string())
+            ),
+            "2023-06 → 2025-01"
+        );
+        assert_eq!(format_date_range(&None, &None), "—");
+    }
+
+    #[test]
+    fn test_file_info_from_local_nonexistent() {
+        let info = FileInfo::from_local(Path::new("/nonexistent/path/file.db"));
+        assert!(!info.exists);
+        assert!(info.size_bytes.is_none());
+        assert!(info.modified_time.is_none());
+    }
+
+    #[test]
+    fn test_file_info_from_local_existing() {
+        let info = FileInfo::from_local(Path::new("Cargo.toml"));
+        assert!(info.exists);
+        assert!(info.size_bytes.is_some());
+        assert!(info.modified_time.is_some());
+    }
+
+    #[test]
+    fn test_sync_status_data_serialization() {
+        let data = SyncStatusData {
+            authenticated: true,
+            last_push_time: Some(1737973800),
+            last_pull_time: None,
+            local: None,
+            remote: None,
+            local_db: FileInfo {
+                exists: true,
+                size_bytes: Some(1048576),
+                modified_time: Some(1737973800),
+            },
+            remote_db: FileInfo {
+                exists: true,
+                size_bytes: Some(1048000),
+                modified_time: Some(1737970000),
+            },
+        };
+
+        let json = serde_json::to_string_pretty(&data).unwrap();
+        assert!(json.contains("authenticated"));
+        assert!(json.contains("local_db"));
+        assert!(json.contains("remote_db"));
+    }
+}

--- a/src/db/integrity.rs
+++ b/src/db/integrity.rs
@@ -1,0 +1,143 @@
+//! Integrity checking for database files arriving from outside this machine.
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Context, Result};
+use log::debug;
+use rusqlite::{Connection, OpenFlags};
+
+/// A grans database always has this table, so its absence means the file is a
+/// database but not one of ours.
+const SENTINEL_TABLE: &str = "documents";
+
+/// Verify that a file is a structurally sound grans database.
+///
+/// Intended for a freshly downloaded file, before it replaces a working
+/// database. Runs SQLite's `quick_check`, which reads every page, then confirms
+/// the file actually carries grans data: an empty file is a perfectly valid
+/// SQLite database and passes `quick_check` on its own.
+pub fn check_pulled_database(path: &Path) -> Result<()> {
+    let start = Instant::now();
+
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("opening {} as a SQLite database", path.display()))?;
+
+    run_quick_check(&conn)?;
+    require_grans_schema(&conn)?;
+
+    debug!("integrity check passed in {:?}", start.elapsed());
+
+    Ok(())
+}
+
+/// Ask SQLite to read every page and report structural damage.
+fn run_quick_check(conn: &Connection) -> Result<()> {
+    let result: String = conn
+        .query_row("PRAGMA quick_check", [], |row| row.get(0))
+        .context("running PRAGMA quick_check; the file is not a readable SQLite database")?;
+
+    if result != "ok" {
+        bail!("SQLite reported corruption: {}", result);
+    }
+
+    Ok(())
+}
+
+/// Confirm the database carries grans tables rather than merely being valid.
+fn require_grans_schema(conn: &Connection) -> Result<()> {
+    let found: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [SENTINEL_TABLE],
+            |row| row.get(0),
+        )
+        .context("reading the database schema")?;
+
+    if found == 0 {
+        return Err(anyhow!(
+            "no '{}' table, so this is not a grans database",
+            SENTINEL_TABLE
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    fn valid_database(dir: &TempDir) -> std::path::PathBuf {
+        let path = dir.path().join("good.db");
+        let conn = Connection::open(&path).unwrap();
+        crate::db::schema::create_tables(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO documents (id, title, created_at) VALUES ('d1', 'T', '2024-01-01T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        path
+    }
+
+    #[test]
+    fn accepts_a_valid_database() {
+        let dir = TempDir::new().unwrap();
+        let path = valid_database(&dir);
+
+        assert!(check_pulled_database(&path).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_file_that_is_not_sqlite() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nonsense.db");
+        std::fs::write(&path, b"<html>504 Gateway Timeout</html>").unwrap();
+
+        let err = check_pulled_database(&path).unwrap_err();
+
+        assert!(
+            err.to_string().to_lowercase().contains("database"),
+            "unhelpful message: {}",
+            err
+        );
+    }
+
+    /// A zero-length file is a valid empty SQLite database, so `quick_check`
+    /// alone would wave it through.
+    #[test]
+    fn rejects_an_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("empty.db");
+        std::fs::write(&path, b"").unwrap();
+
+        assert!(check_pulled_database(&path).is_err());
+    }
+
+    /// A real SQLite database that simply is not a grans database.
+    #[test]
+    fn rejects_a_database_without_grans_tables() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("other.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("CREATE TABLE unrelated (id INTEGER)", []).unwrap();
+        drop(conn);
+
+        assert!(check_pulled_database(&path).is_err());
+    }
+
+    #[test]
+    fn rejects_a_truncated_database() {
+        let dir = TempDir::new().unwrap();
+        let path = valid_database(&dir);
+
+        // Lop off the tail, leaving a valid header over a damaged body.
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.truncate(bytes.len() / 2);
+        std::fs::write(&path, &bytes).unwrap();
+
+        assert!(check_pulled_database(&path).is_err());
+    }
+}

--- a/src/db/integrity.rs
+++ b/src/db/integrity.rs
@@ -128,6 +128,43 @@ mod tests {
         assert!(check_pulled_database(&path).is_err());
     }
 
+    /// Pins a known limit rather than a capability.
+    ///
+    /// grans builds its FTS5 tables with `content=`, and SQLite compares an
+    /// external-content index against its source table only under FTS5's own
+    /// `integrity-check` with `rank=1`. Neither `quick_check` nor
+    /// `integrity_check` runs that, so an index that has drifted from its
+    /// source passes both. Search then silently returns too few rows while the
+    /// database looks healthy.
+    ///
+    /// Closing this needs a writable connection, which this deliberately
+    /// read-only check does not take. If that changes, this test should start
+    /// failing and be inverted.
+    #[test]
+    fn does_not_notice_an_fts_index_that_drifted_from_its_source() {
+        let dir = TempDir::new().unwrap();
+        let path = valid_database(&dir);
+
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(
+            "INSERT INTO transcript_utterances (id, document_id, text)
+                 VALUES ('u1', 'd1', 'deployment rollback discussion'),
+                        ('u2', 'd1', 'quarterly planning notes');
+             INSERT INTO transcript_fts(transcript_fts) VALUES('rebuild');",
+        )
+        .unwrap();
+
+        // Drop source rows without the index maintenance that db::transcripts
+        // normally performs, leaving the index describing rows that are gone.
+        conn.execute("DELETE FROM transcript_utterances", []).unwrap();
+        drop(conn);
+
+        assert!(
+            check_pulled_database(&path).is_ok(),
+            "if this now fails, the FTS drift gap has been closed; invert the test"
+        );
+    }
+
     #[test]
     fn rejects_a_truncated_database() {
         let dir = TempDir::new().unwrap();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,6 +2,7 @@ pub mod calendars;
 mod common;
 pub mod connection;
 pub mod info;
+pub mod integrity;
 pub mod meetings;
 pub mod migrations;
 pub mod panels;

--- a/src/output/format.rs
+++ b/src/output/format.rs
@@ -13,6 +13,23 @@ pub fn detect_output_mode(json_flag: bool) -> OutputMode {
     OutputMode::Tty
 }
 
+/// Format a byte count for display.
+pub fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -25,5 +42,14 @@ mod tests {
     #[test]
     fn test_no_json_flag_gives_tty() {
         assert_eq!(detect_output_mode(false), OutputMode::Tty);
+    }
+
+    #[test]
+    fn test_format_size() {
+        assert_eq!(format_size(500), "500 B");
+        assert_eq!(format_size(1024), "1.0 KB");
+        assert_eq!(format_size(1048576), "1.0 MB");
+        assert_eq!(format_size(47185920), "45.0 MB");
+        assert_eq!(format_size(1073741824), "1.0 GB");
     }
 }

--- a/src/sync/content_hash.rs
+++ b/src/sync/content_hash.rs
@@ -1,0 +1,210 @@
+//! Dropbox content hashing.
+//!
+//! Dropbox reports a `content_hash` for every stored file, letting a download be
+//! checked against the bytes the server actually holds rather than inferring
+//! integrity from a byte count. The algorithm is defined at
+//! <https://www.dropbox.com/developers/reference/content-hash>: split the file
+//! into 4 MiB blocks, SHA-256 each block, concatenate those digests in order,
+//! and SHA-256 the result.
+
+use std::io::{self, Write};
+
+use sha2::{Digest, Sha256};
+
+/// Dropbox hashes the file in 4 MiB blocks.
+const BLOCK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Computes a Dropbox content hash incrementally.
+///
+/// Data may be fed in pieces of any size; block boundaries are handled
+/// internally, so a download can be hashed as it streams past.
+pub struct ContentHasher {
+    /// Hashes the block currently being filled.
+    block: Sha256,
+    /// Bytes accumulated into `block` so far.
+    block_len: usize,
+    /// Hashes the concatenated per-block digests.
+    digests: Sha256,
+}
+
+impl ContentHasher {
+    pub fn new() -> Self {
+        Self {
+            block: Sha256::new(),
+            block_len: 0,
+            digests: Sha256::new(),
+        }
+    }
+
+    pub fn update(&mut self, mut data: &[u8]) {
+        while !data.is_empty() {
+            let room = BLOCK_SIZE - self.block_len;
+            let take = room.min(data.len());
+
+            self.block.update(&data[..take]);
+            self.block_len += take;
+            data = &data[take..];
+
+            if self.block_len == BLOCK_SIZE {
+                self.finish_block();
+            }
+        }
+    }
+
+    /// Fold the completed block's digest into the outer hash.
+    fn finish_block(&mut self) {
+        let digest = self.block.finalize_reset();
+        self.digests.update(digest);
+        self.block_len = 0;
+    }
+
+    /// Finish hashing and return the lowercase hex digest.
+    pub fn finish(mut self) -> String {
+        // A trailing partial block still contributes a digest. An empty input
+        // contributes none, leaving the hash of an empty concatenation.
+        if self.block_len > 0 {
+            self.finish_block();
+        }
+
+        format!("{:x}", self.digests.finalize())
+    }
+}
+
+impl Default for ContentHasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Wraps a writer, hashing everything written through it.
+///
+/// Lets a streaming download verify its content without a second pass over the
+/// file.
+pub struct HashingWriter<W> {
+    inner: W,
+    hasher: ContentHasher,
+}
+
+impl<W: Write> HashingWriter<W> {
+    pub fn new(inner: W) -> Self {
+        Self {
+            inner,
+            hasher: ContentHasher::new(),
+        }
+    }
+
+    /// Return the wrapped writer and the hash of everything written.
+    pub fn finish(self) -> (W, String) {
+        (self.inner, self.hasher.finish())
+    }
+}
+
+impl<W: Write> Write for HashingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Hash only what the inner writer accepted, so a short write cannot
+        // desynchronise the digest from the bytes on disk.
+        let written = self.inner.write(buf)?;
+        self.hasher.update(&buf[..written]);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Expected digests were computed independently with Python's hashlib
+    // following the published algorithm, not with this implementation.
+    const EMPTY: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const HELLO_WORLD: &str = "bc62d4b80d9e36da29c16c5d4d9f11731f36052c72401a76c23c0fb5a9b74423";
+    const ONE_FULL_BLOCK: &str = "907a506cf5e706bda5c7a29b43c9c65d8344bd2fa2f22339b359c214812af5a1";
+    const ONE_BLOCK_PLUS_ONE: &str =
+        "c53f160bb0f52f97d686989961c455b5bba18dbca70d2cdc402eb63cdddf7b4d";
+    const TWO_FULL_BLOCKS: &str = "caa2b7a097746dcd56cbddd09bb9e5b5ab1c3a9a518a63453f07fb799e7839ec";
+
+    fn hash_all(data: &[u8]) -> String {
+        let mut hasher = ContentHasher::new();
+        hasher.update(data);
+        hasher.finish()
+    }
+
+    /// Feed data in fixed-size pieces, mimicking a body arriving over a socket.
+    fn hash_in_pieces(data: &[u8], piece: usize) -> String {
+        let mut hasher = ContentHasher::new();
+        for chunk in data.chunks(piece) {
+            hasher.update(chunk);
+        }
+        hasher.finish()
+    }
+
+    #[test]
+    fn hashes_an_empty_input() {
+        assert_eq!(hash_all(b""), EMPTY);
+    }
+
+    #[test]
+    fn hashes_a_short_input() {
+        assert_eq!(hash_all(b"hello world"), HELLO_WORLD);
+    }
+
+    #[test]
+    fn hashes_exactly_one_block() {
+        assert_eq!(hash_all(&vec![b'a'; BLOCK_SIZE]), ONE_FULL_BLOCK);
+    }
+
+    #[test]
+    fn hashes_one_byte_past_a_block_boundary() {
+        assert_eq!(hash_all(&vec![b'b'; BLOCK_SIZE + 1]), ONE_BLOCK_PLUS_ONE);
+    }
+
+    #[test]
+    fn hashes_two_whole_blocks() {
+        assert_eq!(hash_all(&vec![b'c'; 2 * BLOCK_SIZE]), TWO_FULL_BLOCKS);
+    }
+
+    /// The hash must not depend on how the data was chopped up on the way in,
+    /// which is the property that makes streaming safe.
+    #[test]
+    fn piece_size_does_not_change_the_hash() {
+        let data = vec![b'b'; BLOCK_SIZE + 1];
+
+        for piece in [1, 7, 1000, 64 * 1024, BLOCK_SIZE - 1, BLOCK_SIZE] {
+            assert_eq!(
+                hash_in_pieces(&data, piece),
+                ONE_BLOCK_PLUS_ONE,
+                "piece size {} changed the digest",
+                piece
+            );
+        }
+    }
+
+    #[test]
+    fn hashing_writer_passes_bytes_through_and_hashes_them() {
+        let mut writer = HashingWriter::new(Vec::new());
+
+        writer.write_all(b"hello ").unwrap();
+        writer.write_all(b"world").unwrap();
+        let (inner, hash) = writer.finish();
+
+        assert_eq!(inner, b"hello world");
+        assert_eq!(hash, HELLO_WORLD);
+    }
+
+    #[test]
+    fn hashing_writer_handles_a_block_spanning_write() {
+        let data = vec![b'b'; BLOCK_SIZE + 1];
+        let mut writer = HashingWriter::new(Vec::new());
+
+        for chunk in data.chunks(64 * 1024) {
+            writer.write_all(chunk).unwrap();
+        }
+        let (inner, hash) = writer.finish();
+
+        assert_eq!(inner.len(), data.len());
+        assert_eq!(hash, ONE_BLOCK_PLUS_ONE);
+    }
+}

--- a/src/sync/dropbox.rs
+++ b/src/sync/dropbox.rs
@@ -38,6 +38,11 @@ pub struct FileMetadata {
     pub server_modified: String,
     #[serde(rename = ".tag")]
     pub tag: Option<String>,
+    /// Dropbox's hash of the stored file, for verifying a download.
+    ///
+    /// Optional so that a response without it still deserializes; callers that
+    /// require verification reject its absence themselves.
+    pub content_hash: Option<String>,
 }
 
 /// Error response from Dropbox API.

--- a/src/sync/dropbox.rs
+++ b/src/sync/dropbox.rs
@@ -3,9 +3,11 @@
 //! Implements upload, download, and metadata operations using the Dropbox HTTP API.
 //! Files under 150 MB use single-request uploads; larger files use chunked upload sessions.
 
+use log::debug;
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::path::Path;
+use std::time::Instant;
 
 use super::transfer::{self, UPLOAD_TIMEOUT};
 use super::{SyncError, SyncResult};
@@ -88,12 +90,24 @@ impl DropboxClient {
     /// Files over 150 MB are automatically uploaded using chunked upload sessions.
     pub fn upload(&self, local_path: &Path, dropbox_path: &str) -> SyncResult<FileMetadata> {
         let file_size = std::fs::metadata(local_path)?.len();
+        let start = Instant::now();
 
-        if file_size <= UPLOAD_SINGLE_LIMIT {
+        let result = if file_size <= UPLOAD_SINGLE_LIMIT {
+            debug!("upload {} ({} bytes, single request)", dropbox_path, file_size);
             self.upload_single(local_path, dropbox_path)
         } else {
+            debug!("upload {} ({} bytes, chunked session)", dropbox_path, file_size);
             self.upload_chunked(local_path, dropbox_path, file_size)
+        };
+
+        if result.is_ok() {
+            debug!(
+                "  upload complete: {}",
+                transfer::describe_throughput(file_size, start.elapsed())
+            );
         }
+
+        result
     }
 
     /// Upload a file in a single request (for files <= 150 MB).
@@ -332,22 +346,61 @@ impl DropboxClient {
             path: dropbox_path.to_string(),
         })?;
 
+        debug!("POST {} (download {})", DOWNLOAD_URL, dropbox_path);
+        let start = Instant::now();
+
         let mut response = self
             .http
             .post(DOWNLOAD_URL)
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Dropbox-API-Arg", arg_json)
             .send()
-            .map_err(|e| transfer::transport_error(format!("download of {}", dropbox_path), e))?;
+            .map_err(|e| {
+                debug!("  network error after {:?}: {}", start.elapsed(), e);
+                transfer::transport_error(format!("download of {}", dropbox_path), e)
+            })?;
 
         let status = response.status();
+        debug!("  response: {} in {:?}", status, start.elapsed());
+
         if !status.is_success() {
             let body = response.text().unwrap_or_default();
             return Err(self.parse_error(status, &body));
         }
 
-        transfer::stream_with_progress(&mut response, writer, on_progress)
-            .map_err(|e| transfer::stream_error(format!("download of {}", dropbox_path), e))
+        // Mirror the running count so a failed transfer can still report how far
+        // it got, which is what distinguishes a mid-transfer drop from a stall
+        // that never delivered anything.
+        let body_start = Instant::now();
+        let mut transferred = 0u64;
+        let result = {
+            let mut track = |bytes: u64| {
+                transferred = bytes;
+                on_progress(bytes);
+            };
+            transfer::stream_with_progress(&mut response, writer, &mut track)
+        };
+
+        let elapsed = body_start.elapsed();
+        match result {
+            Ok(written) => {
+                debug!(
+                    "  body complete: {}",
+                    transfer::describe_throughput(written, elapsed)
+                );
+                Ok(written)
+            }
+            Err(e) => {
+                debug!(
+                    "  body failed after {}",
+                    transfer::describe_throughput(transferred, elapsed)
+                );
+                Err(transfer::stream_error(
+                    format!("download of {}", dropbox_path),
+                    e,
+                ))
+            }
+        }
     }
 
     /// Get metadata for a file on Dropbox.
@@ -363,6 +416,9 @@ impl DropboxClient {
             path: dropbox_path.to_string(),
         };
 
+        debug!("POST {} (metadata for {})", METADATA_URL, dropbox_path);
+        let start = Instant::now();
+
         let response = self
             .http
             .post(METADATA_URL)
@@ -371,15 +427,18 @@ impl DropboxClient {
             .json(&arg)
             .send()
             .map_err(|e| {
+                debug!("  network error after {:?}: {}", start.elapsed(), e);
                 transfer::transport_error(format!("metadata lookup for {}", dropbox_path), e)
             })?;
 
         let status = response.status();
+        debug!("  response: {} in {:?}", status, start.elapsed());
         let body = response.text().unwrap_or_default();
 
         if status.as_u16() == 409 {
             // Check if it's a "not found" error
             if body.contains("not_found") {
+                debug!("  {} does not exist on Dropbox", dropbox_path);
                 return Ok(None);
             }
         }

--- a/src/sync/dropbox.rs
+++ b/src/sync/dropbox.rs
@@ -4,9 +4,10 @@
 //! Files under 150 MB use single-request uploads; larger files use chunked upload sessions.
 
 use serde::{Deserialize, Serialize};
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::Path;
 
+use super::transfer::{self, UPLOAD_TIMEOUT};
 use super::{SyncError, SyncResult};
 
 const UPLOAD_URL: &str = "https://content.dropboxapi.com/2/files/upload";
@@ -67,13 +68,18 @@ pub struct DropboxClient {
     http: reqwest::blocking::Client,
 }
 
+/// Serialize a `Dropbox-API-Arg` header value.
+fn serialize_arg<T: Serialize>(arg: &T) -> SyncResult<String> {
+    serde_json::to_string(arg).map_err(|e| SyncError::DropboxApi(format!("serialize arg: {}", e)))
+}
+
 impl DropboxClient {
     /// Create a new client with an access token.
-    pub fn new(access_token: String) -> Self {
-        Self {
+    pub fn new(access_token: String) -> SyncResult<Self> {
+        Ok(Self {
             access_token,
-            http: reqwest::blocking::Client::new(),
-        }
+            http: transfer::build_client()?,
+        })
     }
 
     /// Upload a file to Dropbox.
@@ -101,8 +107,7 @@ impl DropboxClient {
             mute: true,
         };
 
-        let arg_json = serde_json::to_string(&arg)
-            .map_err(|e| SyncError::DropboxApi(format!("serialize arg: {}", e)))?;
+        let arg_json = serialize_arg(&arg)?;
 
         let response = self
             .http
@@ -110,8 +115,10 @@ impl DropboxClient {
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Dropbox-API-Arg", arg_json)
             .header("Content-Type", "application/octet-stream")
+            .timeout(UPLOAD_TIMEOUT)
             .body(content)
-            .send()?;
+            .send()
+            .map_err(|e| transfer::transport_error(format!("upload of {}", dropbox_path), e))?;
 
         self.handle_response(response)
     }
@@ -181,8 +188,7 @@ impl DropboxClient {
             close: bool,
         }
 
-        let arg_json = serde_json::to_string(&StartArg { close: false })
-            .map_err(|e| SyncError::DropboxApi(format!("serialize arg: {}", e)))?;
+        let arg_json = serialize_arg(&StartArg { close: false })?;
 
         let response = self
             .http
@@ -190,8 +196,10 @@ impl DropboxClient {
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Dropbox-API-Arg", &arg_json)
             .header("Content-Type", "application/octet-stream")
+            .timeout(UPLOAD_TIMEOUT)
             .body(data.to_vec())
-            .send()?;
+            .send()
+            .map_err(|e| transfer::transport_error("upload session start", e))?;
 
         #[derive(Deserialize)]
         struct StartResult {
@@ -223,8 +231,7 @@ impl DropboxClient {
             close: false,
         };
 
-        let arg_json = serde_json::to_string(&arg)
-            .map_err(|e| SyncError::DropboxApi(format!("serialize arg: {}", e)))?;
+        let arg_json = serialize_arg(&arg)?;
 
         let response = self
             .http
@@ -232,8 +239,12 @@ impl DropboxClient {
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Dropbox-API-Arg", &arg_json)
             .header("Content-Type", "application/octet-stream")
+            .timeout(UPLOAD_TIMEOUT)
             .body(data.to_vec())
-            .send()?;
+            .send()
+            .map_err(|e| {
+                transfer::transport_error(format!("upload of chunk at offset {}", offset), e)
+            })?;
 
         let status = response.status();
         if !status.is_success() {
@@ -271,8 +282,7 @@ impl DropboxClient {
             },
         };
 
-        let arg_json = serde_json::to_string(&arg)
-            .map_err(|e| SyncError::DropboxApi(format!("serialize arg: {}", e)))?;
+        let arg_json = serialize_arg(&arg)?;
 
         let response = self
             .http
@@ -280,34 +290,55 @@ impl DropboxClient {
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Dropbox-API-Arg", &arg_json)
             .header("Content-Type", "application/octet-stream")
+            .timeout(UPLOAD_TIMEOUT)
             .body(data.to_vec())
-            .send()?;
+            .send()
+            .map_err(|e| {
+                transfer::transport_error(format!("upload commit for {}", dropbox_path), e)
+            })?;
 
         self.handle_response(response)
     }
 
-    /// Download a file from Dropbox.
+    /// Download a small file from Dropbox into memory.
     ///
-    /// Returns the file content as bytes.
+    /// Only for files whose size is known to be modest, such as sync metadata.
+    /// Use [`DropboxClient::download_to_writer`] for databases.
     pub fn download(&self, dropbox_path: &str) -> SyncResult<Vec<u8>> {
+        let mut buffer = Vec::new();
+        self.download_to_writer(dropbox_path, &mut buffer, &mut |_| {})?;
+        Ok(buffer)
+    }
+
+    /// Stream a file from Dropbox into `writer`, reporting the running byte count.
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// Streaming keeps the file out of memory and, because reqwest bounds each
+    /// read rather than the request as a whole, lets a transfer run as long as
+    /// the connection keeps delivering data.
+    pub fn download_to_writer<W: Write>(
+        &self,
+        dropbox_path: &str,
+        writer: &mut W,
+        on_progress: &mut dyn FnMut(u64),
+    ) -> SyncResult<u64> {
         #[derive(Serialize)]
         struct DownloadArg {
             path: String,
         }
 
-        let arg = DownloadArg {
+        let arg_json = serialize_arg(&DownloadArg {
             path: dropbox_path.to_string(),
-        };
+        })?;
 
-        let arg_json = serde_json::to_string(&arg)
-            .map_err(|e| SyncError::DropboxApi(format!("serialize arg: {}", e)))?;
-
-        let response = self
+        let mut response = self
             .http
             .post(DOWNLOAD_URL)
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Dropbox-API-Arg", arg_json)
-            .send()?;
+            .send()
+            .map_err(|e| transfer::transport_error(format!("download of {}", dropbox_path), e))?;
 
         let status = response.status();
         if !status.is_success() {
@@ -315,11 +346,8 @@ impl DropboxClient {
             return Err(self.parse_error(status, &body));
         }
 
-        let bytes = response
-            .bytes()
-            .map_err(|e| SyncError::DropboxApi(format!("read body: {}", e)))?;
-
-        Ok(bytes.to_vec())
+        transfer::stream_with_progress(&mut response, writer, on_progress)
+            .map_err(|e| transfer::stream_error(format!("download of {}", dropbox_path), e))
     }
 
     /// Get metadata for a file on Dropbox.
@@ -341,7 +369,10 @@ impl DropboxClient {
             .header("Authorization", format!("Bearer {}", self.access_token))
             .header("Content-Type", "application/json")
             .json(&arg)
-            .send()?;
+            .send()
+            .map_err(|e| {
+                transfer::transport_error(format!("metadata lookup for {}", dropbox_path), e)
+            })?;
 
         let status = response.status();
         let body = response.text().unwrap_or_default();

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,6 +1,7 @@
 //! Dropbox sync module for synchronizing SQLite index and embeddings databases.
 
 pub mod config;
+pub mod content_hash;
 pub mod dropbox;
 pub mod metadata;
 pub mod oauth;
@@ -36,6 +37,23 @@ pub enum SyncError {
         actual: u64,
         expected: u64,
     },
+
+    #[error(
+        "Corrupt transfer: the {what} received does not match the content hash Dropbox reported \
+         (expected {expected}, computed {actual}). The local file was left untouched; \
+         retry the transfer."
+    )]
+    ContentMismatch {
+        what: String,
+        expected: String,
+        actual: String,
+    },
+
+    #[error(
+        "Dropbox reported no content hash for {path}, so the download could not be verified \
+         against the stored file."
+    )]
+    MissingContentHash { path: String },
 
     #[error("Config error: {0}")]
     Config(String),

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod dropbox;
 pub mod metadata;
 pub mod oauth;
+pub mod transfer;
 
 use thiserror::Error;
 
@@ -17,6 +18,24 @@ pub enum SyncError {
 
     #[error("Dropbox API error: {0}")]
     DropboxApi(String),
+
+    #[error("Dropbox {operation} failed: {hint}")]
+    Transport {
+        operation: String,
+        hint: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    #[error(
+        "Incomplete transfer: {what} delivered {actual} bytes but Dropbox reported {expected}. \
+         The local file was left untouched; retry the transfer."
+    )]
+    IncompleteTransfer {
+        what: String,
+        actual: u64,
+        expected: u64,
+    },
 
     #[error("Config error: {0}")]
     Config(String),

--- a/src/sync/transfer.rs
+++ b/src/sync/transfer.rs
@@ -125,6 +125,22 @@ pub fn describe_throughput(bytes: u64, elapsed: Duration) -> String {
     format!("{:.2} MB in {:?} ({:.2} MB/s)", mib, elapsed, mib / secs)
 }
 
+/// Fail when the bytes received do not match the hash Dropbox holds for the file.
+///
+/// A byte count only proves the transfer was not cut short; this proves the
+/// content is the file Dropbox has.
+pub fn verify_content_hash(actual: &str, expected: &str, what: &str) -> SyncResult<()> {
+    if actual.eq_ignore_ascii_case(expected) {
+        return Ok(());
+    }
+
+    Err(SyncError::ContentMismatch {
+        what: what.to_string(),
+        expected: expected.to_string(),
+        actual: actual.to_string(),
+    })
+}
+
 /// Fail when a transfer delivered a different number of bytes than advertised.
 ///
 /// A download cut short still produces a readable file, so without this check a
@@ -354,6 +370,30 @@ mod tests {
 
         assert!(text.contains("1.00 MB"), "{}", text);
         assert!(!text.contains("inf"), "must not divide by zero: {}", text);
+    }
+
+    #[test]
+    fn verify_content_hash_accepts_a_match() {
+        assert!(verify_content_hash("abc123", "abc123", "database").is_ok());
+    }
+
+    /// Dropbox documents the hash as hex; casing should not decide the outcome.
+    #[test]
+    fn verify_content_hash_ignores_case() {
+        assert!(verify_content_hash("ABC123", "abc123", "database").is_ok());
+    }
+
+    #[test]
+    fn verify_content_hash_rejects_a_mismatch() {
+        let err = verify_content_hash("aaaa", "bbbb", "database").unwrap_err();
+        let msg = err.to_string();
+
+        assert!(msg.contains("aaaa") && msg.contains("bbbb"), "{}", msg);
+        assert!(
+            msg.contains("left untouched"),
+            "should say the local file is safe: {}",
+            msg
+        );
     }
 
     #[test]

--- a/src/sync/transfer.rs
+++ b/src/sync/transfer.rs
@@ -110,6 +110,21 @@ pub fn stream_error(operation: impl Into<String>, err: io::Error) -> SyncError {
     }
 }
 
+/// Describe a completed transfer, including the throughput it achieved.
+///
+/// Throughput is the number that separates "the network is slow" from "grans is
+/// stuck", so it is the first thing worth seeing under `--verbose`.
+pub fn describe_throughput(bytes: u64, elapsed: Duration) -> String {
+    let secs = elapsed.as_secs_f64();
+    let mib = bytes as f64 / 1_048_576.0;
+
+    if secs <= 0.0 {
+        return format!("{:.2} MB in {:?}", mib, elapsed);
+    }
+
+    format!("{:.2} MB in {:?} ({:.2} MB/s)", mib, elapsed, mib / secs)
+}
+
 /// Fail when a transfer delivered a different number of bytes than advertised.
 ///
 /// A download cut short still produces a readable file, so without this check a
@@ -323,6 +338,22 @@ mod tests {
         let err = response.bytes().expect_err("buffering should time out");
 
         assert!(err.is_timeout(), "expected a timeout, got: {}", err);
+    }
+
+    #[test]
+    fn describe_throughput_reports_rate() {
+        let text = describe_throughput(10 * 1_048_576, Duration::from_secs(5));
+
+        assert!(text.contains("10.00 MB"), "{}", text);
+        assert!(text.contains("2.00 MB/s"), "{}", text);
+    }
+
+    #[test]
+    fn describe_throughput_survives_a_zero_duration() {
+        let text = describe_throughput(1_048_576, Duration::ZERO);
+
+        assert!(text.contains("1.00 MB"), "{}", text);
+        assert!(!text.contains("inf"), "must not divide by zero: {}", text);
     }
 
     #[test]

--- a/src/sync/transfer.rs
+++ b/src/sync/transfer.rs
@@ -1,0 +1,341 @@
+//! HTTP transport policy and byte-moving helpers for Dropbox sync.
+
+use std::io::{self, Read, Write};
+use std::time::Duration;
+
+use super::{SyncError, SyncResult};
+
+/// Buffer size for streaming transfers.
+const COPY_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Time allowed for DNS resolution plus the TCP and TLS handshakes.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Time allowed for a single step of a request.
+///
+/// reqwest's blocking client applies its timeout to the whole request, body
+/// included, and defaults to 30 seconds. That default caps *total* transfer
+/// time, so it fails any download large enough to matter regardless of how
+/// healthy the connection is. Downloads here stream the body through `Read`,
+/// which reqwest bounds per read call, so this value acts as a stall detector:
+/// it fires when the peer stops sending, not when the file is merely big.
+const STALL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Time allowed for an upload request.
+///
+/// Uploads send the entire body inside one request, so unlike the streaming
+/// download path this has to cover the whole transfer rather than a stall.
+pub const UPLOAD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Build the HTTP client used for every Dropbox call.
+pub fn build_client() -> SyncResult<reqwest::blocking::Client> {
+    build_client_with_stall_timeout(STALL_TIMEOUT)
+}
+
+/// Build a client with an explicit stall timeout, so tests can exercise the
+/// policy without waiting out the production value.
+fn build_client_with_stall_timeout(stall: Duration) -> SyncResult<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(concat!("grans/", env!("GRANS_VERSION")))
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(stall)
+        .build()
+        .map_err(|source| SyncError::Transport {
+            operation: "HTTP client setup".to_string(),
+            hint: transport_hint(&source),
+            source,
+        })
+}
+
+/// Describe a transport failure in terms the reader can act on.
+///
+/// reqwest renders a stalled body read as "error decoding response body", which
+/// reads like a parsing bug rather than a network problem.
+pub fn transport_hint(err: &reqwest::Error) -> String {
+    if err.is_timeout() {
+        format!(
+            "no data received for {}s (connection stalled or network is down)",
+            STALL_TIMEOUT.as_secs()
+        )
+    } else if err.is_connect() {
+        "could not reach Dropbox (DNS, proxy, or TLS failure)".to_string()
+    } else if err.is_body() || err.is_decode() {
+        "the connection dropped mid-transfer".to_string()
+    } else {
+        "network error".to_string()
+    }
+}
+
+/// Attach operation context to a transport failure, preserving its source chain.
+pub fn transport_error(operation: impl Into<String>, source: reqwest::Error) -> SyncError {
+    SyncError::Transport {
+        operation: operation.into(),
+        hint: transport_hint(&source),
+        source,
+    }
+}
+
+/// Stream `reader` into `writer`, invoking `on_progress` with the running total.
+///
+/// Returns the number of bytes copied.
+pub fn stream_with_progress<R: Read, W: Write>(
+    reader: &mut R,
+    writer: &mut W,
+    on_progress: &mut dyn FnMut(u64),
+) -> io::Result<u64> {
+    let mut buffer = vec![0u8; COPY_BUFFER_SIZE];
+    let mut total = 0u64;
+
+    loop {
+        let bytes_read = reader.read(&mut buffer)?;
+        if bytes_read == 0 {
+            return Ok(total);
+        }
+
+        writer.write_all(&buffer[..bytes_read])?;
+        total += bytes_read as u64;
+        on_progress(total);
+    }
+}
+
+/// Classify a streaming failure, keeping network causes distinguishable from
+/// local disk failures.
+///
+/// reqwest surfaces body-read failures as `io::Error`s wrapping its own error
+/// type, so unwrapping one restores the network diagnosis.
+pub fn stream_error(operation: impl Into<String>, err: io::Error) -> SyncError {
+    match err.downcast::<reqwest::Error>() {
+        Ok(network) => transport_error(operation, network),
+        Err(local) => SyncError::Io(local),
+    }
+}
+
+/// Fail when a transfer delivered a different number of bytes than advertised.
+///
+/// A download cut short still produces a readable file, so without this check a
+/// truncated database would quietly replace a good one.
+pub fn verify_transfer_size(actual: u64, expected: u64, what: &str) -> SyncResult<()> {
+    if actual == expected {
+        return Ok(());
+    }
+
+    Err(SyncError::IncompleteTransfer {
+        what: what.to_string(),
+        actual,
+        expected,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::thread;
+
+    /// Serve one HTTP response whose body arrives in timed pieces, standing in
+    /// for a healthy but slow connection.
+    ///
+    /// Returns the URL to request; the server thread exits after one response.
+    fn serve_slow_body(chunk: &'static [u8], chunks: usize, gap: Duration) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+
+            // Consume the request head so the client's write completes.
+            let mut request = Vec::new();
+            let mut byte = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                match stream.read(&mut byte) {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => request.push(byte[0]),
+                }
+            }
+
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/octet-stream\r\n\r\n",
+                chunk.len() * chunks
+            );
+            if stream.write_all(head.as_bytes()).is_err() {
+                return;
+            }
+
+            for _ in 0..chunks {
+                if stream.write_all(chunk).is_err() || stream.flush().is_err() {
+                    return;
+                }
+                thread::sleep(gap);
+            }
+        });
+
+        format!("http://{}/", addr)
+    }
+
+    /// Yields data in fixed-size pieces so tests exercise the short-read path
+    /// that a real network body takes.
+    struct ChunkedReader {
+        data: Vec<u8>,
+        pos: usize,
+        chunk: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(data: Vec<u8>, chunk: usize) -> Self {
+            Self {
+                data,
+                pos: 0,
+                chunk,
+            }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let n = (self.data.len() - self.pos).min(self.chunk).min(buf.len());
+            buf[..n].copy_from_slice(&self.data[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    /// Fails partway through, standing in for a connection that drops mid-transfer.
+    struct FailingReader {
+        before_error: usize,
+        sent: usize,
+    }
+
+    impl Read for FailingReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.sent >= self.before_error {
+                return Err(io::Error::new(io::ErrorKind::ConnectionReset, "reset"));
+            }
+            let n = (self.before_error - self.sent).min(buf.len());
+            buf[..n].fill(b'x');
+            self.sent += n;
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn stream_copies_all_bytes() {
+        let data: Vec<u8> = (0..10_000u32).map(|i| (i % 256) as u8).collect();
+        let mut reader = ChunkedReader::new(data.clone(), 512);
+        let mut sink = Vec::new();
+
+        let copied = stream_with_progress(&mut reader, &mut sink, &mut |_| {}).unwrap();
+
+        assert_eq!(copied, data.len() as u64);
+        assert_eq!(sink, data);
+    }
+
+    #[test]
+    fn stream_reports_monotonic_progress_ending_at_total() {
+        let data = vec![7u8; 5_000];
+        let mut reader = ChunkedReader::new(data, 300);
+        let mut sink = Vec::new();
+        let mut seen = Vec::new();
+
+        stream_with_progress(&mut reader, &mut sink, &mut |n| seen.push(n)).unwrap();
+
+        assert!(!seen.is_empty(), "progress callback was never invoked");
+        assert!(
+            seen.windows(2).all(|w| w[0] < w[1]),
+            "progress must increase: {:?}",
+            seen
+        );
+        assert_eq!(*seen.last().unwrap(), 5_000);
+    }
+
+    #[test]
+    fn stream_handles_empty_body() {
+        let mut reader = ChunkedReader::new(Vec::new(), 512);
+        let mut sink = Vec::new();
+        let mut calls = 0;
+
+        let copied = stream_with_progress(&mut reader, &mut sink, &mut |_| calls += 1).unwrap();
+
+        assert_eq!(copied, 0);
+        assert!(sink.is_empty());
+        assert_eq!(calls, 0);
+    }
+
+    #[test]
+    fn stream_propagates_read_errors() {
+        let mut reader = FailingReader {
+            before_error: 1_000,
+            sent: 0,
+        };
+        let mut sink = Vec::new();
+
+        let err = stream_with_progress(&mut reader, &mut sink, &mut |_| {}).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    #[test]
+    fn stream_error_keeps_local_io_failures_as_io() {
+        let disk_full = io::Error::new(io::ErrorKind::StorageFull, "no space left on device");
+
+        let err = stream_error("download of /grans.db", disk_full);
+
+        assert!(
+            matches!(err, SyncError::Io(_)),
+            "a disk failure must not be reported as a network problem: {}",
+            err
+        );
+    }
+
+    /// A transfer longer than the client timeout must still succeed, because the
+    /// timeout bounds each read rather than the transfer as a whole.
+    ///
+    /// Buffering the body with `Response::bytes()` instead makes the timeout a
+    /// cap on total transfer time, which is what broke `dropbox pull` on any
+    /// database too large to arrive within it.
+    #[test]
+    fn streaming_outlives_a_transfer_longer_than_the_stall_timeout() {
+        const CHUNK: &[u8] = &[b'z'; 4096];
+        let stall = Duration::from_millis(500);
+        let url = serve_slow_body(CHUNK, 10, Duration::from_millis(100));
+
+        let client = build_client_with_stall_timeout(stall).unwrap();
+        let mut response = client.get(&url).send().expect("request should succeed");
+        let mut sink = Vec::new();
+
+        let copied = stream_with_progress(&mut response, &mut sink, &mut |_| {})
+            .expect("a steady body must not time out because the transfer is long");
+
+        assert_eq!(copied, (CHUNK.len() * 10) as u64);
+        assert!(sink.iter().all(|&b| b == b'z'));
+    }
+
+    /// The same body buffered in one shot trips the timeout, pinning the bug to
+    /// the buffering strategy rather than to the network.
+    #[test]
+    fn buffering_the_whole_body_trips_the_stall_timeout() {
+        const CHUNK: &[u8] = &[b'z'; 4096];
+        let stall = Duration::from_millis(500);
+        let url = serve_slow_body(CHUNK, 10, Duration::from_millis(100));
+
+        let client = build_client_with_stall_timeout(stall).unwrap();
+        let response = client.get(&url).send().expect("request should succeed");
+
+        let err = response.bytes().expect_err("buffering should time out");
+
+        assert!(err.is_timeout(), "expected a timeout, got: {}", err);
+    }
+
+    #[test]
+    fn verify_transfer_size_accepts_exact_match() {
+        assert!(verify_transfer_size(1024, 1024, "database").is_ok());
+    }
+
+    #[test]
+    fn verify_transfer_size_rejects_truncated_transfer() {
+        let err = verify_transfer_size(512, 1024, "database").unwrap_err();
+        let msg = err.to_string();
+
+        assert!(msg.contains("512"), "message should report actual: {}", msg);
+        assert!(msg.contains("1024"), "message should report expected: {}", msg);
+    }
+}


### PR DESCRIPTION
## What was wrong

`dropbox pull` buffered the entire database through reqwest's `Response::bytes()`. The blocking client defaults to a **30-second timeout that covers the whole request, body included**, so that call capped total transfer time rather than detecting a stall. Any database too large to arrive within 30 seconds failed no matter how healthy the connection was.

reqwest reports a timed-out body read as a *decode* error, so the failure surfaced as:

```
Error: Dropbox API error: read body: error decoding response body
```

which reads like a parsing bug. The underlying `operation timed out` was discarded because the reqwest error was flattened into a string instead of kept as an error source.

The remote database here is 424 MB, so this fires on any connection slower than about 14 MB/s.

## What changed

**Streaming.** Downloads now go through `Read`, which reqwest bounds *per read call* rather than per request. The timeout becomes a stall detector, so a transfer may run as long as the connection keeps delivering data. It also keeps the database out of memory.

**Progress.** `pull` shows a bar with throughput and ETA, on a TTY only:

```
Downloading database (424.3 MB)...
[grans] 114.55 MiB/424.25 MiB [========>                     ] 27% 4.21 MiB/s, ETA 1m
```

**Transfer safety.** The download lands in a temp file and its byte count is checked against the size Dropbox reported before replacing the database. A truncated transfer can no longer overwrite a good copy.

**Uploads** get their own generous per-request timeout, since an upload sends its whole body inside one request and cannot use the stall-detector rule.

**Diagnosable errors.** reqwest errors are carried as error sources with the failing operation named, plus a plain-language hint separating a stall, an unreachable host, and a dropped connection.

**Logging.** The sync module had none, so a failing pull offered nothing to turn on. It now matches the Granola API client's convention:

```
$ grans --verbose dropbox pull
[DEBUG grans::sync::dropbox] POST https://api.dropboxapi.com/2/files/get_metadata (metadata for /grans.db)
[DEBUG grans::sync::dropbox]   response: 200 OK in 270.7261ms
[DEBUG grans::sync::dropbox] POST https://content.dropboxapi.com/2/files/download (download /grans.db)
[DEBUG grans::sync::dropbox]   response: 200 OK in 712.5304ms
[DEBUG grans::sync::dropbox]   body complete: 424.28 MB in 6.7065285s (63.26 MB/s)
```

A failed download reports how far it got, separating a mid-transfer drop from a stall that never delivered anything.

## Tests

The regression pair pins the bug to the buffering strategy rather than to the network. Both run against a local server that delivers a body in timed pieces, in under a second:

- `streaming_outlives_a_transfer_longer_than_the_stall_timeout` - a transfer longer than the timeout succeeds when streamed.
- `buffering_the_whole_body_trips_the_stall_timeout` - the same body fails when buffered, which is what the old code did.

Plus unit coverage for the copy loop (short reads, empty body, error propagation, monotonic progress), the size check, throughput formatting, and the rule that a local disk failure is not reported as a network problem.

910 tests pass across all targets.

## Verified against real Dropbox

A full 424 MB pull into a scratch data dir (`XDG_DATA_HOME`, so the real database was untouched) completed in 6.7s at 63 MB/s, and `dropbox status` output is unchanged.

## Last commit is separable

`commands/sync.rs` had grown past 800 lines holding both the transfer commands and the status table. The table moves to `commands/sync_status.rs`, and the `format_size` that existed identically in two modules is now one copy in `output::format`. No behaviour change; drop that commit if you'd rather keep this PR to the fix.

No screenshots: the progress bar and log output are plain text, fully conveyed by the code blocks above.