### PR TITLE
#97: Index every utterance by making the write index it

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ grans uses a task-centric CLI design. Common tasks are promoted to top-level com
 - `auth logout` - Remove the stored credentials
 
 **Admin Commands** (maintenance):
-- `admin db` - Database management (clear, info, list)
+- `admin db` - Database management (clear, info, list, rebuild-fts)
 - `admin token` - Print the current Granola API token
 - `benchmark quality` - Measure search quality (FTS or semantic) against a labeled test suite
 
@@ -472,12 +472,21 @@ grans admin db clear
 # Clear all database files
 grans admin db clear --all
 
-# Show database location and size
+# Show database location, size and search index health
 grans admin db info
 
 # List all database files
 grans admin db list
+
+# Rebuild the full-text search indexes from the tables they index
+grans admin db rebuild-fts
 ```
+
+`admin db info` ends with a line per full-text index saying whether it still
+agrees with the table it indexes. An index that has drifted makes `grep` and
+`search` quietly return too few results while the database otherwise looks
+healthy, and `admin db rebuild-fts` repairs it by re-deriving each index from
+its source. Nothing is lost and no re-sync is needed.
 
 ### Dropbox Sync
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -291,7 +291,7 @@ for you: the index is a separate structure that happens to describe the source
 table, and it only stays true if something keeps writing to it.
 
 `transcript_fts` and `panels_fts` are maintained by triggers on their source
-tables (`v014_fts_triggers.sql`), which is SQLite's documented pattern. The index
+tables (`v015_fts_triggers.sql`), which is SQLite's documented pattern. The index
 entry is written in the same statement as the row, so nothing can commit a row
 without indexing it and no code path has to remember to.
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -270,6 +270,51 @@ CREATE VIRTUAL TABLE notes_fts USING fts5(
 
 Enables fast text search across meeting notes (both plain and markdown formats). This is a contentless FTS table that references `documents`.
 
+### panels_fts
+
+Full-text search index for AI-generated panel content.
+
+```sql
+CREATE VIRTUAL TABLE panels_fts USING fts5(
+    content_markdown,
+    content='panels',
+    content_rowid='rowid'
+);
+```
+
+Enables fast text search across panel markdown. This is a contentless FTS table that references `panels`.
+
+### Keeping the indexes in step
+
+These are external-content tables (`content=`), so SQLite does not maintain them
+for you: the index is a separate structure that happens to describe the source
+table, and it only stays true if something keeps writing to it.
+
+`transcript_fts` and `panels_fts` are maintained by triggers on their source
+tables (`v014_fts_triggers.sql`), which is SQLite's documented pattern. The index
+entry is written in the same statement as the row, so nothing can commit a row
+without indexing it and no code path has to remember to.
+
+They were previously maintained by hand in `db/transcripts.rs` and
+`db/panels.rs`, in a statement issued after the source rows had already been
+committed and with no transaction around either. Any interruption in between
+stranded rows that search could never find; a 456 MB database had accumulated
+237 of them out of 515,606 (#97).
+
+`notes_fts` has no write path at all and has never been populated in production
+(#85), which is why the triggers do not cover it yet.
+
+Drift does not show up in `PRAGMA quick_check` or `PRAGMA integrity_check`.
+Only FTS5's own command compares an external-content index against its source,
+and only at rank 1:
+
+```sql
+INSERT INTO transcript_fts(transcript_fts, rank) VALUES('integrity-check', 1);
+```
+
+`grans admin db info` runs that for each maintained index and reports the result;
+`grans admin db rebuild-fts` re-derives them from their sources.
+
 ## Data Flow
 
 ```mermaid

--- a/src/cli/args/mod.rs
+++ b/src/cli/args/mod.rs
@@ -631,10 +631,15 @@ pub enum DbAction {
         #[arg(long)]
         all: bool,
     },
-    /// Show database location and size
+    /// Show database location, size and search index health
     Info,
     /// List all database files
     List,
+    /// Rebuild the full-text search indexes from the tables they index
+    ///
+    /// The repair for the drift that 'grans admin db info' reports. Re-derives
+    /// each index from its source, so nothing is lost and no re-sync is needed.
+    RebuildFts,
 }
 
 // === Auth Subcommands ===

--- a/src/commands/db.rs
+++ b/src/commands/db.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::path::Path;
 
 use crate::cli::args::DbAction;
