### PR TITLE
#101: Cancel superseded CI runs instead of letting them finish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,20 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+# A run that a newer push has superseded is not merely wasted compute here: the
+# two review jobs post inline comments anchored to diff positions, so a
+# superseded run delivers feedback about a diff that no longer exists, and
+# track_progress adds a second tracking comment beside the current run's. The
+# window is wide enough to hit in practice -- Code Review alone takes a bit over
+# two minutes, and it starts immediately rather than after the tests whenever
+# the paths filter skips them.
+#
+# This workflow is pull_request-only, so cancelling is always the right call.
+# github.ref is refs/pull/<n>/merge here, which keys the group per PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -30,6 +30,21 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+# Cancel only the pull_request runs. Those exist to exercise a change to this
+# file and a newer push to the same PR supersedes them, at a cost of 4-11
+# minutes of a Windows leg spent answering about the wrong commit.
+#
+# Every other trigger gets github.run_id, which is unique, so those runs share
+# no group and cancel-in-progress never reaches them. `cancel-in-progress:
+# false` over a shared group is not the same thing: GitHub holds at most one
+# pending run per group and cancels the previous pending one, so three merges
+# landing in quick succession would drop the middle commit's run entirely. This
+# workflow is the only thing running the integration suites on macOS and
+# Windows, so every merged commit needs its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## ci.yml

Cancels unconditionally. The workflow only triggers on `pull_request`, so a run a newer push has superseded is always worthless, and `github.ref` is `refs/pull/<n>/merge` there, which keys the group per PR.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## platform-tests.yml: one deviation from the issue

The issue proposed the same conditional block for both files:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

That does not do what it looks like for the `push: main` path. `cancel-in-progress: false` does not mean "run both"; it means "queue the second one", and GitHub [holds at most one pending run per group, cancelling the previous pending one](https://docs.github.com/en/actions/using-jobs/using-concurrency). All main pushes share `refs/heads/main`, so three merges landing in quick succession would leave the middle commit's run cancelled before it ever started. That is the outcome the issue was explicitly trying to avoid, since this workflow is the only thing running the integration suites on macOS and Windows.

So non-PR runs key on `github.run_id` instead, which is unique per run. They share no group, and `cancel-in-progress` never reaches them:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
  cancel-in-progress: true
```

PR runs (the workflow triggers on `pull_request` for changes to its own file) still cancel, which was the case worth having: a superseded run there occupies a Windows leg for 4-11 minutes to answer about the wrong commit.

## Checked

- **No deadlock with branch protection.** `CI Status` treats `cancelled` as a failure, but protection evaluates checks against the current head SHA and a cancelled run belongs to the superseded SHA. (Confirmed as already noted in the issue.)
- **The two workflows do not cancel each other.** `${{ github.workflow }}` is in both keys.
- **No spurious tracking issues.** `report-failure` in platform-tests.yml is gated on `failure()`, which is false for a cancelled run; GitHub reports that as `cancelled()`.
- Both files parse.

`claude.yml` is left alone, as the issue asked: it is triggered by issue comments, where concurrent runs are usually independent rather than superseding.

Closes #101

https://claude.ai/code/session_014akTv9Sj4UZ7bQPDhXe5hn