### PR TITLE
Report post-merge platform test failures as an issue

### DIFF
--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -64,3 +64,53 @@ jobs:
 
       - name: Run tests
         run: cargo test --no-fail-fast
+
+  # These runs sit off the critical path: nothing blocks on them and no PR shows
+  # their result, so the only signal a failure otherwise gives is an email to
+  # whoever happened to trigger the run. That is indistinguishable from silence,
+  # and for the weekly cron it is worse, since GitHub attributes those runs to
+  # the repository rather than to an author. So file the failure where the work
+  # is actually tracked.
+  #
+  # Skipped on pull_request: a change to this workflow already shows its own red
+  # X on the PR that made it, and filing an issue for that would be noise.
+  report-failure:
+    name: Report failure
+    needs: full-suite
+    if: failure() && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: File or update the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TRIGGER: ${{ github.event_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          body="The full suite failed on \`${GITHUB_REF_NAME}\` at \`${SHA:0:8}\` (\`${TRIGGER}\`).
+
+          ${RUN_URL}
+
+          ci.yml runs the integration suites on ubuntu only, so a failure here
+          that the PR did not catch is most likely macOS- or Windows-specific."
+
+          # One open issue per outage, not one per run: a cron that fails every
+          # Monday should grow a comment thread rather than a pile of duplicates.
+          existing=$(gh issue list --repo "$REPO" --state open \
+            --label 'ci: platform-tests' --limit 1 --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+            echo "Commented on existing issue #${existing}"
+          else
+            gh issue create --repo "$REPO" \
+              --title "Platform tests are failing on ${GITHUB_REF_NAME}" \
+              --label 'ci: platform-tests' --label 'type: bug' --label 'status: triage' \
+              --body "$body"
+          fi


### PR DESCRIPTION
Follow-up to #95, which added `platform-tests.yml`.

## The gap

Those runs sit off the critical path. Nothing blocks on them, no PR shows their result, and the only signal a failure gave was GitHub's Actions email to whoever happened to trigger the run. That is indistinguishable from silence, so a broken `main` would sit broken until someone thought to open the Actions tab.

The weekly cron is worse. GitHub attributes scheduled runs to the repository rather than to an author, and it disables scheduled workflows outright after 60 days of repository inactivity, so "no failure mail" and "the run no longer exists" look identical.

## The fix

A `report-failure` job files the failure as `type: bug` + `status: triage`, which puts it in the queue that actually gets read rather than an inbox. It dedupes on an open `ci: platform-tests` issue and comments on that instead, so a cron failing every Monday grows a thread rather than a pile of duplicates.

Skipped on `pull_request`, where a change to this workflow already shows its own red X and an issue would just be noise.

The `ci: platform-tests` label is already created. Its prefix sits outside the four groups `enforce-exclusive-labels.yml` manages (`type:`, `status:`, `prio:`, `size:`), so it does not get stripped, and `type: bug` + `status: triage` belong to different groups so they coexist.

## Verified end to end

An untested failure handler has the same problem as the thing it replaces, so both paths were exercised with a temporary forced-failure commit and `workflow_dispatch` against this branch (the `pull_request` trigger deliberately will not run this job). That commit is not in this PR.

**Create path** — [#98](https://github.com/dmwyatt/granz/issues/98) filed with all three labels intact, body rendering correctly:

```
The full suite failed on `chore/platform-tests-failure-issue` at `d5dc3c87` (`workflow_dispatch`).

https://github.com/dmwyatt/granz/actions/runs/30213881555

ci.yml runs the integration suites on ubuntu only, so a failure here
that the PR did not catch is most likely macOS- or Windows-specific.
```

Worth checking, because the body is built inside a YAML block scalar: had the indentation not dedented cleanly, the continuation lines would have rendered as a markdown code block.

**Dedupe path** — a second dispatch left exactly one open marker issue and added a comment to #98. #98 is closed; it was a test artifact.

Both dispatches also confirmed macOS and Windows pass the full suite, which is the post-merge coverage from #95 doing its job.

https://claude.ai/code/session_012c8WU6fhQDaVekXJX5hGhH