+use crate::db::integrity;
 
 pub fn run_with_path(action: &DbAction, db_path: &Path) -> Result<()> {
     match action {
@@ -17,6 +18,9 @@ pub fn run_with_path(action: &DbAction, db_path: &Path) -> Result<()> {
         }
         DbAction::List => {
             list_all_databases()?;
+        }
+        DbAction::RebuildFts => {
+            rebuild_search_indexes(db_path)?;
         }
     }
     Ok(())
@@ -75,11 +79,11 @@ fn show_database_info(db_path: &Path) -> Result<()> {
 
         // Try to read metadata from the database
         if let Ok(conn) = rusqlite::Connection::open(db_path) {
-            if let Ok(schema_version) = conn.query_row(
-                "SELECT value FROM metadata WHERE key = 'schema_version'",
-                [],
-                |row| row.get::<_, String>(0),
-            ) {
+            // From PRAGMA user_version, which is what the migration system
+            // actually tracks. The `metadata` row this used to read is a fossil
+            // of the pre-migration scheme: nothing has written it since, so it
+            // reported 3 on a database at 14.
+            if let Ok(schema_version) = crate::db::migrations::get_schema_version(&conn) {
                 println!("Schema version: {}", schema_version);
             }
 
@@ -117,9 +121,55 @@ fn show_database_info(db_path: &Path) -> Result<()> {
             ) {
                 println!("Transcript utterances: {}", transcript_count);
             }
+
+            report_search_index_health(&conn);
         }
     } else {
         println!("Status: does not exist (run 'grans sync' to create)");
+    }
+
+    Ok(())
+}
+
+/// Print whether each full-text index still agrees with the table it indexes.
+///
+/// This is where FTS drift surfaces. The pull-time check in `db::integrity`
+/// cannot do it: FTS5 spells its check as an `INSERT`, and SQLite refuses that
+/// on the read-only connection that check deliberately opens.
+fn report_search_index_health(conn: &rusqlite::Connection) {
+    let reports = match integrity::check_fts_indexes(conn) {
+        Ok(reports) => reports,
+        Err(err) => {
+            println!("Search indexes: could not be checked ({})", err);
+            return;
+        }
+    };
+
+    for report in reports {
+        match report.state {
+            integrity::FtsIndexState::Consistent => {
+                println!("Search index {}: consistent", report.table);
+            }
+            integrity::FtsIndexState::Drifted(detail) => {
+                println!(
+                    "Search index {}: DRIFTED ({}) -- search under-reports; \
+                     run 'grans admin db rebuild-fts' to repair",
+                    report.table, detail
+                );
+            }
+        }
+    }
+}
+
+fn rebuild_search_indexes(db_path: &Path) -> Result<()> {
+    if !db_path.exists() {
+        println!("No database found at {}", db_path.display());
+        return Ok(());
+    }
+
+    let conn = crate::db::connection::open_db_at_path(db_path)?;
+    for table in integrity::rebuild_fts_indexes(&conn)? {
+        println!("Rebuilt {}", table);
     }
 
     Ok(())

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -67,7 +67,7 @@ mod tests {
         let conn = migrations::open_and_migrate(&db_path).unwrap();
         let version = migrations::get_schema_version(&conn).unwrap();
 
-        // After applying all migrations, version should be 14
-        assert_eq!(version, 14);
+        // After applying all migrations, version should be 15
+        assert_eq!(version, 15);
     }
 }

--- a/src/db/integrity.rs
+++ b/src/db/integrity.rs
@@ -1,15 +1,95 @@
-//! Integrity checking for database files arriving from outside this machine.
+//! Integrity checking: structural soundness of a database file arriving from
+//! outside this machine, and agreement between an FTS5 index and its source.
 
 use std::path::Path;
 use std::time::Instant;
 
 use anyhow::{anyhow, bail, Context, Result};
 use log::debug;
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, ErrorCode, OpenFlags};
 
 /// A grans database always has this table, so its absence means the file is a
 /// database but not one of ours.
 const SENTINEL_TABLE: &str = "documents";
+
+/// The FTS5 indexes that have a maintained write path, and so are expected to
+/// agree with their source tables.
+///
+/// `notes_fts` is absent on purpose. Nothing has ever populated it in
+/// production, so it fails this check on every database in existence and would
+/// report a known gap as if it were damage. It belongs here once #85 gives it a
+/// write path.
+const MAINTAINED_FTS_TABLES: [&str; 2] = ["transcript_fts", "panels_fts"];
+
+/// Whether an FTS5 index still agrees with the table it indexes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FtsIndexState {
+    /// Every source row is indexed and every indexed row exists.
+    Consistent,
+    /// The index and its source disagree, so search silently under-reports.
+    /// Carries SQLite's own description.
+    Drifted(String),
+}
+
+/// One index's result from [`check_fts_indexes`].
+#[derive(Debug)]
+pub struct FtsIndexReport {
+    pub table: &'static str,
+    pub state: FtsIndexState,
+}
+
+/// Compare each maintained FTS5 index against its source table.
+///
+/// Needs a writable connection: FTS5 spells its check as an `INSERT`, and
+/// SQLite refuses that on a read-only connection even though the command writes
+/// nothing.
+pub fn check_fts_indexes(conn: &Connection) -> Result<Vec<FtsIndexReport>> {
+    MAINTAINED_FTS_TABLES
+        .iter()
+        .map(|&table| {
+            check_fts_index(conn, table).map(|state| FtsIndexReport { table, state })
+        })
+        .collect()
+}
+
+/// Run FTS5's `integrity-check` at rank 1 against one index.
+///
+/// Rank 1 is the point of this. These are external-content tables (`content=`),
+/// and only rank 1 compares the index against its source; rank 0 checks the
+/// index's own internal consistency, as do `PRAGMA quick_check` and `PRAGMA
+/// integrity_check`, all three of which report `ok` on a drifted index.
+///
+/// `table` is interpolated because SQLite does not bind identifiers. It is
+/// always one of [`MAINTAINED_FTS_TABLES`]; this function is private so no
+/// caller-supplied name can reach it.
+fn check_fts_index(conn: &Connection, table: &str) -> Result<FtsIndexState> {
+    let sql = format!("INSERT INTO {table}({table}, rank) VALUES('integrity-check', 1)");
+
+    match conn.execute(&sql, []) {
+        Ok(_) => Ok(FtsIndexState::Consistent),
+        // Drift is how FTS5 reports a mismatch, and it is a finding rather than
+        // a failure to look.
+        Err(rusqlite::Error::SqliteFailure(err, msg)) if err.code == ErrorCode::DatabaseCorrupt => {
+            Ok(FtsIndexState::Drifted(
+                msg.unwrap_or_else(|| err.to_string()),
+            ))
+        }
+        Err(err) => Err(err).with_context(|| format!("running integrity-check on {table}")),
+    }
+}
+
+/// Discard each maintained FTS5 index and re-derive it from its source table.
+///
+/// The repair for a [`FtsIndexState::Drifted`] index, and a no-op in effect on a
+/// consistent one.
+pub fn rebuild_fts_indexes(conn: &Connection) -> Result<Vec<&'static str>> {
+    for table in MAINTAINED_FTS_TABLES {
+        conn.execute(&format!("INSERT INTO {table}({table}) VALUES('rebuild')"), [])
+            .with_context(|| format!("rebuilding {table}"))?;
+    }
+
+    Ok(MAINTAINED_FTS_TABLES.to_vec())
+}
 
 /// Verify that a file is a structurally sound grans database.
 ///
