### PR TITLE
#114: Test the GH_TOKEN preference without touching the environment

### DIFF
--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -7,13 +7,22 @@ pub mod wait;
 
 use thiserror::Error;
 
+/// Prefer `GH_TOKEN` (what the gh CLI sets) over `GITHUB_TOKEN`.
+///
+/// Split out from the environment read so the preference can be tested without
+/// mutating process-global state, which three tests used to race on.
+fn pick_github_token(gh: Option<String>, github: Option<String>) -> Option<String> {
+    gh.or(github)
+}
+
 /// Get GitHub token from environment if available.
 ///
 /// Checks `GH_TOKEN` first (used by gh CLI), then `GITHUB_TOKEN`.
 pub(crate) fn get_github_token_from_env() -> Option<String> {
-    std::env::var("GH_TOKEN")
-        .or_else(|_| std::env::var("GITHUB_TOKEN"))
-        .ok()
+    pick_github_token(
+        std::env::var("GH_TOKEN").ok(),
+        std::env::var("GITHUB_TOKEN").ok(),
+    )
 }
 
 /// Check if the gh CLI is available and authenticated.
@@ -73,88 +82,29 @@ pub type UpdateResult<T> = Result<T, UpdateError>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
 
-    // Helper to safely set/remove env vars in tests
-    // SAFETY: These tests run single-threaded (cargo test runs each test in isolation)
-    unsafe fn set_env(key: &str, value: &str) {
-        unsafe { env::set_var(key, value) };
-    }
-
-    unsafe fn remove_env(key: &str) {
-        unsafe { env::remove_var(key) };
-    }
-
-    unsafe fn restore_env(key: &str, orig: Option<String>) {
-        match orig {
-            Some(v) => unsafe { env::set_var(key, v) },
-            None => unsafe { env::remove_var(key) },
-        }
+    fn token(value: &str) -> Option<String> {
+        Some(value.to_string())
     }
 
     #[test]
-    fn test_get_github_token_from_env_prefers_gh_token() {
-        // Save original values
-        let orig_gh = env::var("GH_TOKEN").ok();
-        let orig_github = env::var("GITHUB_TOKEN").ok();
-
-        // SAFETY: Test runs single-threaded
-        unsafe {
-            set_env("GH_TOKEN", "gh_token_value");
-            set_env("GITHUB_TOKEN", "github_token_value");
-        }
-
-        let result = get_github_token_from_env();
-        assert_eq!(result, Some("gh_token_value".to_string()));
-
-        // Restore
-        unsafe {
-            restore_env("GH_TOKEN", orig_gh);
-            restore_env("GITHUB_TOKEN", orig_github);
-        }
+    fn test_pick_github_token_prefers_gh_token() {
+        assert_eq!(
+            pick_github_token(token("gh_token_value"), token("github_token_value")),
+            token("gh_token_value")
+        );
     }
 
     #[test]
-    fn test_get_github_token_from_env_falls_back_to_github_token() {
-        // Save original values
-        let orig_gh = env::var("GH_TOKEN").ok();
-        let orig_github = env::var("GITHUB_TOKEN").ok();
-
-        // SAFETY: Test runs single-threaded
-        unsafe {
-            remove_env("GH_TOKEN");
-            set_env("GITHUB_TOKEN", "github_token_value");
-        }
-
-        let result = get_github_token_from_env();
-        assert_eq!(result, Some("github_token_value".to_string()));
-
-        // Restore
-        unsafe {
-            restore_env("GH_TOKEN", orig_gh);
-            restore_env("GITHUB_TOKEN", orig_github);
-        }
+    fn test_pick_github_token_falls_back_to_github_token() {
+        assert_eq!(
+            pick_github_token(None, token("github_token_value")),
+            token("github_token_value")
+        );
     }
 
     #[test]
-    fn test_get_github_token_from_env_returns_none_when_unset() {
-        // Save original values
-        let orig_gh = env::var("GH_TOKEN").ok();
-        let orig_github = env::var("GITHUB_TOKEN").ok();
-
-        // SAFETY: Test runs single-threaded
-        unsafe {
-            remove_env("GH_TOKEN");
-            remove_env("GITHUB_TOKEN");
-        }
-
-        let result = get_github_token_from_env();
-        assert_eq!(result, None);
-
-        // Restore
-        unsafe {
-            restore_env("GH_TOKEN", orig_gh);
-            restore_env("GITHUB_TOKEN", orig_github);
-        }
+    fn test_pick_github_token_returns_none_when_neither_is_set() {
+        assert_eq!(pick_github_token(None, None), None);
     }
 }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 /// Prefer `GH_TOKEN` (what the gh CLI sets) over `GITHUB_TOKEN`.
 ///
 /// Split out from the environment read so the preference can be tested without
-/// mutating process-global state, which three tests used to race on.
+/// mutating process-global state.
 fn pick_github_token(gh: Option<String>, github: Option<String>) -> Option<String> {
     gh.or(github)
 }


### PR DESCRIPTION
## Reproduced first

On `main`, at `--test-threads=8`:

```
$ for i in $(seq 1 25); do
    cargo test --bin grans update::tests::test_get_github_token -- --test-threads=8
  done
failed 15 / 25 runs
```

After the change, the equivalent loop over the new test names:

```
failed 0 / 25 runs
```

## What was wrong

The three tests each mutated `GH_TOKEN` and `GITHUB_TOKEN` with `env::set_var` / `env::remove_var`. Those are process-global, and `cargo test` runs test cases as threads in one process, so the three overwrote each other's setup.

The `unsafe` was justified with:

```rust
// SAFETY: These tests run single-threaded (cargo test runs each test in isolation)
```

That is not accurate. `cargo test` isolates test *cases*, not *processes*. On edition 2024 `env::set_var` is `unsafe` precisely because a concurrent `set_var` and `getenv` is a data race, so this was undefined behavior in a multithreaded process, not merely a racy assertion.

## The fix

The preference between the two variables is a decision that does not need the environment to express. It moves into a pure function:

```rust
fn pick_github_token(gh: Option<String>, github: Option<String>) -> Option<String> {
    gh.or(github)
}
```

`get_github_token_from_env` reads the two variables and calls it. The three tests exercise `pick_github_token` directly, so there is no shared mutable state left to race on, and the `set_env` / `remove_env` / `restore_env` helpers plus every `unsafe` block in the module are deleted along with the wrong SAFETY comment.

Serializing the tests behind a mutex was the alternative; it would have left both the `unsafe` and the inaccurate comment in place.

## The other `env::set_var`

`src/embed/model.rs:43` sets `HF_HOME`. Checked as the issue asked: its only caller is `FastEmbedModel::new`, no test reaches it, and it runs before `fastembed` constructs the model. Its SAFETY claim holds, and it is now the only environment mutation in the tree.

## Why existing tests did not catch this

The tests were the bug. Nothing ran them under deliberate contention, and the default thread pool spreads 900+ tests widely enough that these three rarely overlapped in a full run. There is no scheduling in which pure functions disagree, so the question is now moot rather than newly covered.

## Verification

Full suite from PowerShell (per CLAUDE.md), `cargo test --no-fail-fast`: all six binaries pass, 945 tests, exit 0.

Closes #114

https://claude.ai/code/session_014akTv9Sj4UZ7bQPDhXe5hn