### PR TITLE
Show progress for Dropbox uploads, and verify what got stored

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,14 +540,19 @@ Embeddings:                 52.8K               51.2K
 
 This helps you see at a glance whether your local database is ahead of or behind the remote copy, without downloading the full database.
 
-**Transfer progress:** `pull` streams the database to disk and shows a progress bar with throughput and an ETA. Databases with embeddings run to hundreds of megabytes, so a pull can take a while on a slow connection:
+**Transfer progress:** `push` and `pull` both stream the database and show a progress bar with throughput and an ETA. Databases with embeddings run to hundreds of megabytes, so either can take a while on a slow connection:
 
 ```
 Downloading database (424.3 MB)...
 [grans] 114.55 MiB/424.25 MiB [========>                     ] 27% 4.21 MiB/s, ETA 1m
 ```
 
-The bar is written to stderr and is skipped when output is redirected.
+```
+Uploading database (428.9 MB)...
+[grans] 96.00 MiB/428.90 MiB [======>                       ] 22% 3.80 MiB/s, ETA 1m
+```
+
+The bar is written to stderr and is skipped when output is redirected. Uploads above 150 MB are sent as chunked sessions, so the bar advances 8 MB at a time; smaller ones stream in a single request and advance smoothly.
 
 **Conflict handling:** Sync refuses to overwrite newer files by default. Use `--force` to override:
 

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -21,7 +21,7 @@ use crate::sync::oauth::{
 use crate::db::integrity::check_pulled_database;
 use crate::output::progress::create_spinner;
 use crate::sync::content_hash::HashingWriter;
-use crate::sync::transfer::{verify_content_hash, verify_transfer_size};
+use crate::sync::transfer::{no_progress, verify_content_hash, verify_transfer_size, ProgressFn};
 use crate::sync::SyncError;
 
 /// Remote paths on Dropbox (within app folder)
@@ -143,7 +143,8 @@ fn upload_metadata(client: &DropboxClient, metadata: &SyncMetadata) -> Result<()
     std::fs::write(&temp_path, &json)?;
 
     println!("Uploading sync metadata...");
-    client.upload(&temp_path, REMOTE_METADATA_PATH)?;
+    // A few hundred bytes: a progress bar would flash and vanish.
+    client.upload(&temp_path, REMOTE_METADATA_PATH, no_progress())?;
 
     // Clean up temp file
     let _ = std::fs::remove_file(&temp_path);
@@ -161,29 +162,26 @@ fn push_file(
     let local_mtime = get_file_mtime(local_path)?;
 
     // Check remote file
-    if !force {
-        if let Some(remote) = client.get_metadata(remote_path)? {
-            if let Some(remote_mtime) = parse_dropbox_time(&remote.server_modified) {
-                if remote_mtime > local_mtime {
-                    return Err(SyncError::ConflictRemoteNewer {
-                        what: name.to_string(),
-                        remote_time: format_timestamp(remote_mtime),
-                        local_time: format_timestamp(local_mtime),
-                    }
-                    .into());
-                }
-            }
+    if !force
+        && let Some(remote) = client.get_metadata(remote_path)?
+        && let Some(remote_mtime) = parse_dropbox_time(&remote.server_modified)
+        && remote_mtime > local_mtime
+    {
+        return Err(SyncError::ConflictRemoteNewer {
+            what: name.to_string(),
+            remote_time: format_timestamp(remote_mtime),
+            local_time: format_timestamp(local_mtime),
         }
+        .into());
     }
 
     let size = std::fs::metadata(local_path)?.len();
-    println!(
-        "Uploading {} ({:.2} MB)...",
-        name,
-        size as f64 / 1_048_576.0
-    );
+    println!("Uploading {} ({})...", name, format_size(size));
 
-    client.upload(local_path, remote_path)?;
+    let progress = TransferProgress::new(size);
+    client.upload(local_path, remote_path, progress.reporter())?;
+    drop(progress);
+
     println!("  Uploaded to {}", remote_path);
 
     Ok(())
@@ -342,7 +340,7 @@ fn stream_to_file(
     temp_path: &Path,
     expected_size: u64,
 ) -> Result<(u64, String)> {
-    let progress = DownloadProgress::new(expected_size);
+    let progress = TransferProgress::new(expected_size);
 
     let file = std::fs::File::create(temp_path)?;
     let mut writer = HashingWriter::new(BufWriter::new(file));
@@ -362,12 +360,13 @@ fn stream_to_file(
     Ok((written, actual_hash))
 }
 
-/// Byte-count progress bar, shown only when stderr is a terminal.
-struct DownloadProgress {
+/// Byte-count progress bar for a transfer in either direction, shown only when
+/// stderr is a terminal.
+struct TransferProgress {
     bar: Option<ProgressBar>,
 }
 
-impl DownloadProgress {
+impl TransferProgress {
     fn new(total: u64) -> Self {
         if !io::stderr().is_terminal() {
             return Self { bar: None };
@@ -390,11 +389,25 @@ impl DownloadProgress {
             pb.set_position(bytes);
         }
     }
+
+    /// An owned reporter for callers that hand progress off to the transport.
+    ///
+    /// The handle is a cheap clone of the same bar, so updates through it land
+    /// on the bar this value still controls and clears.
+    fn reporter(&self) -> ProgressFn {
+        match self.bar {
+            Some(ref pb) => {
+                let handle = pb.clone();
+                Box::new(move |bytes| handle.set_position(bytes))
+            }
+            None => no_progress(),
+        }
+    }
 }
 
-/// Clear the bar however the download ends, so a failure message is not printed
+/// Clear the bar however the transfer ends, so a failure message is not printed
 /// underneath a stale progress line.
-impl Drop for DownloadProgress {
+impl Drop for TransferProgress {
     fn drop(&mut self) {
         if let Some(ref pb) = self.bar {
             pb.finish_and_clear();

--- a/src/sync/content_hash.rs
+++ b/src/sync/content_hash.rs
@@ -7,12 +7,33 @@
 //! into 4 MiB blocks, SHA-256 each block, concatenate those digests in order,
 //! and SHA-256 the result.
 
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
+use std::path::Path;
 
 use sha2::{Digest, Sha256};
 
 /// Dropbox hashes the file in 4 MiB blocks.
 const BLOCK_SIZE: usize = 4 * 1024 * 1024;
+
+/// Compute the Dropbox content hash of a file on disk.
+///
+/// Reads the file in its own pass rather than hashing during the upload, which
+/// would mean threading a shared hasher through a request body that reqwest
+/// owns. The extra read costs a second or so against a transfer measured in
+/// minutes.
+pub fn hash_file(path: &Path) -> io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = ContentHasher::new();
+    let mut buffer = vec![0u8; BLOCK_SIZE];
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            return Ok(hasher.finish());
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+}
 
 /// Computes a Dropbox content hash incrementally.
 ///
@@ -180,6 +201,33 @@ mod tests {
                 piece
             );
         }
+    }
+
+    /// Hashing a file must agree with hashing the same bytes in memory, so an
+    /// upload check compares like with like.
+    #[test]
+    fn hash_file_matches_the_in_memory_hash() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("payload.bin");
+        let data = vec![b'b'; BLOCK_SIZE + 1];
+        std::fs::write(&path, &data).unwrap();
+
+        assert_eq!(hash_file(&path).unwrap(), ONE_BLOCK_PLUS_ONE);
+        assert_eq!(hash_file(&path).unwrap(), hash_all(&data));
+    }
+
+    #[test]
+    fn hash_file_handles_an_empty_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("empty.bin");
+        std::fs::write(&path, b"").unwrap();
+
+        assert_eq!(hash_file(&path).unwrap(), EMPTY);
+    }
+
+    #[test]
+    fn hash_file_reports_a_missing_file() {
+        assert!(hash_file(Path::new("no/such/file.bin")).is_err());
     }
 
     #[test]

--- a/src/sync/dropbox.rs
+++ b/src/sync/dropbox.rs
@@ -9,6 +9,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::time::Instant;
 
+use super::content_hash;
 use super::transfer::{self, ProgressFn, ProgressReader, UPLOAD_TIMEOUT};
 use super::{SyncError, SyncResult};
 
@@ -100,24 +101,36 @@ impl DropboxClient {
         on_progress: ProgressFn,
     ) -> SyncResult<FileMetadata> {
         let file_size = std::fs::metadata(local_path)?.len();
+        let local_hash = content_hash::hash_file(local_path)?;
         let start = Instant::now();
 
-        let result = if file_size <= UPLOAD_SINGLE_LIMIT {
+        let uploaded = if file_size <= UPLOAD_SINGLE_LIMIT {
             debug!("upload {} ({} bytes, single request)", dropbox_path, file_size);
             self.upload_single(local_path, dropbox_path, file_size, on_progress)
         } else {
             debug!("upload {} ({} bytes, chunked session)", dropbox_path, file_size);
             self.upload_chunked(local_path, dropbox_path, file_size, on_progress)
-        };
+        }?;
 
-        if result.is_ok() {
-            debug!(
-                "  upload complete: {}",
-                transfer::describe_throughput(file_size, start.elapsed())
-            );
-        }
+        debug!(
+            "  upload complete: {}",
+            transfer::describe_throughput(file_size, start.elapsed())
+        );
 
-        result
+        // Dropbox reports what it stored, so an upload can prove it arrived
+        // intact instead of leaving a corrupt backup to be discovered on the
+        // next pull.
+        let stored_hash =
+            uploaded
+                .content_hash
+                .as_deref()
+                .ok_or_else(|| SyncError::MissingContentHash {
+                    path: dropbox_path.to_string(),
+                })?;
+        transfer::verify_content_hash(stored_hash, &local_hash, "uploaded file")?;
+        debug!("  content hash verified: {}", local_hash);
+
+        Ok(uploaded)
     }
 
     /// Upload a file in a single request (for files <= 150 MB).

--- a/src/sync/dropbox.rs
+++ b/src/sync/dropbox.rs
@@ -9,7 +9,7 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::time::Instant;
 
-use super::transfer::{self, UPLOAD_TIMEOUT};
+use super::transfer::{self, ProgressFn, ProgressReader, UPLOAD_TIMEOUT};
 use super::{SyncError, SyncResult};
 
 const UPLOAD_URL: &str = "https://content.dropboxapi.com/2/files/upload";
@@ -93,16 +93,21 @@ impl DropboxClient {
     ///
     /// The `dropbox_path` should be like `/index.db` (within the app folder).
     /// Files over 150 MB are automatically uploaded using chunked upload sessions.
-    pub fn upload(&self, local_path: &Path, dropbox_path: &str) -> SyncResult<FileMetadata> {
+    pub fn upload(
+        &self,
+        local_path: &Path,
+        dropbox_path: &str,
+        on_progress: ProgressFn,
+    ) -> SyncResult<FileMetadata> {
         let file_size = std::fs::metadata(local_path)?.len();
         let start = Instant::now();
 
         let result = if file_size <= UPLOAD_SINGLE_LIMIT {
             debug!("upload {} ({} bytes, single request)", dropbox_path, file_size);
-            self.upload_single(local_path, dropbox_path)
+            self.upload_single(local_path, dropbox_path, file_size, on_progress)
         } else {
             debug!("upload {} ({} bytes, chunked session)", dropbox_path, file_size);
-            self.upload_chunked(local_path, dropbox_path, file_size)
+            self.upload_chunked(local_path, dropbox_path, file_size, on_progress)
         };
 
         if result.is_ok() {
@@ -116,9 +121,13 @@ impl DropboxClient {
     }
 
     /// Upload a file in a single request (for files <= 150 MB).
-    fn upload_single(&self, local_path: &Path, dropbox_path: &str) -> SyncResult<FileMetadata> {
-        let content = std::fs::read(local_path)?;
-
+    fn upload_single(
+        &self,
+        local_path: &Path,
+        dropbox_path: &str,
+        file_size: u64,
+        on_progress: ProgressFn,
+    ) -> SyncResult<FileMetadata> {
         let arg = UploadArg {
             path: dropbox_path.to_string(),
             mode: "overwrite".to_string(),
@@ -128,6 +137,12 @@ impl DropboxClient {
 
         let arg_json = serialize_arg(&arg)?;
 
+        // Stream from the file rather than reading it in: this keeps up to
+        // 150 MB out of memory and lets reqwest's pull of the body drive the
+        // progress report.
+        let file = std::fs::File::open(local_path)?;
+        let body = reqwest::blocking::Body::sized(ProgressReader::new(file, on_progress), file_size);
+
         let response = self
             .http
             .post(UPLOAD_URL)
@@ -135,7 +150,7 @@ impl DropboxClient {
             .header("Dropbox-API-Arg", arg_json)
             .header("Content-Type", "application/octet-stream")
             .timeout(UPLOAD_TIMEOUT)
-            .body(content)
+            .body(body)
             .send()
             .map_err(|e| transfer::transport_error(format!("upload of {}", dropbox_path), e))?;
 
@@ -148,6 +163,7 @@ impl DropboxClient {
         local_path: &Path,
         dropbox_path: &str,
         file_size: u64,
+        mut on_progress: ProgressFn,
     ) -> SyncResult<FileMetadata> {
         let mut file = std::fs::File::open(local_path)?;
         let mut buf = vec![0u8; UPLOAD_CHUNK_SIZE];
@@ -157,6 +173,7 @@ impl DropboxClient {
         let bytes_read = file.read(&mut buf).map_err(SyncError::Io)?;
         let session_id = self.upload_session_start(&buf[..bytes_read])?;
         offset += bytes_read as u64;
+        on_progress(offset);
 
         // Append: send middle chunks
         while offset < file_size {
@@ -166,22 +183,9 @@ impl DropboxClient {
             }
 
             let remaining = file_size - offset - bytes_read as u64;
-            if remaining > 0 {
-                // More data to come — append
-                self.upload_session_append(&session_id, offset, &buf[..bytes_read])?;
-                offset += bytes_read as u64;
-                eprint!(
-                    "\r  Uploaded {:.0} / {:.0} MB",
-                    offset as f64 / 1_048_576.0,
-                    file_size as f64 / 1_048_576.0,
-                );
-            } else {
-                // Last chunk — finish
-                eprint!(
-                    "\r  Uploaded {:.0} / {:.0} MB\n",
-                    file_size as f64 / 1_048_576.0,
-                    file_size as f64 / 1_048_576.0,
-                );
+            if remaining == 0 {
+                // Last chunk — commit the session
+                on_progress(file_size);
                 return self.upload_session_finish(
                     &session_id,
                     offset,
@@ -189,14 +193,14 @@ impl DropboxClient {
                     dropbox_path,
                 );
             }
+
+            self.upload_session_append(&session_id, offset, &buf[..bytes_read])?;
+            offset += bytes_read as u64;
+            on_progress(offset);
         }
 
         // Edge case: file size was an exact multiple of chunk size, finish with empty body
-        eprint!(
-            "\r  Uploaded {:.0} / {:.0} MB\n",
-            file_size as f64 / 1_048_576.0,
-            file_size as f64 / 1_048_576.0,
-        );
+        on_progress(file_size);
         self.upload_session_finish(&session_id, offset, &[], dropbox_path)
     }
 

--- a/src/sync/transfer.rs
+++ b/src/sync/transfer.rs
@@ -27,6 +27,52 @@ const STALL_TIMEOUT: Duration = Duration::from_secs(60);
 /// download path this has to cover the whole transfer rather than a stall.
 pub const UPLOAD_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 
+/// Reports the running byte total of a transfer.
+///
+/// Owned and `Send` rather than borrowed, because a streaming upload body has
+/// to satisfy reqwest's `Send + 'static` bound.
+pub type ProgressFn = Box<dyn FnMut(u64) + Send>;
+
+/// A progress sink that reports nothing, for transfers too small to bother.
+pub fn no_progress() -> ProgressFn {
+    Box::new(|_| {})
+}
+
+/// Wraps a reader, reporting the running total as bytes are consumed.
+///
+/// Lets an upload report progress while reqwest pulls the request body, without
+/// first loading the file into memory.
+pub struct ProgressReader<R> {
+    inner: R,
+    transferred: u64,
+    on_progress: ProgressFn,
+}
+
+impl<R: Read> ProgressReader<R> {
+    pub fn new(inner: R, on_progress: ProgressFn) -> Self {
+        Self {
+            inner,
+            transferred: 0,
+            on_progress,
+        }
+    }
+}
+
+impl<R: Read> Read for ProgressReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let bytes_read = self.inner.read(buf)?;
+
+        // Staying silent at end of stream keeps the final total from being
+        // reported twice.
+        if bytes_read > 0 {
+            self.transferred += bytes_read as u64;
+            (self.on_progress)(self.transferred);
+        }
+
+        Ok(bytes_read)
+    }
+}
+
 /// Build the HTTP client used for every Dropbox call.
 pub fn build_client() -> SyncResult<reqwest::blocking::Client> {
     build_client_with_stall_timeout(STALL_TIMEOUT)
@@ -161,6 +207,7 @@ pub fn verify_transfer_size(actual: u64, expected: u64, what: &str) -> SyncResul
 mod tests {
     use super::*;
     use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
     use std::thread;
 
     /// Serve one HTTP response whose body arrives in timed pieces, standing in
@@ -370,6 +417,135 @@ mod tests {
 
         assert!(text.contains("1.00 MB"), "{}", text);
         assert!(!text.contains("inf"), "must not divide by zero: {}", text);
+    }
+
+    /// Collect what a `ProgressFn` was told, from outside the box it lives in.
+    fn recording_progress() -> (ProgressFn, Arc<Mutex<Vec<u64>>>) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        (Box::new(move |n| sink.lock().unwrap().push(n)), seen)
+    }
+
+    #[test]
+    fn progress_reader_passes_bytes_through_unchanged() {
+        let data: Vec<u8> = (0..5000u32).map(|i| (i % 256) as u8).collect();
+        let (progress, _seen) = recording_progress();
+        let mut reader = ProgressReader::new(ChunkedReader::new(data.clone(), 256), progress);
+
+        let mut got = Vec::new();
+        reader.read_to_end(&mut got).unwrap();
+
+        assert_eq!(got, data);
+    }
+
+    #[test]
+    fn progress_reader_reports_a_running_total_ending_at_the_length() {
+        let (progress, seen) = recording_progress();
+        let mut reader = ProgressReader::new(ChunkedReader::new(vec![9u8; 4096], 512), progress);
+
+        io::copy(&mut reader, &mut io::sink()).unwrap();
+
+        let seen = seen.lock().unwrap();
+        assert!(!seen.is_empty(), "progress was never reported");
+        assert!(
+            seen.windows(2).all(|w| w[0] < w[1]),
+            "totals must increase: {:?}",
+            seen
+        );
+        assert_eq!(*seen.last().unwrap(), 4096);
+    }
+
+    #[test]
+    fn progress_reader_stays_quiet_on_an_empty_source() {
+        let (progress, seen) = recording_progress();
+        let mut reader = ProgressReader::new(ChunkedReader::new(Vec::new(), 512), progress);
+
+        io::copy(&mut reader, &mut io::sink()).unwrap();
+
+        assert!(seen.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn progress_reader_propagates_read_errors() {
+        let (progress, _seen) = recording_progress();
+        let mut reader = ProgressReader::new(
+            FailingReader {
+                before_error: 512,
+                sent: 0,
+            },
+            progress,
+        );
+
+        let err = io::copy(&mut reader, &mut io::sink()).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
+    }
+
+    /// Accept one request, return how many body bytes actually arrived.
+    ///
+    /// Returns the URL and a handle yielding the received body length.
+    fn accept_one_upload() -> (String, thread::JoinHandle<usize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+
+            let mut head = Vec::new();
+            let mut byte = [0u8; 1];
+            while !head.ends_with(b"\r\n\r\n") {
+                if stream.read(&mut byte).unwrap_or(0) == 0 {
+                    return 0;
+                }
+                head.push(byte[0]);
+            }
+
+            let head = String::from_utf8_lossy(&head).to_lowercase();
+            let declared: usize = head
+                .split("content-length:")
+                .nth(1)
+                .and_then(|rest| rest.split("\r\n").next())
+                .and_then(|v| v.trim().parse().ok())
+                .expect("upload must declare a Content-Length");
+
+            let mut body = vec![0u8; declared];
+            stream.read_exact(&mut body).expect("read body");
+
+            let _ = stream.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: application/json\r\n\r\n{}",
+            );
+            body.len()
+        });
+
+        (format!("http://{}/", addr), handle)
+    }
+
+    /// A streamed upload body must deliver every byte and report progress as it
+    /// goes, which is what lets `dropbox push` show a bar without first reading
+    /// the whole file into memory.
+    #[test]
+    fn a_streamed_upload_body_delivers_every_byte_and_reports_progress() {
+        const LEN: usize = 300_000;
+        let (url, server) = accept_one_upload();
+        let (progress, seen) = recording_progress();
+
+        let client = build_client().unwrap();
+        let body = reqwest::blocking::Body::sized(
+            ProgressReader::new(io::Cursor::new(vec![7u8; LEN]), progress),
+            LEN as u64,
+        );
+
+        let response = client.post(&url).body(body).send().expect("upload");
+        assert!(response.status().is_success());
+
+        assert_eq!(server.join().unwrap(), LEN, "server received a short body");
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(
+            *seen.last().expect("progress was never reported"),
+            LEN as u64
+        );
+        assert!(seen.windows(2).all(|w| w[0] < w[1]), "{:?}", seen);
     }
 
     #[test]


### PR DESCRIPTION
`push` reported almost nothing while sending hundreds of megabytes.

- Files over 150 MB printed a bare carriage-return counter from inside the API client, unconditionally, so redirecting output filled the log with rewrite sequences.
- Files under 150 MB printed nothing at all, and were read fully into memory before sending.

## Progress

Uploads now report through a callback the command layer owns, so the client no longer draws UI. The bar, its terminal check, and its cleanup are shared with `pull`:

```
Uploading database (428.9 MB)...
[grans] 96.00 MiB/428.90 MiB [======>                       ] 22% 3.80 MiB/s, ETA 1m
```

Single-request uploads stream from the file through a sized reqwest body instead of `std::fs::read`, which keeps up to 150 MB out of memory and lets reqwest's pull of the body drive the report. The callback is owned and `Send` because a streaming body has to satisfy reqwest's `'static` bound.

Chunked uploads now also report their first chunk, which the old counter skipped: the display used to begin at 8 MB.

## Verification

A pull checked the file it received; a push assumed the bytes arrived. A corrupt upload would sit in Dropbox looking healthy until someone pulled it, which is the worst possible time to learn a backup is bad.

Dropbox returns a `content_hash` for the file it committed, so the upload response already carries the proof. Comparing it against a hash of the local file makes a bad push fail immediately, while the good copy is still on disk. This is the counterpart to the pull-side check added in #96.

## On the chunked path

`upload_chunked` is the path a real database takes, and this PR edits its control flow, so it is worth being explicit that the restructure is an identity transformation:

```rust
// before
if remaining > 0 { append; offset += n; eprint } else { eprint; return finish(..) }

// after
if remaining == 0 { on_progress(file_size); return finish(..) }
append; offset += n; on_progress(offset);
```

The old `else` already returned, so inverting the condition and dropping the nesting changes nothing about which requests are sent or in what order. Everything else added is a progress call.

## Tests

935 pass across all targets. New coverage:

- `a_streamed_upload_body_delivers_every_byte_and_reports_progress` runs a real request through `build_client()` against a local HTTP server, asserting the server received exactly the declared `Content-Length` and that progress ended at the full size. This is what proves a streamed body is not truncated.
- `ProgressReader` unit tests: pass-through fidelity, monotonic totals ending at the length, silence on an empty source, error propagation.
- `hash_file` tests, including agreement with the in-memory hasher on a block-boundary-spanning file.

`upload_chunked`'s session state machine still has no automated coverage, because the Dropbox URLs are `const` and cannot be pointed at a fake server. Making them injectable would allow testing offsets, session lifecycle, and the exact-multiple-of-8MB edge case; that is a follow-up rather than something this PR takes on.

No screenshots: the progress bar is plain text and fully conveyed by the block above.