@@ -128,41 +208,114 @@ mod tests {
         assert!(check_pulled_database(&path).is_err());
     }
 
-    /// Pins a known limit rather than a capability.
-    ///
-    /// grans builds its FTS5 tables with `content=`, and SQLite compares an
-    /// external-content index against its source table only under FTS5's own
-    /// `integrity-check` with `rank=1`. Neither `quick_check` nor
-    /// `integrity_check` runs that, so an index that has drifted from its
-    /// source passes both. Search then silently returns too few rows while the
-    /// database looks healthy.
-    ///
-    /// Closing this needs a writable connection, which this deliberately
-    /// read-only check does not take. If that changes, this test should start
-    /// failing and be inverted.
+    /// Force an index out of step with its source, the way an interrupted sync
+    /// used to: write rows straight into the FTS table for a document the source
+    /// table does not have.
+    fn drift_the_transcript_index(conn: &Connection) {
+        conn.execute(
+            "INSERT INTO transcript_fts(rowid, text) VALUES (9001, 'orphaned row')",
+            [],
+        )
+        .unwrap();
+    }
+
     #[test]
-    fn does_not_notice_an_fts_index_that_drifted_from_its_source() {
+    fn reports_a_consistent_fts_index_as_consistent() {
         let dir = TempDir::new().unwrap();
         let path = valid_database(&dir);
-
         let conn = Connection::open(&path).unwrap();
-        conn.execute_batch(
+        conn.execute(
             "INSERT INTO transcript_utterances (id, document_id, text)
-                 VALUES ('u1', 'd1', 'deployment rollback discussion'),
-                        ('u2', 'd1', 'quarterly planning notes');
-             INSERT INTO transcript_fts(transcript_fts) VALUES('rebuild');",
+                 VALUES ('u1', 'd1', 'deployment rollback discussion')",
+            [],
         )
         .unwrap();
 
-        // Drop source rows without the index maintenance that db::transcripts
-        // normally performs, leaving the index describing rows that are gone.
-        conn.execute("DELETE FROM transcript_utterances", []).unwrap();
-        drop(conn);
+        let reports = check_fts_indexes(&conn).unwrap();
+
+        assert_eq!(reports.len(), 2);
+        for report in &reports {
+            assert_eq!(
+                report.state,
+                FtsIndexState::Consistent,
+                "{} should be consistent",
+                report.table
+            );
+        }
+    }
+
+    #[test]
+    fn reports_a_drifted_fts_index_as_drifted() {
+        let dir = TempDir::new().unwrap();
+        let path = valid_database(&dir);
+        let conn = Connection::open(&path).unwrap();
+        drift_the_transcript_index(&conn);
+
+        let reports = check_fts_indexes(&conn).unwrap();
+
+        let transcripts = reports.iter().find(|r| r.table == "transcript_fts").unwrap();
+        assert!(
+            matches!(transcripts.state, FtsIndexState::Drifted(_)),
+            "expected drift, got {:?}",
+            transcripts.state
+        );
+        // The damage is confined to the index that was tampered with.
+        let panels = reports.iter().find(|r| r.table == "panels_fts").unwrap();
+        assert_eq!(panels.state, FtsIndexState::Consistent);
+    }
+
+    #[test]
+    fn rebuild_repairs_a_drifted_fts_index() {
+        let dir = TempDir::new().unwrap();
+        let path = valid_database(&dir);
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text)
+                 VALUES ('u1', 'd1', 'deployment rollback discussion')",
+            [],
+        )
+        .unwrap();
+        drift_the_transcript_index(&conn);
+
+        rebuild_fts_indexes(&conn).unwrap();
+
+        for report in check_fts_indexes(&conn).unwrap() {
+            assert_eq!(report.state, FtsIndexState::Consistent, "{}", report.table);
+        }
+        // Repair restores the index rather than merely emptying it.
+        let hits: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcript_fts WHERE transcript_fts MATCH 'rollback'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 1);
+    }
+
+    /// Records why the FTS check is not part of [`check_pulled_database`],
+    /// rather than pinning a gap: SQLite refuses the `INSERT` that FTS5 spells
+    /// its check as, on the read-only connection this deliberately opens.
+    #[test]
+    fn the_fts_check_needs_a_writable_connection() {
+        let dir = TempDir::new().unwrap();
+        let path = valid_database(&dir);
+        {
+            let conn = Connection::open(&path).unwrap();
+            drift_the_transcript_index(&conn);
+        }
+
+        let read_only =
+            Connection::open_with_flags(&path, OpenFlags::SQLITE_OPEN_READ_ONLY).unwrap();
+        let err = check_fts_indexes(&read_only).unwrap_err();
 
         assert!(
-            check_pulled_database(&path).is_ok(),
-            "if this now fails, the FTS drift gap has been closed; invert the test"
+            err.to_string().contains("integrity-check"),
+            "unhelpful message: {err}"
         );
+        // And so the pull-time check, which is read-only by design, still passes
+        // a drifted file. `grans db info` is where drift surfaces.
+        assert!(check_pulled_database(&path).is_ok());
     }
 
     #[test]

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -165,8 +165,8 @@ mod tests {
         let conn = open_and_migrate(&db_path).unwrap();
         let version = get_schema_version(&conn).unwrap();
 
-        // Should be version 14 after all migrations
-        assert_eq!(version, 14);
+        // Should be version 15 after all migrations
+        assert_eq!(version, 15);
     }
 
     #[test]

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -29,6 +29,7 @@ fn migrations() -> Migrations<'static> {
         M::up(include_str!("v012_rename_is_primary_to_primary.sql")),
         M::up(include_str!("v013_api_snapshot.sql")),
         M::up(include_str!("v014_utterance_speaker_name.sql")),
