### PR TITLE
#100: Stop the macOS keychain challenging reads for anyone who signed in earlier

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -57,9 +57,9 @@ pub fn resolve_token(override_token: Option<&str>) -> Result<String> {
 /// Use grans's own credentials if it has any, otherwise whatever this platform
 /// can fall back to.
 fn stored_or_local_token() -> Result<String> {
-    let store = CredentialStore::open()?;
+    let (store, stored) = CredentialStore::open()?;
 
-    match store.load()? {
+    match stored {
         Some(credentials) => {
             debug!("Using grans's own stored credentials");
             token_from_credentials(credentials, &store)

--- a/src/api/credential_store.rs
+++ b/src/api/credential_store.rs
@@ -40,16 +40,33 @@ pub enum CredentialStore {
 }
 
 impl CredentialStore {
-    /// Open the best available store, moving file-stored credentials into the
-    /// keychain the first time one is available.
-    pub fn open() -> Result<Self> {
-        let store = match reachable_keychain() {
-            Some(entry) => Self::Keychain(Box::new(entry)),
-            None => Self::File(credentials_path()?),
+    /// Open the best available store, and hand back the credentials it already
+    /// had to read to do so.
+    ///
+    /// Deciding whether a keychain is usable means reading from it, and on
+    /// macOS every read is its own authorization. Returning that read rather
+    /// than leaving the caller to repeat it is the difference between one
+    /// password prompt per command and two.
+    ///
+    /// A caller that needs to see a write another process made since must ask
+    /// for it with [`Self::load`], which always reads.
+    pub fn open() -> Result<(Self, Option<GranolaCredentials>)> {
+        let Some((entry, stored)) = reachable_keychain() else {
+            let path = credentials_path()?;
+            let stored = read_file(&path)?;
+            return Ok((Self::File(path), stored));
         };
 
-        store.absorb_credentials_file()?;
-        Ok(store)
+        let store = Self::Keychain(Box::new(entry));
+        let in_keychain = stored.as_deref().map(parse_credentials).transpose()?;
+
+        // The fallback file is only ever written by a run that found no
+        // keychain at all, so where both exist the file is the later of the
+        // two and wins.
+        Ok(match store.absorb_credentials_file()? {
+            Some(absorbed) => (store, Some(absorbed)),
+            None => (store, in_keychain),
+        })
     }
 
     /// A store backed by a specific file. Used for the fallback and by tests.
@@ -57,16 +74,18 @@ impl CredentialStore {
         Self::File(path)
     }
 
+    /// Read the credentials, going to the store every time.
+    ///
+    /// [`Self::open`] already returns what it read, so a command that wants
+    /// the credentials once should take them from there; this is for a caller
+    /// that specifically needs to see what is stored *now*.
     pub fn load(&self) -> Result<Option<GranolaCredentials>> {
         match self {
             Self::File(path) => read_file(path),
-            Self::Keychain(entry) => match entry.get_password() {
-                Ok(json) => serde_json::from_str(&json)
-                    .map(Some)
-                    .context("Failed to parse credentials from the keychain"),
-                Err(keyring::Error::NoEntry) => Ok(None),
-                Err(e) => Err(e).context("Failed to read credentials from the keychain"),
-            },
+            Self::Keychain(entry) => read_keychain(entry)?
+                .as_deref()
+                .map(parse_credentials)
+                .transpose(),
         }
     }
 
@@ -104,44 +123,64 @@ impl CredentialStore {
         }
     }
 
-    /// Move credentials out of the fallback file once a keychain is available.
+    /// Move credentials out of the fallback file once a keychain is available,
+    /// returning whatever was moved.
     ///
     /// The file is removed only after the keychain write succeeds, so a
     /// failure here leaves the existing credentials usable.
-    fn absorb_credentials_file(&self) -> Result<()> {
+    fn absorb_credentials_file(&self) -> Result<Option<GranolaCredentials>> {
         let Self::Keychain(_) = self else {
-            return Ok(());
+            return Ok(None);
         };
 
         let path = credentials_path()?;
         let Some(credentials) = read_file(&path)? else {
-            return Ok(());
+            return Ok(None);
         };
 
         debug!("Moving credentials from {} into the keychain", path.display());
         self.save(&credentials)?;
-        delete_file(&path)
+        delete_file(&path)?;
+
+        Ok(Some(credentials))
     }
 }
 
-/// The keychain, if one can actually be read from.
+/// The keychain, if one can actually be read from, and what that read found.
 ///
 /// Constructing an entry is not proof: a Linux box with no Secret Service, or
 /// a locked keychain, fails only when read. So this reads, and treats "no such
-/// entry" as a working keychain that is simply empty.
-fn reachable_keychain() -> Option<keyring::Entry> {
+/// entry" as a working keychain that is simply empty. What it read is handed
+/// back rather than discarded; see [`CredentialStore::open`].
+fn reachable_keychain() -> Option<(keyring::Entry, Option<String>)> {
     let entry = keyring::Entry::new(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
         .inspect_err(|e| debug!("No keychain available: {}", e))
         .ok()?;
 
-    match entry.get_password() {
-        Ok(_) | Err(keyring::Error::NoEntry) => Some(entry),
+    match read_keychain(&entry) {
+        Ok(stored) => Some((entry, stored)),
         Err(e) => {
-            debug!("Keychain present but unreadable: {}", e);
+            debug!("Keychain present but unreadable: {:#}", e);
             None
         }
     }
 }
+
+/// Read the stored secret verbatim, or `None` if the keychain holds none.
+fn read_keychain(entry: &keyring::Entry) -> Result<Option<String>> {
+    match entry.get_password() {
+        Ok(json) => Ok(Some(json)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(e).context("Failed to read credentials from the keychain"),
+    }
+}
+
+/// Parse what the keychain hands back, which is JSON rather than the TOML the
+/// file backend writes.
+fn parse_credentials(json: &str) -> Result<GranolaCredentials> {
+    serde_json::from_str(json).context("Failed to parse credentials from the keychain")
+}
+
 
 /// Write the secret so the next build of grans can still read it.
 ///

--- a/src/api/credential_store.rs
+++ b/src/api/credential_store.rs
@@ -10,7 +10,10 @@
 //! On macOS the stored item is given a permissive ACL, which lets any process
 //! running as the user read it without a keychain prompt. That is a real
 //! concession, and [`super::keychain_acl`] explains why the alternative is
-//! being challenged for a password on every single read.
+//! being challenged for a password on every single read. Opening the store
+//! also repairs an item an older grans left without one, since a signed-in
+//! user can otherwise go indefinitely without writing anything for the fix to
+//! attach to.
 
 use std::fs;
 use std::io::Write;
@@ -18,6 +21,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use log::debug;
+#[cfg(target_os = "macos")]
+use log::warn;
 
 use super::credentials::GranolaCredentials;
 #[cfg(target_os = "macos")]
@@ -56,6 +61,12 @@ impl CredentialStore {
             let stored = read_file(&path)?;
             return Ok((Self::File(path), stored));
         };
+
+        // Before parsing, because the repair writes back the bytes that are
+        // there rather than a re-serialization of them.
+        if let Some(json) = &stored {
+            open_up_pinned_item(json);
+        }
 
         let store = Self::Keychain(Box::new(entry));
         let in_keychain = stored.as_deref().map(parse_credentials).transpose()?;
@@ -180,6 +191,27 @@ fn read_keychain(entry: &keyring::Entry) -> Result<Option<String>> {
 fn parse_credentials(json: &str) -> Result<GranolaCredentials> {
     serde_json::from_str(json).context("Failed to parse credentials from the keychain")
 }
+
+/// Give an entry written by an older grans the permissive ACL, so that reads
+/// from this build stop being challenged.
+///
+/// Failure is reported and stepped over rather than propagated. The credential
+/// has already been read by the time this runs, so the command can do its job
+/// either way, and the cost of not repairing is the prompt the user was
+/// getting anyway. Breaking `grans sync` over a keychain entry that is merely
+/// inconvenient would be the worse trade.
+#[cfg(target_os = "macos")]
+fn open_up_pinned_item(json: &str) {
+    match keychain_acl::open_up_existing(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, json.as_bytes()) {
+        Ok(true) => debug!("Reset the keychain entry's ACL; later reads will not be challenged"),
+        Ok(false) => {}
+        Err(e) => warn!("Could not stop the keychain challenging every read: {:#}", e),
+    }
+}
+
+/// Nothing to do: no other platform ties reads to the caller's code signature.
+#[cfg(not(target_os = "macos"))]
+fn open_up_pinned_item(_json: &str) {}
 
 
 /// Write the secret so the next build of grans can still read it.

--- a/src/api/keychain_acl/mod.rs
+++ b/src/api/keychain_acl/mod.rs
@@ -28,8 +28,22 @@
 //!
 //! Creating the item with its access already attached needs no such
 //! authorization, so [`store_with_open_access`] deletes whatever is there and
-//! writes a new item rather than amending one. That also upgrades an entry left
-//! by an older grans, without the prompt an amend would have cost.
+//! writes a new item rather than amending one.
+//!
+//! # Why the read path has to check too
+//!
+//! Writing covers an item this build wrote, but grans mostly reads: a user
+//! whose stored access token is still valid goes a whole command without
+//! writing anything. An entry left by a grans from before any of this existed
+//! is still pinned to whatever build wrote it, is still challenged on every
+//! read, and no amount of writing that never happens will fix it.
+//!
+//! [`open_up_existing`] is the check that closes that gap. Locating an item and
+//! reading its ACLs decrypts nothing and needs no authorization, so it costs
+//! the user nothing on the common path where the item is already open, and it
+//! rewrites only what would otherwise have gone on prompting forever.
+
+mod sys;
 
 use std::ffi::c_void;
 use std::ptr;
@@ -38,7 +52,7 @@ use anyhow::{bail, Result};
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
 use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
-use core_foundation_sys::base::{CFRelease, CFTypeRef, OSStatus};
+use core_foundation_sys::base::{CFRelease, OSStatus};
 use core_foundation_sys::string::CFStringRef;
 use security_framework::os::macos::access::SecAccess;
 use security_framework::os::macos::keychain::SecKeychain;
@@ -47,65 +61,12 @@ use security_framework_sys::base::{
     SecAccessRef, SecKeychainAttribute, SecKeychainAttributeList, SecKeychainItemRef,
 };
 
-/// An entry in a `SecAccess`'s ACL list. Opaque; only handed back to Security.
-type SecACLRef = *const c_void;
-
-/// `SecKeychainPromptSelector`, a bitfield of the conditions that force a
-/// prompt even for a trusted caller. Zero forces none of them.
-type SecKeychainPromptSelector = u16;
-
-/// `errSecItemNotFound`. A miss, rather than something going wrong.
-const ITEM_NOT_FOUND: OSStatus = -25300;
-
-// Four-character codes, spelled out because the `-sys` crate binds none of
-// them: 'genp' (a generic password), 'svce' (its service), 'acct' (its
-// account).
-const GENERIC_PASSWORD_CLASS: u32 = 0x6765_6E70;
-const SERVICE_ATTR: u32 = 0x7376_6365;
-const ACCOUNT_ATTR: u32 = 0x6163_6374;
-
-// Neither `security-framework` nor its `-sys` crate binds these: the former
-// declares the `SecAccess` type and nothing that builds one, and the latter
-// covers only `SecAccessGetTypeID`.
-unsafe extern "C" {
-    fn SecAccessCreate(
-        descriptor: CFStringRef,
-        trustedlist: CFArrayRef,
-        accessRef: *mut SecAccessRef,
-    ) -> OSStatus;
-
-    fn SecAccessCopyACLList(accessRef: SecAccessRef, aclList: *mut CFArrayRef) -> OSStatus;
-
-    fn SecACLSetContents(
-        acl: SecACLRef,
-        applicationList: CFArrayRef,
-        description: CFStringRef,
-        promptSelector: SecKeychainPromptSelector,
-    ) -> OSStatus;
-
-    fn SecKeychainFindGenericPassword(
-        keychainOrArray: CFTypeRef,
-        serviceNameLength: u32,
-        serviceName: *const c_void,
-        accountNameLength: u32,
-        accountName: *const c_void,
-        passwordLength: *mut u32,
-        passwordData: *mut *mut c_void,
-        itemRef: *mut SecKeychainItemRef,
-    ) -> OSStatus;
-
-    fn SecKeychainItemCreateFromContent(
-        itemClass: u32,
-        attrList: *const SecKeychainAttributeList,
-        length: u32,
-        data: *const c_void,
-        keychainRef: CFTypeRef,
-        initialAccess: SecAccessRef,
-        itemRef: *mut SecKeychainItemRef,
-    ) -> OSStatus;
-
-    fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) -> OSStatus;
-}
+use sys::{
+    SecACLCopyContents, SecACLRef, SecACLSetContents, SecAccessCopyACLList, SecAccessCreate,
+    SecKeychainFindGenericPassword, SecKeychainItemCopyAccess, SecKeychainItemCreateFromContent,
+    SecKeychainItemDelete, SecKeychainPromptSelector, ACCOUNT_ATTR, GENERIC_PASSWORD_CLASS,
+    ITEM_NOT_FOUND, SERVICE_ATTR,
+};
 
 /// Store `secret` under `service`/`account` so any application can read it back
 /// without a password prompt.
@@ -114,6 +75,37 @@ unsafe extern "C" {
 /// replaces rather than amends.
 pub fn store_with_open_access(service: &str, account: &str, secret: &[u8]) -> Result<()> {
     store(None, service, account, secret)
+}
+
+/// Give a stored item the open ACL if it does not already have one, and report
+/// whether that was necessary.
+///
+/// `secret` is what the item currently holds. Opening it up means replacing it
+/// (see the module docs), so the value has to be written back.
+pub fn open_up_existing(service: &str, account: &str, secret: &[u8]) -> Result<bool> {
+    open_up(None, service, account, secret)
+}
+
+/// The same, against a specific keychain.
+fn open_up(
+    keychain: Option<&SecKeychain>,
+    service: &str,
+    account: &str,
+    secret: &[u8],
+) -> Result<bool> {
+    // Scoped, so the item reference is gone before `store` deletes what it
+    // points at.
+    let pinned = match find_item(keychain, service, account)? {
+        Some(item) => names_applications(&item)?,
+        None => return Ok(false),
+    };
+
+    if !pinned {
+        return Ok(false);
+    }
+
+    store(keychain, service, account, secret)?;
+    Ok(true)
 }
 
 /// The same, against a specific keychain. Tests pass a throwaway one rather
@@ -224,16 +216,54 @@ fn permissive_access(descriptor: &CFString) -> Result<SecAccess> {
     Ok(access)
 }
 
+/// Whether the item still trusts a fixed list of applications, which is what
+/// makes macOS challenge every build of grans but the one that wrote it.
+fn names_applications(item: &SecKeychainItem) -> Result<bool> {
+    let mut access: SecAccessRef = ptr::null_mut();
+    check(
+        unsafe { SecKeychainItemCopyAccess(item.as_concrete_TypeRef(), &mut access) },
+        "read the access settings of the keychain entry",
+    )?;
+    let access = unsafe { SecAccess::wrap_under_create_rule(access) };
+
+    // Bound rather than iterated inline: the entries are borrowed from the
+    // array, so it has to outlive the loop.
+    let acls = acl_list(&access)?;
+    for acl in acls.entries() {
+        if acl_names_applications(acl)? {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+/// Whether one ACL names applications. Any list at all is a fixed set; only a
+/// NULL one means "every application".
+fn acl_names_applications(acl: SecACLRef) -> Result<bool> {
+    let mut applications: CFArrayRef = ptr::null();
+    let mut description: CFStringRef = ptr::null();
+    let mut prompt: SecKeychainPromptSelector = 0;
+
+    check(
+        unsafe { SecACLCopyContents(acl, &mut applications, &mut description, &mut prompt) },
+        "read the contents of an ACL",
+    )?;
+
+    // Both out-params come back under the create rule, so both are ours to
+    // release even though only one is being read.
+    let applications = OwnedArray(applications);
+    if !description.is_null() {
+        unsafe { CFRelease(description.cast()) };
+    }
+
+    Ok(!applications.is_null())
+}
+
 /// Drop every ACL's trusted-application list.
 fn clear_trusted_applications(access: &SecAccess, descriptor: &CFString) -> Result<()> {
-    let mut list: CFArrayRef = ptr::null();
-    check(
-        unsafe { SecAccessCopyACLList(access.as_concrete_TypeRef(), &mut list) },
-        "read the ACLs of a keychain access object",
-    )?;
-    let list = OwnedArray(list);
-
-    for acl in list.entries() {
+    let acls = acl_list(access)?;
+    for acl in acls.entries() {
         check(
             // NULL is what macOS reads as "any application, no prompt". An
             // empty array is the opposite: nobody is trusted, always ask.
@@ -245,6 +275,17 @@ fn clear_trusted_applications(access: &SecAccess, descriptor: &CFString) -> Resu
     Ok(())
 }
 
+/// The ACLs of `access`, as an array that releases itself.
+fn acl_list(access: &SecAccess) -> Result<OwnedArray> {
+    let mut list: CFArrayRef = ptr::null();
+    check(
+        unsafe { SecAccessCopyACLList(access.as_concrete_TypeRef(), &mut list) },
+        "read the ACLs of a keychain access object",
+    )?;
+
+    Ok(OwnedArray(list))
+}
+
 /// A `CFArrayRef` handed over under the create rule, released when dropped.
 struct OwnedArray(CFArrayRef);
 
@@ -254,6 +295,12 @@ impl OwnedArray {
         (0..count)
             .map(|index| unsafe { CFArrayGetValueAtIndex(self.0, index) })
             .collect()
+    }
+
+    /// Whether Security handed back no array at all, which for a
+    /// trusted-application list is what "every application" looks like.
+    fn is_null(&self) -> bool {
+        self.0.is_null()
     }
 }
 
@@ -281,22 +328,6 @@ mod tests {
     use security_framework::os::macos::passwords::find_generic_password;
     use tempfile::TempDir;
 
-    // Read-side counterparts of the calls above, needed only to assert on what
-    // was written.
-    unsafe extern "C" {
-        fn SecKeychainItemCopyAccess(
-            itemRef: SecKeychainItemRef,
-            accessRef: *mut SecAccessRef,
-        ) -> OSStatus;
-
-        fn SecACLCopyContents(
-            acl: SecACLRef,
-            applicationList: *mut CFArrayRef,
-            description: *mut CFStringRef,
-            promptSelector: *mut SecKeychainPromptSelector,
-        ) -> OSStatus;
-    }
-
     const SERVICE: &str = "grans-acl-test";
     const ACCOUNT: &str = "granola-session";
 
@@ -318,34 +349,18 @@ mod tests {
         keychain
     }
 
-    /// For each ACL on the stored item, whether it trusts a fixed list of
-    /// applications rather than all of them.
-    fn acls_naming_applications(keychain: &SecKeychain) -> Vec<bool> {
+    /// Whether the stored item would challenge a build of grans other than the
+    /// one that wrote it.
+    fn is_pinned(keychain: &SecKeychain) -> bool {
         let item = find_item(Some(keychain), SERVICE, ACCOUNT).unwrap().unwrap();
 
-        let mut access: SecAccessRef = ptr::null_mut();
-        let status = unsafe { SecKeychainItemCopyAccess(item.as_concrete_TypeRef(), &mut access) };
-        assert_eq!(status, 0, "SecKeychainItemCopyAccess");
-        let access = unsafe { SecAccess::wrap_under_create_rule(access) };
+        names_applications(&item).unwrap()
+    }
 
-        let mut list: CFArrayRef = ptr::null();
-        let status = unsafe { SecAccessCopyACLList(access.as_concrete_TypeRef(), &mut list) };
-        assert_eq!(status, 0, "SecAccessCopyACLList");
-        let list = OwnedArray(list);
+    fn stored_secret(keychain: SecKeychain) -> Vec<u8> {
+        let (password, _item) = find_generic_password(Some(&[keychain]), SERVICE, ACCOUNT).unwrap();
 
-        list.entries()
-            .into_iter()
-            .map(|acl| {
-                let mut applications: CFArrayRef = ptr::null();
-                let mut description: CFStringRef = ptr::null();
-                let mut prompt: SecKeychainPromptSelector = 0;
-                let status = unsafe {
-                    SecACLCopyContents(acl, &mut applications, &mut description, &mut prompt)
-                };
-                assert_eq!(status, 0, "SecACLCopyContents");
-                !applications.is_null()
-            })
-            .collect()
+        password.to_vec()
     }
 
     #[test]
@@ -356,7 +371,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let keychain = keychain_pinned_to_creator(&dir);
 
-        assert!(acls_naming_applications(&keychain).contains(&true));
+        assert!(is_pinned(&keychain));
     }
 
     #[test]
@@ -366,7 +381,7 @@ mod tests {
 
         store(Some(&keychain), SERVICE, ACCOUNT, b"secret").unwrap();
 
-        assert!(!acls_naming_applications(&keychain).contains(&true));
+        assert!(!is_pinned(&keychain));
     }
 
     #[test]
@@ -376,8 +391,7 @@ mod tests {
 
         store(Some(&keychain), SERVICE, ACCOUNT, b"secret").unwrap();
 
-        let (password, _item) = find_generic_password(Some(&[keychain]), SERVICE, ACCOUNT).unwrap();
-        assert_eq!(&*password, b"secret");
+        assert_eq!(stored_secret(keychain), b"secret");
     }
 
     #[test]
@@ -388,8 +402,7 @@ mod tests {
         store(Some(&keychain), SERVICE, ACCOUNT, b"first").unwrap();
         store(Some(&keychain), SERVICE, ACCOUNT, b"second").unwrap();
 
-        let (password, _item) = find_generic_password(Some(&[keychain]), SERVICE, ACCOUNT).unwrap();
-        assert_eq!(&*password, b"second");
+        assert_eq!(stored_secret(keychain), b"second");
     }
 
     #[test]
@@ -398,13 +411,12 @@ mod tests {
         // against a signature that has since changed; replacing it does not.
         let dir = TempDir::new().unwrap();
         let keychain = keychain_pinned_to_creator(&dir);
-        assert!(acls_naming_applications(&keychain).contains(&true));
+        assert!(is_pinned(&keychain));
 
         store(Some(&keychain), SERVICE, ACCOUNT, b"rotated").unwrap();
 
-        assert!(!acls_naming_applications(&keychain).contains(&true));
-        let (password, _item) = find_generic_password(Some(&[keychain]), SERVICE, ACCOUNT).unwrap();
-        assert_eq!(&*password, b"rotated");
+        assert!(!is_pinned(&keychain));
+        assert_eq!(stored_secret(keychain), b"rotated");
     }
 
     #[test]
@@ -415,5 +427,47 @@ mod tests {
         assert!(find_item(Some(&keychain), SERVICE, "nobody")
             .unwrap()
             .is_none());
+    }
+
+    // --- opening up what an older grans left behind ---
+
+    #[test]
+    fn test_open_up_rewrites_a_pinned_entry_and_keeps_its_secret() {
+        // The bug this exists for: grans updates, the item it stored months
+        // ago is still pinned to a build that no longer exists, and every read
+        // is challenged. Nothing writes on a read-only command, so without
+        // this the prompting never stops.
+        let dir = TempDir::new().unwrap();
+        let keychain = keychain_pinned_to_creator(&dir);
+
+        let rewritten = open_up(Some(&keychain), SERVICE, ACCOUNT, b"secret").unwrap();
+
+        assert!(rewritten);
+        assert!(!is_pinned(&keychain));
+        assert_eq!(stored_secret(keychain), b"secret");
+    }
+
+    #[test]
+    fn test_open_up_leaves_an_already_open_entry_alone() {
+        // Every command opens the credential store, so an item that is already
+        // open must not be deleted and rewritten each time.
+        let dir = TempDir::new().unwrap();
+        let keychain = keychain(&dir);
+        store(Some(&keychain), SERVICE, ACCOUNT, b"secret").unwrap();
+
+        let rewritten = open_up(Some(&keychain), SERVICE, ACCOUNT, b"secret").unwrap();
+
+        assert!(!rewritten);
+        assert!(!is_pinned(&keychain));
+    }
+
+    #[test]
+    fn test_open_up_reports_nothing_to_do_when_the_entry_is_gone() {
+        // The item is looked up again here after having been read, so it can
+        // have been removed in between.
+        let dir = TempDir::new().unwrap();
+        let keychain = keychain(&dir);
+
+        assert!(!open_up(Some(&keychain), SERVICE, ACCOUNT, b"secret").unwrap());
     }
 }

--- a/src/api/keychain_acl/sys.rs
+++ b/src/api/keychain_acl/sys.rs
@@ -1,0 +1,83 @@
+//! Raw Security framework bindings the crates in use do not provide.
+//!
+//! `security-framework` declares the `SecAccess` type and nothing that builds
+//! or inspects one, and `security-framework-sys` covers only
+//! `SecAccessGetTypeID`, so the ACL calls have to be declared here. Everything
+//! in this module is a verbatim transcription of `<Security/Security.h>`; the
+//! policy that uses it lives in the parent.
+
+use std::ffi::c_void;
+
+use core_foundation_sys::array::CFArrayRef;
+use core_foundation_sys::base::{CFTypeRef, OSStatus};
+use core_foundation_sys::string::CFStringRef;
+use security_framework_sys::base::{SecAccessRef, SecKeychainAttributeList, SecKeychainItemRef};
+
+/// An entry in a `SecAccess`'s ACL list. Opaque; only handed back to Security.
+pub type SecACLRef = *const c_void;
+
+/// `SecKeychainPromptSelector`, a bitfield of the conditions that force a
+/// prompt even for a trusted caller. Zero forces none of them.
+pub type SecKeychainPromptSelector = u16;
+
+/// `errSecItemNotFound`. A miss, rather than something going wrong.
+pub const ITEM_NOT_FOUND: OSStatus = -25300;
+
+// Four-character codes, spelled out because the `-sys` crate binds none of
+// them: 'genp' (a generic password), 'svce' (its service), 'acct' (its
+// account).
+pub const GENERIC_PASSWORD_CLASS: u32 = 0x6765_6E70;
+pub const SERVICE_ATTR: u32 = 0x7376_6365;
+pub const ACCOUNT_ATTR: u32 = 0x6163_6374;
+
+unsafe extern "C" {
+    pub fn SecAccessCreate(
+        descriptor: CFStringRef,
+        trustedlist: CFArrayRef,
+        accessRef: *mut SecAccessRef,
+    ) -> OSStatus;
+
+    pub fn SecAccessCopyACLList(accessRef: SecAccessRef, aclList: *mut CFArrayRef) -> OSStatus;
+
+    pub fn SecACLSetContents(
+        acl: SecACLRef,
+        applicationList: CFArrayRef,
+        description: CFStringRef,
+        promptSelector: SecKeychainPromptSelector,
+    ) -> OSStatus;
+
+    pub fn SecACLCopyContents(
+        acl: SecACLRef,
+        applicationList: *mut CFArrayRef,
+        description: *mut CFStringRef,
+        promptSelector: *mut SecKeychainPromptSelector,
+    ) -> OSStatus;
+
+    pub fn SecKeychainItemCopyAccess(
+        itemRef: SecKeychainItemRef,
+        accessRef: *mut SecAccessRef,
+    ) -> OSStatus;
+
+    pub fn SecKeychainFindGenericPassword(
+        keychainOrArray: CFTypeRef,
+        serviceNameLength: u32,
+        serviceName: *const c_void,
+        accountNameLength: u32,
+        accountName: *const c_void,
+        passwordLength: *mut u32,
+        passwordData: *mut *mut c_void,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    pub fn SecKeychainItemCreateFromContent(
+        itemClass: u32,
+        attrList: *const SecKeychainAttributeList,
+        length: u32,
+        data: *const c_void,
+        keychainRef: CFTypeRef,
+        initialAccess: SecAccessRef,
+        itemRef: *mut SecKeychainItemRef,
+    ) -> OSStatus;
+
+    pub fn SecKeychainItemDelete(itemRef: SecKeychainItemRef) -> OSStatus;
+}

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -33,9 +33,9 @@ pub fn run(action: &AuthAction, tz: &FixedOffset) -> Result<()> {
 }
 
 fn login(provider: AuthProvider, refresh_token_stdin: bool) -> Result<()> {
-    let store = CredentialStore::open()?;
+    let (store, existing) = CredentialStore::open()?;
 
-    if existing_session_kept(&store)? {
+    if existing.is_some() && !replacing_existing_session()? {
         return Ok(());
     }
 
@@ -70,12 +70,8 @@ fn print_no_keychain_warning() {
 
 /// Ask before replacing a session that already works.
 ///
-/// Returns true when the caller should stop, leaving the session alone.
-fn existing_session_kept(store: &CredentialStore) -> Result<bool> {
-    if store.load()?.is_none() {
-        return Ok(false);
-    }
-
+/// Returns true when the caller should go ahead and sign in again.
+fn replacing_existing_session() -> Result<bool> {
     println!("grans already has a Granola session.");
     print!("Sign in again? [y/N] ");
     io::stdout().flush()?;
@@ -84,11 +80,11 @@ fn existing_session_kept(store: &CredentialStore) -> Result<bool> {
     io::stdin().read_line(&mut input)?;
 
     if input.trim().eq_ignore_ascii_case("y") {
-        return Ok(false);
+        return Ok(true);
     }
 
     println!("Keeping the existing session.");
-    Ok(true)
+    Ok(false)
 }
 
 /// Bootstrap from a refresh token supplied on stdin.
@@ -159,9 +155,9 @@ fn print_callback_instructions() {
 }
 
 fn status(tz: &FixedOffset) -> Result<()> {
-    let store = CredentialStore::open()?;
+    let (store, stored) = CredentialStore::open()?;
 
-    let Some(credentials) = store.load()? else {
+    let Some(credentials) = stored else {
         println!("Not signed in.");
         println!("grans falls back to the token Granola's desktop app stored locally,");
         println!("which no longer works on current macOS builds. Run `grans auth login`.");
@@ -210,9 +206,9 @@ fn describe_expiry(credentials: &GranolaCredentials, tz: &FixedOffset) -> String
 }
 
 fn logout() -> Result<()> {
-    let store = CredentialStore::open()?;
+    let (store, stored) = CredentialStore::open()?;
 
-    if store.load()?.is_none() {
+    if stored.is_none() {
         println!("Not signed in; nothing to remove.");
         return Ok(());
     }


### PR DESCRIPTION
`grans sync` on macOS still pops the login-password dialog, several times per run, on a build that has the #104 fix in it. Two things were wrong.

## The fix only applied to items grans wrote

Attaching the permissive ACL happens in `store_secret`. Reads and deletes go through `keyring` untouched, so an entry created before #104 keeps the default ACL, pinned to the code signature of whatever build stored it. Every read from a newer binary is challenged.

#104's upgrade path rode along with `store`, and a signed-in user whose access token is still valid completes a whole command without writing anything. Nothing ever triggers the upgrade, so the prompting never stops. Anyone who signed in before #104 merged is in this state permanently.

Opening the credential store now checks the stored item's ACL and rewrites it if it is still pinned. Finding an item and reading its ACLs decrypts nothing and needs no authorization, so an already-open entry costs nothing; a pinned one is rewritten once. A failure to repair is logged and stepped over rather than propagated, since the credential has already been read by that point and failing the command would trade something working for something cosmetic.

## And every command read the keychain twice

`CredentialStore::open` has to read to know a keychain is usable at all, then threw the result away, and every caller followed it with a `load` that fetched the same secret again. On macOS each is its own authorization, so an entry the system is challenging cost two dialogs per command. `open` now returns what it read.

`load` stays and still always reads. The refresh chain re-reads deliberately, to find out whether a concurrent grans rotated the token, and that is the one caller a cached answer would break.

## Tests

New unit tests in `keychain_acl`, against a throwaway keychain:

- `test_open_up_rewrites_a_pinned_entry_and_keeps_its_secret` — the regression. Fails without this change, because there was no repair at all.
- `test_open_up_leaves_an_already_open_entry_alone` — every command opens the store, so an open entry must not be deleted and rewritten each time.
- `test_open_up_reports_nothing_to_do_when_the_entry_is_gone` — the item is looked up again after having been read, so it can vanish in between.

The read-side Security calls these need were living in the test module as assertion helpers. They are production code now, so they moved up, and the raw bindings went into a `sys` submodule: the file was carrying both a transcription of `Security.h` and grans's ACL policy, at 536 lines.

## Verification

Everything here is macOS-gated and cannot be compiled on the Windows box it was written on (`cargo check --target aarch64-apple-darwin` needs a cross C toolchain). The macOS CI leg is the check. The full suite passes locally on Windows: 870 unit tests plus 75 integration tests.

## Why existing tests missed it

No test covered `CredentialStore::open` at all, on any platform, and the ACL tests all drove `store` directly. Both defects live in the gap between the two: what `open` does with what it reads, and what happens to an item nothing writes to.

https://claude.ai/code/session_01PpupoVWhf56HHZ2sR6koRk