+        M::up(include_str!("v015_fts_triggers.sql")),
     ])
 }
 
@@ -52,7 +53,7 @@ pub fn open_and_migrate(db_path: &Path) -> Result<Connection> {
         rusqlite_migration::SchemaVersion::Inside(v) => {
             // Check if current version is less than the number of migrations
             let current = v.get();
-            let total = 14; // We have 14 migrations (v001-v014)
+            let total = 15; // We have 15 migrations (v001-v015)
             current < total
         }
         rusqlite_migration::SchemaVersion::Outside(_) => false,
@@ -834,5 +835,83 @@ mod tests {
             )
             .unwrap();
         assert!(chat_url.is_none());
+    }
+
+    fn transcript_hits(conn: &Connection, query: &str) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM transcript_fts WHERE transcript_fts MATCH ?1",
+            [query],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    fn assert_fts_consistent(conn: &Connection) {
+        for report in crate::db::integrity::check_fts_indexes(conn).unwrap() {
+            assert_eq!(
+                report.state,
+                crate::db::integrity::FtsIndexState::Consistent,
+                "{}",
+                report.table
+            );
+        }
+    }
+
+    /// Fixing the write path only helps rows written after the fix. Every
+    /// database in existence already holds utterances that an interrupted sync
+    /// committed without ever indexing (#97), so v014 has to repair them too.
+    #[test]
+    fn v014_rebuilds_an_index_that_drifted_before_it_existed() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mut conn = Connection::open(&db_path).unwrap();
+
+        migrations().to_version(&mut conn, 13).unwrap();
+
+        // Exactly the shape an interrupted sync left behind: source rows
+        // committed, the trailing FTS insert never reached.
+        conn.execute("INSERT INTO documents (id, title) VALUES ('doc1', 'Test')", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text)
+             VALUES ('u1', 'doc1', 'deployment rollback')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            transcript_hits(&conn, "rollback"),
+            0,
+            "precondition: at v013 nothing indexed the row"
+        );
+
+        migrations().to_latest(&mut conn).unwrap();
+
+        assert_eq!(
+            transcript_hits(&conn, "rollback"),
+            1,
+            "v014 should have rebuilt the index from the source table"
+        );
+        assert_fts_consistent(&conn);
+    }
+
+    /// The other half of v014: after it, a row cannot be written without being
+    /// indexed, because the trigger does it in the same statement.
+    #[test]
+    fn v014_installs_triggers_that_index_writes() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+        let conn = open_and_migrate(&db_path).unwrap();
+
+        conn.execute("INSERT INTO documents (id, title) VALUES ('doc1', 'Test')", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text)
+             VALUES ('u1', 'doc1', 'deployment rollback')",
+            [],
+        )
+        .unwrap();
+
+        assert_eq!(transcript_hits(&conn, "rollback"), 1);
+        assert_fts_consistent(&conn);
     }
 }

--- a/src/db/migrations/v015_fts_triggers.sql
+++ b/src/db/migrations/v015_fts_triggers.sql
@@ -1,0 +1,64 @@
+-- Maintain the FTS5 indexes with triggers, and rebuild what has already drifted.
+--
+-- transcript_fts and panels_fts were maintained by hand: db/transcripts.rs and
+-- db/panels.rs deleted the index rows, deleted the source rows, inserted the new
+-- source rows, then indexed them. Four statements in autocommit with no
+-- transaction around them, and the index write came last. Anything that stopped
+-- the process in between -- Ctrl-C during a sync, a crash, a dropped connection
+-- mid-loop -- committed source rows that nothing ever indexed. On a 449 MB
+-- database that left roughly one utterance in 1500 unfindable with zero orphaned
+-- index entries, which is the signature an interruption leaves and not the one a
+-- stale-index bug would (#97).
+--
+-- A trigger writes the index entry in the same statement as the row itself, so
+-- there is no window to be interrupted in and no code path left that could
+-- forget. This is SQLite's documented pattern for external-content FTS5 tables.
+--
+-- notes_fts is deliberately untouched. Nothing has ever populated it in
+-- production, so it needs a write path before triggers or a rebuild would mean
+-- anything, and turning it on changes what search returns. That is #85.
+
+-- Heal indexes that drifted before the triggers existed. 'rebuild' discards the
+-- index and re-derives it from the content table, so this is a no-op in effect
+-- on a database that was already consistent, and the only repair available to
+-- one that was not.
+INSERT INTO transcript_fts(transcript_fts) VALUES('rebuild');
+INSERT INTO panels_fts(panels_fts) VALUES('rebuild');
+
+-- 'delete' takes the column values as they were indexed, which is why the
+-- delete and update triggers pass `old`: re-reading the content table (what a
+-- bare DELETE FROM transcript_fts does) reads whatever is there now, which is
+-- not necessarily what the index holds.
+DROP TRIGGER IF EXISTS transcript_utterances_ai;
+CREATE TRIGGER transcript_utterances_ai AFTER INSERT ON transcript_utterances BEGIN
+    INSERT INTO transcript_fts(rowid, text) VALUES (new.rowid, new.text);
+END;
+
+DROP TRIGGER IF EXISTS transcript_utterances_ad;
+CREATE TRIGGER transcript_utterances_ad AFTER DELETE ON transcript_utterances BEGIN
+    INSERT INTO transcript_fts(transcript_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+END;
+
+DROP TRIGGER IF EXISTS transcript_utterances_au;
+CREATE TRIGGER transcript_utterances_au AFTER UPDATE ON transcript_utterances BEGIN
+    INSERT INTO transcript_fts(transcript_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+    INSERT INTO transcript_fts(rowid, text) VALUES (new.rowid, new.text);
+END;
+
+DROP TRIGGER IF EXISTS panels_ai;
+CREATE TRIGGER panels_ai AFTER INSERT ON panels BEGIN
+    INSERT INTO panels_fts(rowid, content_markdown) VALUES (new.rowid, new.content_markdown);
+END;
+
+DROP TRIGGER IF EXISTS panels_ad;
+CREATE TRIGGER panels_ad AFTER DELETE ON panels BEGIN
+    INSERT INTO panels_fts(panels_fts, rowid, content_markdown)
+        VALUES('delete', old.rowid, old.content_markdown);
+END;
+
+DROP TRIGGER IF EXISTS panels_au;
+CREATE TRIGGER panels_au AFTER UPDATE ON panels BEGIN
+    INSERT INTO panels_fts(panels_fts, rowid, content_markdown)
+        VALUES('delete', old.rowid, old.content_markdown);
+    INSERT INTO panels_fts(rowid, content_markdown) VALUES (new.rowid, new.content_markdown);
+END;

--- a/src/db/panels.rs
+++ b/src/db/panels.rs
@@ -244,7 +244,7 @@ pub fn insert_panels_from_api(
 
     // One transaction for the whole replace, so an interrupted sync leaves the
     // document with its old panels rather than a half-written set. panels_fts
-    // needs no handling here: the v014 triggers index each row in the same
+    // needs no handling here: the v015 triggers index each row in the same
     // statement that writes it.
     let tx = conn
         .unchecked_transaction()
@@ -532,7 +532,7 @@ mod tests {
 
     /// The panels index was maintained the same hand-rolled way transcripts
     /// were, in a statement after the source rows had already been committed
-    /// (#97). The v014 triggers make the index entry part of the write.
+    /// (#97). The v015 triggers make the index entry part of the write.
     #[test]
     fn writing_a_panel_indexes_it_without_a_separate_step() {
         let conn = build_test_db(&panels_state());

--- a/src/db/panels.rs
+++ b/src/db/panels.rs
@@ -242,22 +242,21 @@ pub fn insert_panels_from_api(
         anyhow::bail!("Document {} not found in database", document_id);
     }
 
-    // Delete from FTS index first
-    conn.execute(
-        "DELETE FROM panels_fts WHERE rowid IN (
-            SELECT rowid FROM panels WHERE document_id = ?1
-        )",
-        [document_id],
-    )
-    .ok();
+    // One transaction for the whole replace, so an interrupted sync leaves the
+    // document with its old panels rather than a half-written set. panels_fts
+    // needs no handling here: the v014 triggers index each row in the same
+    // statement that writes it.
+    let tx = conn
+        .unchecked_transaction()
+        .context("Failed to begin panel replacement")?;
 
     // Delete existing panels for this document
-    conn.execute(
+    tx.execute(
         "DELETE FROM panels WHERE document_id = ?1",
         [document_id],
     )?;
 
-    let mut stmt = conn.prepare(
+    let mut stmt = tx.prepare(
         "INSERT INTO panels (id, document_id, title, content_json, content_markdown,
                              original_content_json, template_slug,
                              created_at, updated_at, deleted_at, extra_json, chat_url,
@@ -290,12 +289,9 @@ pub fn insert_panels_from_api(
         inserted += 1;
     }
 
-    // Update FTS index for the new panels
-    conn.execute(
-        "INSERT INTO panels_fts(rowid, content_markdown)
-         SELECT rowid, content_markdown FROM panels WHERE document_id = ?1",
-        [document_id],
-    )?;
+    drop(stmt);
+    tx.commit()
+        .context("Failed to commit panel replacement")?;
 
     Ok(inserted)
 }
@@ -523,6 +519,53 @@ mod tests {
 
         // New content should be searchable
         assert_eq!(fts_count("quantum mechanics"), 1);
+
+        for report in crate::db::integrity::check_fts_indexes(&conn).unwrap() {
+            assert_eq!(
+                report.state,
+                crate::db::integrity::FtsIndexState::Consistent,
+                "{}",
+                report.table
+            );
+        }
+    }
+
+    /// The panels index was maintained the same hand-rolled way transcripts
+    /// were, in a statement after the source rows had already been committed
+    /// (#97). The v014 triggers make the index entry part of the write.
+    #[test]
+    fn writing_a_panel_indexes_it_without_a_separate_step() {
+        let conn = build_test_db(&panels_state());
+
+        let hits = |query: &str| -> i64 {
+            conn.query_row(
+                "SELECT COUNT(*) FROM panels_fts WHERE panels_fts MATCH ?1",
+                [query],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+
+        conn.execute(
+            "INSERT INTO panels (id, document_id, content_markdown)
+             VALUES ('panel-bare', 'doc-1', 'photosynthesis')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(hits("photosynthesis"), 1, "the insert alone should index it");
+
+        conn.execute("DELETE FROM panels WHERE id = 'panel-bare'", [])
+            .unwrap();
+        assert_eq!(hits("photosynthesis"), 0, "the delete alone should unindex it");
+
+        for report in crate::db::integrity::check_fts_indexes(&conn).unwrap() {
+            assert_eq!(
+                report.state,
+                crate::db::integrity::FtsIndexState::Consistent,
+                "{}",
+                report.table
+            );
+        }
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -32,5 +32,6 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
     conn.execute_batch(include_str!("migrations/v012_rename_is_primary_to_primary.sql"))?;
     conn.execute_batch(include_str!("migrations/v013_api_snapshot.sql"))?;
     conn.execute_batch(include_str!("migrations/v014_utterance_speaker_name.sql"))?;
+    conn.execute_batch(include_str!("migrations/v015_fts_triggers.sql"))?;
     Ok(())
 }

--- a/src/db/test_fixtures.rs
+++ b/src/db/test_fixtures.rs
@@ -438,10 +438,12 @@ pub fn build_test_db(state: &Value) -> Connection {
         }
     }
 
-    // Populate FTS indexes
-    conn.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('rebuild')", []).unwrap();
+    // transcript_fts and panels_fts were indexed by their triggers as the rows
+    // above went in, the same way production indexes them. Rebuilding here would
+    // hide a broken trigger behind a fixture, which is how #85 went unnoticed.
+    //
+    // notes_fts has no write path at all yet (#85), so it still needs this.
     conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')", []).unwrap();
-    conn.execute("INSERT INTO panels_fts(panels_fts) VALUES('rebuild')", []).unwrap();
 
     conn
 }

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -257,7 +257,7 @@ pub fn insert_transcript_from_api(
 
     // One transaction for the whole replace, so an interrupted sync leaves the
     // document with its old transcript rather than a half-written one.
-    // transcript_fts needs no handling here: the v014 triggers index each row in
+    // transcript_fts needs no handling here: the v015 triggers index each row in
     // the same statement that writes it.
     let tx = conn
         .unchecked_transaction()
@@ -514,7 +514,7 @@ mod tests {
     /// Indexing used to be a statement of its own that ran after the source rows
     /// had already been committed, with no transaction around either. Anything
     /// that stopped the process in between left rows nothing would ever index,
-    /// and search could not find them again (#97). The v014 triggers make the
+    /// and search could not find them again (#97). The v015 triggers make the
     /// index entry part of the write, so there is no such window and no code
     /// path that can skip it.
     #[test]

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -255,23 +255,22 @@ pub fn insert_transcript_from_api(
         anyhow::bail!("Document {} not found in database", document_id);
     }
 
-    // Delete from FTS index first (before deleting from source table)
-    // The FTS table is content-synced, so we need to handle this specially
-    conn.execute(
-        "DELETE FROM transcript_fts WHERE rowid IN (
-            SELECT rowid FROM transcript_utterances WHERE document_id = ?1
-        )",
-        [document_id],
-    ).ok(); // Ignore errors if already deleted
+    // One transaction for the whole replace, so an interrupted sync leaves the
+    // document with its old transcript rather than a half-written one.
+    // transcript_fts needs no handling here: the v014 triggers index each row in
+    // the same statement that writes it.
+    let tx = conn
+        .unchecked_transaction()
+        .context("Failed to begin transcript replacement")?;
 
     // Delete existing transcripts for this document
-    conn.execute(
+    tx.execute(
         "DELETE FROM transcript_utterances WHERE document_id = ?1",
         [document_id],
     )?;
 
     // Insert new utterances with 'api' source
-    let mut stmt = conn.prepare(
+    let mut stmt = tx.prepare(
         "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, transcript_source, source, is_final, api_snapshot, speaker_name)
          VALUES (?1, ?2, ?3, ?4, ?5, 'api', ?6, ?7, ?8, ?9)",
     )?;
@@ -299,12 +298,9 @@ pub fn insert_transcript_from_api(
         inserted += 1;
     }
 
-    // Update FTS index for the new utterances
-    conn.execute(
-        "INSERT INTO transcript_fts(rowid, text)
-         SELECT rowid, text FROM transcript_utterances WHERE document_id = ?1",
-        [document_id],
-    )?;
+    drop(stmt);
+    tx.commit()
+        .context("Failed to commit transcript replacement")?;
 
     Ok(inserted)
 }
@@ -502,6 +498,66 @@ mod tests {
 
         // NEW text SHOULD be searchable
         assert_eq!(fts_count("quantum computing"), 1, "Should find 'quantum computing' after replacement");
+
+        // And the index agrees with the source, which the old hand-maintained
+        // path could not promise.
+        for report in crate::db::integrity::check_fts_indexes(&conn).unwrap() {
+            assert_eq!(
+                report.state,
+                crate::db::integrity::FtsIndexState::Consistent,
+                "{}",
+                report.table
+            );
+        }
+    }
+
+    /// Indexing used to be a statement of its own that ran after the source rows
+    /// had already been committed, with no transaction around either. Anything
+    /// that stopped the process in between left rows nothing would ever index,
+    /// and search could not find them again (#97). The v014 triggers make the
+    /// index entry part of the write, so there is no such window and no code
+    /// path that can skip it.
+    #[test]
+    fn writing_an_utterance_indexes_it_without_a_separate_step() {
+        let conn = build_test_db(&transcripts_state());
+
+        let hits = |query: &str| -> i64 {
+            conn.query_row(
+                "SELECT COUNT(*) FROM transcript_fts WHERE transcript_fts MATCH ?1",
+                [query],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text)
+             VALUES ('u-bare', 'doc-1', 'photosynthesis')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(hits("photosynthesis"), 1, "the insert alone should index it");
+
+        conn.execute(
+            "UPDATE transcript_utterances SET text = 'respiration' WHERE id = 'u-bare'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(hits("photosynthesis"), 0, "the update should unindex the old text");
+        assert_eq!(hits("respiration"), 1, "the update should index the new text");
+
+        conn.execute("DELETE FROM transcript_utterances WHERE id = 'u-bare'", [])
+            .unwrap();
+        assert_eq!(hits("respiration"), 0, "the delete alone should unindex it");
+
+        for report in crate::db::integrity::check_fts_indexes(&conn).unwrap() {
+            assert_eq!(
+                report.state,
+                crate::db::integrity::FtsIndexState::Consistent,
+                "{}",
+                report.table
+            );
+        }
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -245,6 +245,33 @@ fn create_test_tables(conn: &Connection) {
             content_rowid='rowid'
         );
 
+        -- Must mirror v014_fts_triggers.sql. Without these, rows inserted below
+        -- land in the source tables and never reach the index, so every search
+        -- assertion in tests/ would be testing an empty index.
+        CREATE TRIGGER transcript_utterances_ai AFTER INSERT ON transcript_utterances BEGIN
+            INSERT INTO transcript_fts(rowid, text) VALUES (new.rowid, new.text);
+        END;
+        CREATE TRIGGER transcript_utterances_ad AFTER DELETE ON transcript_utterances BEGIN
+            INSERT INTO transcript_fts(transcript_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+        END;
+        CREATE TRIGGER transcript_utterances_au AFTER UPDATE ON transcript_utterances BEGIN
+            INSERT INTO transcript_fts(transcript_fts, rowid, text) VALUES('delete', old.rowid, old.text);
+            INSERT INTO transcript_fts(rowid, text) VALUES (new.rowid, new.text);
+        END;
+
+        CREATE TRIGGER panels_ai AFTER INSERT ON panels BEGIN
+            INSERT INTO panels_fts(rowid, content_markdown) VALUES (new.rowid, new.content_markdown);
+        END;
+        CREATE TRIGGER panels_ad AFTER DELETE ON panels BEGIN
+            INSERT INTO panels_fts(panels_fts, rowid, content_markdown)
+                VALUES('delete', old.rowid, old.content_markdown);
+        END;
+        CREATE TRIGGER panels_au AFTER UPDATE ON panels BEGIN
+            INSERT INTO panels_fts(panels_fts, rowid, content_markdown)
+                VALUES('delete', old.rowid, old.content_markdown);
+            INSERT INTO panels_fts(rowid, content_markdown) VALUES (new.rowid, new.content_markdown);
+        END;
+
         -- Set schema version via user_version pragma (used by rusqlite_migration)
         PRAGMA user_version = 14;
         "#,
@@ -475,10 +502,15 @@ fn insert_test_data(conn: &Connection, state: &serde_json::Value) {
         }
     }
 
-    // Populate FTS indexes
-    conn.execute("INSERT INTO transcript_fts(transcript_fts) VALUES('rebuild')", []).unwrap();
+    // transcript_fts and panels_fts are already populated: the triggers in
+    // create_test_tables indexed each row as it was inserted, which is the same
+    // path production takes. Rebuilding them here would paper over a broken
+    // trigger, which is the mistake #85 documents.
+    //
+    // notes_fts still needs the explicit rebuild, because nothing populates it
+    // anywhere -- that is the bug in #85, and until it is fixed this is what
+    // makes `--in notes` return anything in tests.
     conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')", []).unwrap();
-    conn.execute("INSERT INTO panels_fts(panels_fts) VALUES('rebuild')", []).unwrap();
 }
 
 /// Build a fixture state with known, deterministic data.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -245,7 +245,7 @@ fn create_test_tables(conn: &Connection) {
             content_rowid='rowid'
         );
 
-        -- Must mirror v014_fts_triggers.sql. Without these, rows inserted below
+        -- Must mirror v015_fts_triggers.sql. Without these, rows inserted below
         -- land in the source tables and never reach the index, so every search
         -- assertion in tests/ would be testing an empty index.
         CREATE TRIGGER transcript_utterances_ai AFTER INSERT ON transcript_utterances BEGIN


### PR DESCRIPTION
## Root cause

Not a stale-index bug. `db/transcripts.rs` and `db/panels.rs` maintained their FTS index by hand:

1. `DELETE FROM transcript_fts WHERE rowid IN (...)` (with `.ok()`, discarding failures)
2. `DELETE FROM transcript_utterances WHERE document_id = ?`
3. `INSERT INTO transcript_utterances ...` once per utterance
4. `INSERT INTO transcript_fts(rowid, text) SELECT ...`

Four statements in autocommit, no transaction around them, and **the index write came last**. Anything that stopped the process between 3 and 4 (Ctrl-C during a sync, a crash, a connection dropped mid-loop) committed source rows that nothing ever indexed.

That predicts a specific signature, and it is the one the issue measured: rows present in the source and absent from the index, with **zero orphans**. A stale-index bug produces orphans; an interruption cannot. Reproduced in isolation:

```
source committed, trailing FTS insert never ran: FAIL -> database disk image is malformed
  rows in source: 2
  findable via FTS: 0
  orphaned index rowids: 0
```

## Fix: the trigger, not a bigger rebuild

`v015_fts_triggers.sql` does both halves.

**Prevention.** Triggers on `transcript_utterances` and `panels`, the pattern SQLite documents for external-content FTS5 tables. The index entry is written in the same statement as the row, so there is no window to be interrupted in and no code path that can forget. The delete and update triggers use FTS5's `'delete'` command with `old.*`, which passes the values as they were indexed, rather than re-reading the content table for whatever is there now.

**Repair.** A one-time `'rebuild'` of `transcript_fts` and `panels_fts`. Fixing the write path only helps rows written after the fix; every existing database already holds stranded rows.

`insert_transcript_from_api` and `insert_panels_from_api` lose their FTS statements entirely (including the `.ok()` swallow) and gain a transaction around the replace, so an interrupted sync now leaves the old transcript rather than half of a new one.

## Verified on the real database

456 MB, 515,606 utterances, copied to an isolated `XDG_DATA_HOME`.

```
BEFORE (pre-migration backup)
  source utterances:          515,606  (non-empty text: 515,606)
  rows present in the index:  515,369
  missing from the index:     237  (0.046%)
AFTER (v015 applied)
  source utterances:          515,606
  rows present in the index:  515,606
  missing from the index:     0  (0.000%)
```

Close to the ~0.07% the issue estimated by sampling. `transcript_fts` went from failing `integrity-check` at rank 1 to passing, and all six triggers are installed. **The whole migration took 1.8s wall clock including the automatic 456 MB pre-migration backup**, so the rebuild is not a cost worth warning users about.

Then round-tripped through the real API: deleted 9,527 utterances across two documents (index stayed consistent, so the delete triggers work), re-fetched them with `grans sync transcripts --limit 2`, count back to 515,606, index still consistent. `grep` returns rows normally afterwards.

## Detection: `admin db info`, not the pull gate

PR #96 recorded the gap as a characterization test in `db/integrity.rs`, with the note "closing this needs a writable connection". That turned out to be the deciding constraint rather than an aside: FTS5 spells its check as an `INSERT`, and SQLite refuses it on the read-only connection `check_pulled_database` opens by design.

```
read-only integrity-check -> OperationalError attempt to write a readonly database
```

So the check lives on the read-write side, which is also where the issue suggested it might belong:

```
$ grans admin db info
Database size: 0.19 MB (200704 bytes)
Status: exists
Schema version: 14
Documents: 1
Transcript utterances: 1
Search index transcript_fts: DRIFTED (database disk image is malformed) -- search under-reports; run 'grans admin db rebuild-fts' to repair
Search index panels_fts: consistent

$ grans admin db rebuild-fts
Rebuilt transcript_fts
Rebuilt panels_fts

$ grans admin db info
Search index transcript_fts: consistent
Search index panels_fts: consistent
```

The characterization test is rewritten rather than deleted: it now verifies the *reason* for the boundary (the read-only refusal) instead of pinning the gap, so the decision stays testable rather than becoming a comment.

`admin db info` also stops reporting a fossil as the schema version. It read a `metadata` row nothing has written since the migration system replaced it, and printed `3` for a database at `14`.

## Scope: notes_fts is left alone

The issue proposed widening the rebuild to all three FTS tables. This covers two.

`notes_fts` has no write path at all and has never been populated in production. Rebuilding it would make notes searchable for the first time, which is a user-visible retrieval change that #85 explicitly wants measured against the benchmark before it lands. Doing it here would deliver that change unmeasured and close #85 by accident. It is excluded from the triggers, the rebuild, and the health check, each with a comment pointing at #85.

## Why existing tests did not catch this

Both fixture builders ran `INSERT INTO <tbl>_fts(<tbl>_fts) VALUES('rebuild')` after inserting rows, so every test saw a freshly rebuilt index that production never had. A write path that indexed nothing would have looked perfect. Those rebuilds are removed for `transcript_fts` and `panels_fts`; rows now reach the index the same way they do in production, and the 75 integration tests pass on that basis. The `notes_fts` rebuild stays, because it is the only thing making `--in notes` return anything at all (#85, again).

New tests, each verified to fail against the corresponding half of the change:

| Test | Fails without |
|---|---|
| `v014_rebuilds_an_index_that_drifted_before_it_existed` | the `'rebuild'` statements |
| `v014_installs_triggers_that_index_writes` | the triggers |
| `writing_an_utterance_indexes_it_without_a_separate_step` | the triggers (`left: 0, right: 1`) |
| `writing_a_panel_indexes_it_without_a_separate_step` | the triggers |
| `reports_a_drifted_fts_index_as_drifted` | the new check |
| `rebuild_repairs_a_drifted_fts_index` | `rebuild_fts_indexes` |
| `the_fts_check_needs_a_writable_connection` | records why the pull gate is excluded |

Full suite from PowerShell, `cargo test --no-fail-fast`: 952 tests, all six binaries, exit 0.

## Heads up: three branches claim v015

`main` is at v013. This PR adds `v015_fts_triggers.sql`; PR #81 adds `v014_titles_fts.sql`; the unmerged `feature/native-speaker-attribution` branch adds `v014_utterance_speaker_name.sql` (and has already migrated the live database to `user_version` 14, which is why the measurement above had to rewind a copy to 13). Whichever two merge second need renumbering. They do not otherwise conflict.

Closes #97

https://claude.ai/code/session_014akTv9Sj4UZ7bQPDhXe5hn
