### PR TITLE
#103: Format the tree with rustfmt and gate it in CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# Commits that only reformat, so `git blame` walks past them to the change that
+# actually wrote the line.
+#
+# Configured per clone, not automatically:
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# GitHub's blame view honours this file without any setup.
+
+# #103: Format the whole tree with cargo fmt
+4f59b3f08da6241bc889a1a68a2ea144e5652591

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,39 @@ jobs:
           filters: |
             rust:
               - 'src/**'
+              - 'tests/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/workflows/ci.yml'
+
+  # Fast and independent of the project's own build, so it does not sit behind
+  # the matrix. Runs under the same filter as `test`, which is why 'tests/**'
+  # joined that filter: a PR touching only tests/*.rs previously matched nothing
+  # and skipped CI altogether, and it is exactly the kind of PR a formatting
+  # gate needs to see. platform-tests.yml has always listed 'tests/**'.
+  #
+  # This is the only formatting gate; there is deliberately no git hook. Rust
+  # convention is editor format-on-save (rust-analyzer's `editor.formatOnSave`)
+  # plus a CI check, and every hook option costs something a one-job gate does
+  # not: cargo-husky and rusty-hook write to .git/hooks as a build side effect,
+  # the pre-commit framework pulls Python into a Rust repo, and a committed
+  # .githooks/ needs `git config core.hooksPath` run in every clone.
+  fmt:
+    name: Formatting
+    needs: [changes]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check
 
   test:
     name: Tests (${{ matrix.os }})
@@ -277,17 +307,23 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, fmt]
     if: always()
     steps:
-      - name: Report aggregate test result
+      - name: Report aggregate result
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+          FMT_RESULT: ${{ needs.fmt.result }}
         run: |
-          result="${{ needs.test.result }}"
           # `skipped` is a non-Rust PR the paths filter excluded. Anything
           # other than that or a clean pass has to hold the merge, cancelled
           # runs included -- this job is the gate, so it cannot wave through
           # a result it never saw.
-          case "$result" in
-            success | skipped) ;;
-            *) echo "Tests: $result"; exit 1 ;;
-          esac
+          failed=0
+          for job in "Tests:$TEST_RESULT" "Formatting:$FMT_RESULT"; do
+            case "${job#*:}" in
+              success | skipped) ;;
+              *) echo "${job%%:*} ${job#*:}"; failed=1 ;;
+            esac
+          done
+          exit "$failed"

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -4,7 +4,7 @@
 //! grans's own session and, off macOS, `super::local_store` reads the one
 //! Granola's desktop app stored. This module is the order they are tried in.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use chrono::Utc;
 use log::debug;
 
@@ -229,7 +229,11 @@ mod tests {
 
     // --- refresh chain ---
 
-    fn stored(refresh_token: &str, access_token: Option<&str>, expires_at: Option<i64>) -> GranolaCredentials {
+    fn stored(
+        refresh_token: &str,
+        access_token: Option<&str>,
+        expires_at: Option<i64>,
+    ) -> GranolaCredentials {
         GranolaCredentials {
             refresh_token: refresh_token.to_string(),
             access_token: access_token.map(str::to_string),
@@ -286,8 +290,8 @@ mod tests {
         let creds = stored("refresh-dead", None, None);
         store.save(&creds).unwrap();
 
-        let err = refresh_and_persist(creds, 1_000, &store, |_| bail!("token expired"))
-            .unwrap_err();
+        let err =
+            refresh_and_persist(creds, 1_000, &store, |_| bail!("token expired")).unwrap_err();
 
         assert!(err.to_string().contains("grans auth login"));
     }
@@ -300,11 +304,15 @@ mod tests {
         let store = CredentialStore::file(dir.path().join("auth.toml"));
         let ours = stored("refresh-old", None, None);
         store
-            .save(&stored("refresh-rotated", Some("access-from-other-run"), Some(9_000)))
+            .save(&stored(
+                "refresh-rotated",
+                Some("access-from-other-run"),
+                Some(9_000),
+            ))
             .unwrap();
 
-        let token = refresh_and_persist(ours, 1_000, &store, |_| bail!("token already used"))
-            .unwrap();
+        let token =
+            refresh_and_persist(ours, 1_000, &store, |_| bail!("token already used")).unwrap();
 
         assert_eq!(token, "access-from-other-run");
     }
@@ -352,5 +360,4 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(attempts.get(), 1);
     }
-
 }

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -7,14 +7,12 @@ use rand::Rng;
 use thiserror::Error;
 
 use super::types::{
-    ApiPanel, GetDocumentsRequest, GetDocumentsResponse, GetDocumentPanelsRequest,
+    ApiPanel, GetDocumentPanelsRequest, GetDocumentsRequest, GetDocumentsResponse,
     GetPanelTemplatesRequest, GetPeopleRequest, GetRecipesRequest, GetRecipesResponse,
     GetSelectedCalendarsRequest, GetSelectedCalendarsResponse, GetTranscriptRequest,
     RefreshCalendarEventsRequest, RefreshCalendarEventsResponse, TranscriptResponse,
 };
-use crate::models::{
-    CalendarEvent, Document, PanelTemplate, Person, TranscriptUtterance,
-};
+use crate::models::{CalendarEvent, Document, PanelTemplate, Person, TranscriptUtterance};
 
 const API_V1_URL: &str = "https://api.granola.ai/v1";
 const API_V2_URL: &str = "https://api.granola.ai/v2";
@@ -39,7 +37,9 @@ fn truncate_for_log(s: &str, max_len: usize) -> String {
 
 #[derive(Debug, Error)]
 pub enum ApiError {
-    #[error("Authentication failed (401). Your token may have expired. Please re-login to Granola.")]
+    #[error(
+        "Authentication failed (401). Your token may have expired. Please re-login to Granola."
+    )]
     Unauthorized,
 
     #[error("Resource not found (404). The requested resource may not exist.")]
@@ -128,9 +128,9 @@ impl ApiClient {
         match status.as_u16() {
             200 => {
                 // Read body as text first so we can include it in error messages
-                let body = response
-                    .text()
-                    .map_err(|e| ApiError::InvalidResponse(format!("failed to read body: {}", e)))?;
+                let body = response.text().map_err(|e| {
+                    ApiError::InvalidResponse(format!("failed to read body: {}", e))
+                })?;
                 debug!("  response body: {} bytes", body.len());
                 debug!("  response preview: {}", truncate_for_log(&body, 200));
                 serde_json::from_str(&body).map_err(|e| {
@@ -149,7 +149,10 @@ impl ApiClient {
                             if start < body.len() {
                                 format!(
                                     "Context around column {} (chars {}-{}):\n...{}...",
-                                    col, start, end, safe_slice(&body, start, end)
+                                    col,
+                                    start,
+                                    end,
+                                    safe_slice(&body, start, end)
                                 )
                             } else {
                                 format!("Column {} is beyond body length {}", col, body.len())
@@ -190,7 +193,11 @@ impl ApiClient {
             }
             _ => {
                 let body = response.text().unwrap_or_default();
-                debug!("  server error ({}): {}", status.as_u16(), truncate_for_log(&body, 500));
+                debug!(
+                    "  server error ({}): {}",
+                    status.as_u16(),
+                    truncate_for_log(&body, 500)
+                );
                 Err(ApiError::ServerError(status.as_u16(), body))
             }
         }
@@ -229,12 +236,10 @@ impl ApiClient {
         match status.as_u16() {
             200 => {
                 // API returns array directly, not wrapped in {"transcript": [...]}
-                let utterances: Vec<TranscriptUtterance> = response
-                    .json()
-                    .map_err(|e| {
-                        debug!("  deserialization error: {}", e);
-                        ApiError::InvalidResponse(e.to_string())
-                    })?;
+                let utterances: Vec<TranscriptUtterance> = response.json().map_err(|e| {
+                    debug!("  deserialization error: {}", e);
+                    ApiError::InvalidResponse(e.to_string())
+                })?;
                 debug!("  got {} utterances", utterances.len());
                 Ok(TranscriptResponse {
                     transcript: utterances,
@@ -254,7 +259,11 @@ impl ApiClient {
             }
             _ => {
                 let body = response.text().unwrap_or_default();
-                debug!("  server error ({}): {}", status.as_u16(), truncate_for_log(&body, 500));
+                debug!(
+                    "  server error ({}): {}",
+                    status.as_u16(),
+                    truncate_for_log(&body, 500)
+                );
                 Err(ApiError::ServerError(status.as_u16(), body))
             }
         }
@@ -297,10 +306,7 @@ impl ApiClient {
         let request = RefreshCalendarEventsRequest::default();
         let response: RefreshCalendarEventsResponse =
             self.post_v1("refresh-calendar-events", &request)?;
-        Ok(response
-            .results
-            .map(|r| r.events)
-            .unwrap_or_default())
+        Ok(response.results.map(|r| r.events).unwrap_or_default())
     }
 
     // ========================================================================
@@ -339,15 +345,15 @@ impl ApiClient {
 
 /// Convenience function to fetch a transcript with a given token
 pub fn fetch_transcript(token: &str, document_id: &str) -> Result<TranscriptResponse, ApiError> {
-    let client = ApiClient::new(token.to_string())
-        .map_err(|e| ApiError::NetworkError(e.to_string()))?;
+    let client =
+        ApiClient::new(token.to_string()).map_err(|e| ApiError::NetworkError(e.to_string()))?;
     client.fetch_transcript(document_id)
 }
 
 /// Convenience function to fetch panels with a given token
 pub fn fetch_panels(token: &str, document_id: &str) -> Result<Vec<ApiPanel>, ApiError> {
-    let client = ApiClient::new(token.to_string())
-        .map_err(|e| ApiError::NetworkError(e.to_string()))?;
+    let client =
+        ApiClient::new(token.to_string()).map_err(|e| ApiError::NetworkError(e.to_string()))?;
     client.fetch_panels(document_id)
 }
 
@@ -430,7 +436,7 @@ mod tests {
     #[test]
     fn test_safe_slice_utf8_multibyte() {
         // Each emoji is 4 bytes
-        let s = "a😀b😀c";  // bytes: a(1) + 😀(4) + b(1) + 😀(4) + c(1) = 11 bytes
+        let s = "a😀b😀c"; // bytes: a(1) + 😀(4) + b(1) + 😀(4) + c(1) = 11 bytes
 
         // Slicing at byte 1 would be mid-emoji without safe_slice
         // safe_slice should adjust to valid boundaries

--- a/src/api/credential_store.rs
+++ b/src/api/credential_store.rs
@@ -149,7 +149,10 @@ impl CredentialStore {
             return Ok(None);
         };
 
-        debug!("Moving credentials from {} into the keychain", path.display());
+        debug!(
+            "Moving credentials from {} into the keychain",
+            path.display()
+        );
         self.save(&credentials)?;
         delete_file(&path)?;
 
@@ -205,14 +208,16 @@ fn open_up_pinned_item(json: &str) {
     match keychain_acl::open_up_existing(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT, json.as_bytes()) {
         Ok(true) => debug!("Reset the keychain entry's ACL; later reads will not be challenged"),
         Ok(false) => {}
-        Err(e) => warn!("Could not stop the keychain challenging every read: {:#}", e),
+        Err(e) => warn!(
+            "Could not stop the keychain challenging every read: {:#}",
+            e
+        ),
     }
 }
 
 /// Nothing to do: no other platform ties reads to the caller's code signature.
 #[cfg(not(target_os = "macos"))]
 fn open_up_pinned_item(_json: &str) {}
-
 
 /// Write the secret so the next build of grans can still read it.
 ///

--- a/src/api/granola_auth.rs
+++ b/src/api/granola_auth.rs
@@ -12,7 +12,7 @@
 
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use log::debug;
 use serde::Deserialize;
 use url::Url;
@@ -205,11 +205,7 @@ pub fn check_client_version_accepted(auth_url: &str) -> Result<()> {
 /// Unauthenticated, which is what makes bootstrapping a session possible.
 /// `started_with` is the click id grans sent when it built the auth URL, used
 /// only when the callback did not restate it.
-pub fn exchange_code(
-    callback: &Callback,
-    verifier: &str,
-    started_with: &str,
-) -> Result<TokenSet> {
+pub fn exchange_code(callback: &Callback, verifier: &str, started_with: &str) -> Result<TokenSet> {
     let body = serde_json::json!({
         "code": callback.code,
         "codeVerifier": verifier,
@@ -222,9 +218,8 @@ pub fn exchange_code(
     let response = post_json(AUTH_COMPLETE_URL, &body, None)
         .context("Failed to exchange the authorization code")?;
 
-    extract_token_set(&response).context(
-        "Granola's response to the code exchange did not contain the expected tokens",
-    )
+    extract_token_set(&response)
+        .context("Granola's response to the code exchange did not contain the expected tokens")
 }
 
 /// Exchange a refresh token for a new token set.
@@ -246,11 +241,7 @@ pub fn refresh_tokens(access_token: Option<&str>, refresh_token: &str) -> Result
 }
 
 /// POST JSON to a Granola auth endpoint and return the response body.
-fn post_json(
-    url: &str,
-    body: &serde_json::Value,
-    bearer: Option<&str>,
-) -> Result<String> {
+fn post_json(url: &str, body: &serde_json::Value, bearer: Option<&str>) -> Result<String> {
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
         .build()
@@ -351,7 +342,11 @@ fn describe_json_shape(value: &serde_json::Value, depth: usize) -> String {
         }
         serde_json::Value::Array(items) => match items.first() {
             Some(_) if depth == 0 => format!("[{} items]", items.len()),
-            Some(first) => format!("[{}; {}]", describe_json_shape(first, depth - 1), items.len()),
+            Some(first) => format!(
+                "[{}; {}]",
+                describe_json_shape(first, depth - 1),
+                items.len()
+            ),
             None => "[]".to_string(),
         },
         serde_json::Value::String(_) => "string".to_string(),
@@ -503,8 +498,7 @@ mod tests {
     fn test_extract_token_set_from_double_encoded_string() {
         // Granola writes workos_tokens as encoded JSON in its own token store,
         // so the API is assumed capable of the same shape.
-        let body =
-            r#"{"workos_tokens": "{\"access_token\":\"at\",\"refresh_token\":\"rt\"}"}"#;
+        let body = r#"{"workos_tokens": "{\"access_token\":\"at\",\"refresh_token\":\"rt\"}"}"#;
 
         let tokens = extract_token_set(body).unwrap();
 

--- a/src/api/keychain_acl/mod.rs
+++ b/src/api/keychain_acl/mod.rs
@@ -48,7 +48,7 @@ mod sys;
 use std::ffi::c_void;
 use std::ptr;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use core_foundation::base::TCFType;
 use core_foundation::string::CFString;
 use core_foundation_sys::array::{CFArrayGetCount, CFArrayGetValueAtIndex, CFArrayRef};
@@ -62,10 +62,10 @@ use security_framework_sys::base::{
 };
 
 use sys::{
-    SecACLCopyContents, SecACLRef, SecACLSetContents, SecAccessCopyACLList, SecAccessCreate,
+    ACCOUNT_ATTR, GENERIC_PASSWORD_CLASS, ITEM_NOT_FOUND, SERVICE_ATTR, SecACLCopyContents,
+    SecACLRef, SecACLSetContents, SecAccessCopyACLList, SecAccessCreate,
     SecKeychainFindGenericPassword, SecKeychainItemCopyAccess, SecKeychainItemCreateFromContent,
-    SecKeychainItemDelete, SecKeychainPromptSelector, ACCOUNT_ATTR, GENERIC_PASSWORD_CLASS,
-    ITEM_NOT_FOUND, SERVICE_ATTR,
+    SecKeychainItemDelete, SecKeychainPromptSelector,
 };
 
 /// Store `secret` under `service`/`account` so any application can read it back
@@ -110,7 +110,12 @@ fn open_up(
 
 /// The same, against a specific keychain. Tests pass a throwaway one rather
 /// than touching the login keychain.
-fn store(keychain: Option<&SecKeychain>, service: &str, account: &str, secret: &[u8]) -> Result<()> {
+fn store(
+    keychain: Option<&SecKeychain>,
+    service: &str,
+    account: &str,
+    secret: &[u8],
+) -> Result<()> {
     if let Some(existing) = find_item(keychain, service, account)? {
         check(
             unsafe { SecKeychainItemDelete(existing.as_concrete_TypeRef()) },
@@ -196,7 +201,9 @@ fn find_item(
     }
     check(status, "look for grans's entry in the keychain")?;
 
-    Ok(Some(unsafe { SecKeychainItem::wrap_under_create_rule(item) }))
+    Ok(Some(unsafe {
+        SecKeychainItem::wrap_under_create_rule(item)
+    }))
 }
 
 /// Build an access object that challenges nobody.
@@ -352,7 +359,9 @@ mod tests {
     /// Whether the stored item would challenge a build of grans other than the
     /// one that wrote it.
     fn is_pinned(keychain: &SecKeychain) -> bool {
-        let item = find_item(Some(keychain), SERVICE, ACCOUNT).unwrap().unwrap();
+        let item = find_item(Some(keychain), SERVICE, ACCOUNT)
+            .unwrap()
+            .unwrap();
 
         names_applications(&item).unwrap()
     }
@@ -424,9 +433,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let keychain = keychain(&dir);
 
-        assert!(find_item(Some(&keychain), SERVICE, "nobody")
-            .unwrap()
-            .is_none());
+        assert!(
+            find_item(Some(&keychain), SERVICE, "nobody")
+                .unwrap()
+                .is_none()
+        );
     }
 
     // --- opening up what an older grans left behind ---

--- a/src/api/local_store.rs
+++ b/src/api/local_store.rs
@@ -9,7 +9,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use log::debug;
 use serde::Deserialize;
 
@@ -75,7 +75,10 @@ fn read_token_json(dir: &Path) -> Result<String> {
     if encrypted.exists() {
         debug!("Reading encrypted token store at {}", encrypted.display());
         return token_store::decrypt_token_json(dir).with_context(|| {
-            format!("Failed to read encrypted Granola token store in {}", dir.display())
+            format!(
+                "Failed to read encrypted Granola token store in {}",
+                dir.display()
+            )
         });
     }
 
@@ -99,7 +102,10 @@ fn extract_access_token(json: &str, dir: &Path) -> Result<String> {
         ))?;
 
     if token.is_empty() {
-        bail!("Access token is empty in Granola config at {}. Please re-login to Granola.", dir.display());
+        bail!(
+            "Access token is empty in Granola config at {}. Please re-login to Granola.",
+            dir.display()
+        );
     }
 
     debug!("Loaded auth token ({} chars)", token.len());
@@ -110,12 +116,14 @@ fn extract_access_token(json: &str, dir: &Path) -> Result<String> {
 /// directory qualifies if it contains either token store file.
 fn find_granola_dir() -> Result<PathBuf> {
     let candidates = granola_dir_candidates();
-    debug!("Searching for Granola config in {} locations", candidates.len());
+    debug!(
+        "Searching for Granola config in {} locations",
+        candidates.len()
+    );
 
     for candidate in &candidates {
         debug!("  checking: {}", candidate.display());
-        if candidate.join("supabase.json.enc").exists()
-            || candidate.join("supabase.json").exists()
+        if candidate.join("supabase.json.enc").exists() || candidate.join("supabase.json").exists()
         {
             debug!("  found: {}", candidate.display());
             return Ok(candidate.clone());
@@ -263,7 +271,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let config_path = dir.path().join("supabase.json");
 
-        std::fs::write(&config_path, r#"{"workos_tokens": {"access_token": "my-secret-token"}}"#).unwrap();
+        std::fs::write(
+            &config_path,
+            r#"{"workos_tokens": {"access_token": "my-secret-token"}}"#,
+        )
+        .unwrap();
 
         // We can't easily test get_auth_token() directly since it uses platform paths,
         // but we can test the parsing logic
@@ -287,9 +299,7 @@ mod tests {
         if let Some(candidates) = wsl_windows_granola_dirs() {
             for path in &candidates {
                 let path_str = path.to_string_lossy();
-                assert!(
-                    path_str.contains("/mnt/c/Users/") && path_str.ends_with("Granola")
-                );
+                assert!(path_str.contains("/mnt/c/Users/") && path_str.ends_with("Granola"));
             }
         }
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -16,6 +16,6 @@ pub mod local_store;
 mod token_store;
 pub mod types;
 
-pub use auth::{resolve_token, token_override, TOKEN_ENV_VAR};
-pub use client::{fetch_panels, fetch_transcript, ApiClient, ApiError};
+pub use auth::{TOKEN_ENV_VAR, resolve_token, token_override};
+pub use client::{ApiClient, ApiError, fetch_panels, fetch_transcript};
 pub use types::ApiPanel;

--- a/src/api/token_store.rs
+++ b/src/api/token_store.rs
@@ -21,7 +21,7 @@
 
 use aes_gcm::aead::Aead;
 use aes_gcm::{Aes256Gcm, Key, KeyInit, Nonce};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use base64::Engine;
 use log::debug;
 use std::path::Path;
@@ -65,8 +65,8 @@ pub fn decrypt_token_json(granola_dir: &Path) -> Result<String> {
 #[cfg(windows)]
 fn unseal_dek(granola_dir: &Path) -> Result<Vec<u8>> {
     let master = master_key(granola_dir)?;
-    let dek_blob = std::fs::read(granola_dir.join("storage.dek"))
-        .context("Failed to read storage.dek")?;
+    let dek_blob =
+        std::fs::read(granola_dir.join("storage.dek")).context("Failed to read storage.dek")?;
     // storage.dek is a "v10"-prefixed os_crypt GCM blob.
     gcm_open(&master, &dek_blob, 3).context("Failed to decrypt storage.dek")
 }
@@ -127,7 +127,7 @@ fn gcm_open(key: &[u8], blob: &[u8], prefix_len: usize) -> Result<Vec<u8>> {
 #[cfg(windows)]
 fn os_unwrap(blob: &[u8]) -> Result<Vec<u8>> {
     use windows_sys::Win32::Foundation::LocalFree;
-    use windows_sys::Win32::Security::Cryptography::{CryptUnprotectData, CRYPT_INTEGER_BLOB};
+    use windows_sys::Win32::Security::Cryptography::{CRYPT_INTEGER_BLOB, CryptUnprotectData};
 
     let mut input = CRYPT_INTEGER_BLOB {
         cbData: blob.len() as u32,
@@ -156,9 +156,7 @@ fn os_unwrap(blob: &[u8]) -> Result<Vec<u8>> {
     }
 
     // SAFETY: on success `output.pbData` is valid for `output.cbData` bytes.
-    let key = unsafe {
-        std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec()
-    };
+    let key = unsafe { std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec() };
     // SAFETY: freeing the buffer Windows allocated for us.
     unsafe { LocalFree(output.pbData as _) };
     Ok(key)
@@ -218,5 +216,4 @@ mod tests {
         let blob = seal(&[9u8; 32], &[1u8; NONCE_LEN], b"x", b"");
         assert!(gcm_open(&[0u8; 16], &blob, 0).is_err());
     }
-
 }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -251,7 +251,10 @@ mod tests {
         let doc: Document = serde_json::from_str(json).unwrap();
         assert_eq!(doc.id, Some("doc-1".to_string()));
         let people = doc.people.unwrap();
-        assert_eq!(people.creator.as_ref().unwrap().name, Some("Alice".to_string()));
+        assert_eq!(
+            people.creator.as_ref().unwrap().name,
+            Some("Alice".to_string())
+        );
         assert_eq!(people.attendees.as_ref().unwrap().len(), 1);
     }
 
@@ -338,7 +341,13 @@ mod tests {
         }"#;
 
         let response: GetSelectedCalendarsResponse = serde_json::from_str(json).unwrap();
-        assert!(response.calendars_selected.as_ref().unwrap().contains_key("user@example.com"));
+        assert!(
+            response
+                .calendars_selected
+                .as_ref()
+                .unwrap()
+                .contains_key("user@example.com")
+        );
         assert_eq!(response.enabled_calendars.as_ref().unwrap()[0], "google");
     }
 
@@ -399,7 +408,10 @@ mod tests {
         let recipe: Recipe = serde_json::from_str(json).unwrap();
         assert_eq!(recipe.id, Some("recipe-1".to_string()));
         assert_eq!(recipe.slug, Some("test-recipe".to_string()));
-        assert_eq!(recipe.config.as_ref().unwrap().model, Some("gpt-4o".to_string()));
+        assert_eq!(
+            recipe.config.as_ref().unwrap().model,
+            Some("gpt-4o".to_string())
+        );
     }
 
     #[test]
@@ -416,7 +428,10 @@ mod tests {
         let response: GetRecipesResponse = serde_json::from_str(json).unwrap();
         assert_eq!(response.default_recipes.len(), 0);
         assert_eq!(response.public_recipes.len(), 1);
-        assert_eq!(response.public_recipes[0].slug, Some("public-recipe".to_string()));
+        assert_eq!(
+            response.public_recipes[0].slug,
+            Some("public-recipe".to_string())
+        );
         assert_eq!(response.user_recipes.len(), 1);
         assert_eq!(response.user_recipes[0].slug, Some("my-recipe".to_string()));
         assert_eq!(response.shared_recipes.len(), 0);

--- a/src/cli/args/mod.rs
+++ b/src/cli/args/mod.rs
@@ -4,8 +4,9 @@ use crate::query::filter::SearchTarget;
 use crate::query::speaker::SpeakerSelector;
 
 fn parse_speaker_selector(s: &str) -> Result<SpeakerSelector, String> {
-    SpeakerSelector::parse(s)
-        .ok_or_else(|| "empty speaker filter: expected 'me', 'other', or a speaker's name".to_string())
+    SpeakerSelector::parse(s).ok_or_else(|| {
+        "empty speaker filter: expected 'me', 'other', or a speaker's name".to_string()
+    })
 }
 
 #[derive(Parser, Debug)]
@@ -397,7 +398,12 @@ pub enum BenchmarkAction {
         k: usize,
 
         /// Search mode to benchmark
-        #[arg(long, value_enum, default_value = "semantic", conflicts_with = "compare")]
+        #[arg(
+            long,
+            value_enum,
+            default_value = "semantic",
+            conflicts_with = "compare"
+        )]
         mode: QualityMode,
 
         /// Compare modes, e.g. fts,semantic: per-query rank table plus

--- a/src/cli/args/tests.rs
+++ b/src/cli/args/tests.rs
@@ -65,8 +65,7 @@ fn search_context_composes_with_other_flags() {
 
 #[test]
 fn search_min_score_parses() {
-    let cli =
-        Cli::try_parse_from(["grans", "search", "q", "--min-score", "0.4"]).unwrap();
+    let cli = Cli::try_parse_from(["grans", "search", "q", "--min-score", "0.4"]).unwrap();
     let Commands::Search { min_score, .. } = &cli.command else {
         panic!("expected search subcommand");
     };
@@ -77,17 +76,33 @@ fn search_min_score_parses() {
 fn search_min_score_conflicts_with_fast() {
     // Only the rerank stage produces the relevance score --min-score
     // thresholds, and --fast skips that stage.
-    let result =
-        Cli::try_parse_from(["grans", "search", "q", "--min-score", "0.4", "--fast"]);
+    let result = Cli::try_parse_from(["grans", "search", "q", "--min-score", "0.4", "--fast"]);
     assert!(result.is_err(), "--min-score --fast should conflict");
 }
 
 #[test]
 fn grep_parses_with_lookup_flags() {
     let cli = Cli::try_parse_from([
-        "grans", "grep", "kumquat", "--speaker", "me", "--in", "titles,transcripts",
-        "--meeting", "standup", "--context", "2", "--matches", "3", "--limit", "5",
-        "--from", "2026-01-01", "--to", "2026-02-01", "--include-deleted",
+        "grans",
+        "grep",
+        "kumquat",
+        "--speaker",
+        "me",
+        "--in",
+        "titles,transcripts",
+        "--meeting",
+        "standup",
+        "--context",
+        "2",
+        "--matches",
+        "3",
+        "--limit",
+        "5",
+        "--from",
+        "2026-01-01",
+        "--to",
+        "2026-02-01",
+        "--include-deleted",
     ])
     .unwrap();
     let Commands::Grep {
@@ -149,12 +164,16 @@ fn grep_in_rejects_an_unknown_target() {
     // `transcript` (singular typo) must fail loudly instead of collapsing to
     // an empty target set that greps nothing (#74). The error names the bad
     // value and lists the valid ones.
-    let err = Cli::try_parse_from(["grans", "grep", "budget", "--in", "transcript"])
-        .unwrap_err();
+    let err = Cli::try_parse_from(["grans", "grep", "budget", "--in", "transcript"]).unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("transcript"), "error should name the bad value: {msg}");
     assert!(
-        msg.contains("titles") && msg.contains("transcripts") && msg.contains("notes")
+        msg.contains("transcript"),
+        "error should name the bad value: {msg}"
+    );
+    assert!(
+        msg.contains("titles")
+            && msg.contains("transcripts")
+            && msg.contains("notes")
             && msg.contains("panels"),
         "error should list the valid targets: {msg}"
     );
@@ -165,7 +184,10 @@ fn grep_in_rejects_an_unknown_target_inside_a_valid_list() {
     // `titles,transcript` must not silently search titles only (#74); one
     // bad token fails the whole list.
     let result = Cli::try_parse_from(["grans", "grep", "budget", "--in", "titles,transcript"]);
-    assert!(result.is_err(), "an unknown token anywhere must fail the list");
+    assert!(
+        result.is_err(),
+        "an unknown token anywhere must fail the list"
+    );
 }
 
 #[test]
@@ -202,7 +224,9 @@ fn quality_compare(cli: &Cli) -> &[QualityMode] {
     }
 }
 
-fn embed_experiment_flags(cli: &Cli) -> (Option<usize>, Option<usize>, Option<String>, Option<bool>) {
+fn embed_experiment_flags(
+    cli: &Cli,
+) -> (Option<usize>, Option<usize>, Option<String>, Option<bool>) {
     match &cli.command {
         Commands::Embed {
             chunk_target_tokens,
@@ -242,14 +266,18 @@ fn embed_experiment_flags_parse() {
     .unwrap();
     assert_eq!(
         embed_experiment_flags(&cli),
-        (Some(192), Some(48), Some("utterances".to_string()), Some(true))
+        (
+            Some(192),
+            Some(48),
+            Some("utterances".to_string()),
+            Some(true)
+        )
     );
 }
 
 #[test]
 fn embed_contextual_headers_can_be_forced_off() {
-    let cli =
-        Cli::try_parse_from(["grans", "embed", "--contextual-headers=false"]).unwrap();
+    let cli = Cli::try_parse_from(["grans", "embed", "--contextual-headers=false"]).unwrap();
     assert_eq!(embed_experiment_flags(&cli).3, Some(false));
 }
 
@@ -261,24 +289,33 @@ fn embed_overlap_mode_rejects_unknown_value() {
 
 #[test]
 fn benchmark_quality_title_boost_weight_parses_and_defaults_to_none() {
-    let cli = Cli::try_parse_from([
-        "grans", "benchmark", "quality", "--file", "golden.json",
-    ])
-    .unwrap();
-    let Commands::Benchmark { action: BenchmarkAction::Quality { title_boost_weight, .. } } =
-        &cli.command
+    let cli =
+        Cli::try_parse_from(["grans", "benchmark", "quality", "--file", "golden.json"]).unwrap();
+    let Commands::Benchmark {
+        action: BenchmarkAction::Quality {
+            title_boost_weight, ..
+        },
+    } = &cli.command
     else {
         panic!("expected benchmark quality subcommand");
     };
     assert_eq!(*title_boost_weight, None);
 
     let cli = Cli::try_parse_from([
-        "grans", "benchmark", "quality", "--file", "golden.json",
-        "--title-boost-weight", "0.3",
+        "grans",
+        "benchmark",
+        "quality",
+        "--file",
+        "golden.json",
+        "--title-boost-weight",
+        "0.3",
     ])
     .unwrap();
-    let Commands::Benchmark { action: BenchmarkAction::Quality { title_boost_weight, .. } } =
-        &cli.command
+    let Commands::Benchmark {
+        action: BenchmarkAction::Quality {
+            title_boost_weight, ..
+        },
+    } = &cli.command
     else {
         panic!("expected benchmark quality subcommand");
     };
@@ -351,7 +388,10 @@ fn benchmark_quality_note_requires_record() {
 
 fn transcripts_action(cli: &Cli) -> &SyncAction {
     match &cli.command {
-        Commands::Sync { action: Some(action), .. } => action,
+        Commands::Sync {
+            action: Some(action),
+            ..
+        } => action,
         _ => panic!("expected sync subcommand"),
     }
 }
@@ -375,10 +415,11 @@ fn sync_transcripts_positional_conflicts_with_limit() {
 
 #[test]
 fn sync_transcripts_positional_allows_embed() {
-    let cli =
-        Cli::try_parse_from(["grans", "sync", "transcripts", "doc-1", "--embed"]).unwrap();
+    let cli = Cli::try_parse_from(["grans", "sync", "transcripts", "doc-1", "--embed"]).unwrap();
     match transcripts_action(&cli) {
-        SyncAction::Transcripts { document_id, embed, .. } => {
+        SyncAction::Transcripts {
+            document_id, embed, ..
+        } => {
             assert_eq!(document_id.as_deref(), Some("doc-1"));
             assert!(*embed);
         }
@@ -388,8 +429,7 @@ fn sync_transcripts_positional_allows_embed() {
 
 #[test]
 fn sync_transcripts_positional_allows_dry_run() {
-    let cli =
-        Cli::try_parse_from(["grans", "sync", "transcripts", "doc-1", "--dry-run"]).unwrap();
+    let cli = Cli::try_parse_from(["grans", "sync", "transcripts", "doc-1", "--dry-run"]).unwrap();
     match &cli.command {
         Commands::Sync { dry_run, .. } => assert!(*dry_run),
         _ => panic!("expected sync subcommand"),

--- a/src/cli/context.rs
+++ b/src/cli/context.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use chrono::FixedOffset;
 
-use crate::output::format::{detect_output_mode, OutputMode};
+use crate::output::format::{OutputMode, detect_output_mode};
 
 pub struct RunContext {
     pub output_mode: OutputMode,

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, BufRead, Write};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use chrono::{FixedOffset, TimeZone, Utc};
 
 use crate::api::credential_store::CredentialStore;

--- a/src/commands/benchmark/dump.rs
+++ b/src/commands/benchmark/dump.rs
@@ -30,7 +30,9 @@ impl CandidateDumpWriter {
     pub(super) fn create(path: &Path) -> Result<Self> {
         let file = File::create(path)
             .with_context(|| format!("Failed to create dump file: {}", path.display()))?;
-        Ok(Self { writer: BufWriter::new(file) })
+        Ok(Self {
+            writer: BufWriter::new(file),
+        })
     }
 
     pub(super) fn write_query(
@@ -73,8 +75,15 @@ mod tests {
         let path = dir.path().join("dump.jsonl");
 
         let mut writer = CandidateDumpWriter::create(&path).unwrap();
-        writer.write_query("first query", &[candidate("doc-a", 1), candidate("doc-b", 2)]).unwrap();
-        writer.write_query("second query", &[candidate("doc-c", 1)]).unwrap();
+        writer
+            .write_query(
+                "first query",
+                &[candidate("doc-a", 1), candidate("doc-b", 2)],
+            )
+            .unwrap();
+        writer
+            .write_query("second query", &[candidate("doc-c", 1)])
+            .unwrap();
         writer.finish().unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
@@ -87,7 +96,10 @@ mod tests {
         assert_eq!(first["candidates"][0]["document_id"], "doc-a");
         assert_eq!(first["candidates"][0]["fused_rank"], 1);
         assert_eq!(first["candidates"][0]["fused_score"], 0.016);
-        assert_eq!(first["candidates"][0]["passage"], "Title doc-a\n\nchunk text");
+        assert_eq!(
+            first["candidates"][0]["passage"],
+            "Title doc-a\n\nchunk text"
+        );
         assert_eq!(first["candidates"][0]["title"], "Title doc-a");
         assert_eq!(first["candidates"][0]["created_at"], "2026-01-02T10:00:00Z");
         assert!((first["candidates"][0]["rerank_score"].as_f64().unwrap() - 0.9).abs() < 1e-6);

--- a/src/commands/benchmark/ledger.rs
+++ b/src/commands/benchmark/ledger.rs
@@ -83,7 +83,8 @@ pub(super) fn record_run(ctx: &RecordContext, run: &ModeRun) -> Result<PathBuf> 
         db: ctx.db,
         run,
     };
-    let (run_path, rel_path) = write_unique(&runs_dir, &base, &serde_json::to_string_pretty(&run_file)?)?;
+    let (run_path, rel_path) =
+        write_unique(&runs_dir, &base, &serde_json::to_string_pretty(&run_file)?)?;
 
     let entry = LedgerEntry {
         date: ctx.date,
@@ -119,7 +120,11 @@ fn write_unique(dir: &Path, base: &str, content: &str) -> Result<(PathBuf, Strin
             format!("{}-{}.json", base, attempt)
         };
         let path = dir.join(&name);
-        match fs::OpenOptions::new().write(true).create_new(true).open(&path) {
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
             Ok(mut file) => {
                 file.write_all(content.as_bytes())
                     .with_context(|| format!("Failed to write run file: {}", path.display()))?;
@@ -128,7 +133,7 @@ fn write_unique(dir: &Path, base: &str, content: &str) -> Result<(PathBuf, Strin
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
                 return Err(e)
-                    .with_context(|| format!("Failed to create run file: {}", path.display()))
+                    .with_context(|| format!("Failed to create run file: {}", path.display()));
             }
         }
     }
@@ -241,7 +246,8 @@ mod tests {
         record_run(&ctx, &test_run("semantic")).unwrap();
 
         let ledger = fs::read_to_string(dir.path().join("ledger.jsonl")).unwrap();
-        let entry: serde_json::Value = serde_json::from_str(ledger.lines().next().unwrap()).unwrap();
+        let entry: serde_json::Value =
+            serde_json::from_str(ledger.lines().next().unwrap()).unwrap();
         assert!(entry.get("notes").is_none());
     }
 }

--- a/src/commands/benchmark/metrics.rs
+++ b/src/commands/benchmark/metrics.rs
@@ -352,11 +352,7 @@ mod tests {
         let a = qs(Some(1), 10, 1.0);
         let b = qs(None, 10, 0.0);
         let c = qs(Some(2), 10, 1.0);
-        let strata = vec![
-            ("exact-term", &a),
-            ("paraphrase", &b),
-            ("exact-term", &c),
-        ];
+        let strata = vec![("exact-term", &a), ("paraphrase", &b), ("exact-term", &c)];
         let by = aggregate_by_stratum(&strata);
 
         assert_eq!(by.len(), 2);

--- a/src/commands/benchmark/perf.rs
+++ b/src/commands/benchmark/perf.rs
@@ -2,7 +2,7 @@
 
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rand::prelude::*;
 use rusqlite::Connection;
 use serde::Serialize;
@@ -56,7 +56,9 @@ pub(super) fn run_semantic_search_benchmark(
     };
 
     if vectors.is_empty() {
-        bail!("No vectors available for benchmarking. Run `grans embed` first to generate embeddings, or use --synthetic mode.");
+        bail!(
+            "No vectors available for benchmarking. Run `grans embed` first to generate embeddings, or use --synthetic mode."
+        );
     }
 
     let actual_vector_count = vectors.len();

--- a/src/commands/benchmark/quality.rs
+++ b/src/commands/benchmark/quality.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::Path;
 use std::time::Instant;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 
@@ -134,7 +134,10 @@ pub struct ModeRun {
 
 impl ModeRun {
     fn best_ranks(&self) -> Vec<Option<usize>> {
-        self.query_results.iter().map(|o| o.score.best_rank).collect()
+        self.query_results
+            .iter()
+            .map(|o| o.score.best_rank)
+            .collect()
     }
 }
 
@@ -225,7 +228,9 @@ fn record_runs(runs: &[ModeRun], args: &QualityArgs) -> Result<()> {
     let binary = format!("grans {}", env!("GRANS_VERSION"));
     let db = match args.db {
         Some(path) => path.display().to_string(),
-        None => crate::db::connection::default_db_path()?.display().to_string(),
+        None => crate::db::connection::default_db_path()?
+            .display()
+            .to_string(),
     };
 
     let note = ranking_note(&args.ranking, args.note);
@@ -275,7 +280,11 @@ fn parse_benchmark(content: &str) -> Result<Vec<BenchmarkQuery>> {
             bail!("Benchmark query {} has an empty query string", i + 1);
         }
         if q.relevant_meetings.is_empty() && q.relevant_meeting_ids.is_empty() {
-            bail!("Benchmark query {} ({:?}) has no relevance labels", i + 1, q.query);
+            bail!(
+                "Benchmark query {} ({:?}) has no relevance labels",
+                i + 1,
+                q.query
+            );
         }
     }
 
@@ -301,7 +310,15 @@ where
 
         let matcher = bq.matcher(title_map);
         let score = metrics::score_query(&ranked, &matcher, k);
-        outcomes.push(build_outcome(bq, &ranked, matcher.method(), score, latency_ms, title_map, k));
+        outcomes.push(build_outcome(
+            bq,
+            &ranked,
+            matcher.method(),
+            score,
+            latency_ms,
+            title_map,
+            k,
+        ));
     }
 
     let overall = metrics::aggregate(outcomes.iter().map(|o| &o.score));
@@ -488,7 +505,10 @@ mod tests {
         assert_eq!(ranking_note(&default, None), None);
         assert_eq!(ranking_note(&default, Some("phase5")), None);
 
-        let overridden = RankingConfig { title_boost_weight: 0.5, ..Default::default() };
+        let overridden = RankingConfig {
+            title_boost_weight: 0.5,
+            ..Default::default()
+        };
         assert_eq!(
             ranking_note(&overridden, None).as_deref(),
             Some("title-boost-weight=0.5")
@@ -581,11 +601,8 @@ mod tests {
 
     #[test]
     fn resolve_modes_rejects_duplicate_compare_modes() {
-        let err = resolve_modes(
-            QualityMode::Semantic,
-            &[QualityMode::Fts, QualityMode::Fts],
-        )
-        .unwrap_err();
+        let err = resolve_modes(QualityMode::Semantic, &[QualityMode::Fts, QualityMode::Fts])
+            .unwrap_err();
         assert!(err.to_string().contains("duplicate"));
     }
 
@@ -710,14 +727,7 @@ mod tests {
     fn single_run_has_no_comparisons() {
         let queries = parse_benchmark(V1_JSON).unwrap();
         let title_map = HashMap::new();
-        let run = run_queries(
-            |_| Ok(vec![]),
-            &queries,
-            &title_map,
-            QualityMode::Fts,
-            10,
-        )
-        .unwrap();
+        let run = run_queries(|_| Ok(vec![]), &queries, &title_map, QualityMode::Fts, 10).unwrap();
 
         assert!(pairwise_comparisons(&[run]).is_empty());
     }

--- a/src/commands/benchmark/retriever.rs
+++ b/src/commands/benchmark/retriever.rs
@@ -16,7 +16,7 @@ use crate::embed::config::EmbedSpec;
 use crate::embed::model::{Embedder, FastEmbedModel};
 use crate::embed::rerank::{FastEmbedReranker, RerankModel, Reranker};
 use crate::embed::search::SemanticSearchResult;
-use crate::embed::{ensure_embeddings, EmbeddingIndex, DEFAULT_BATCH_SIZE};
+use crate::embed::{DEFAULT_BATCH_SIZE, EmbeddingIndex, ensure_embeddings};
 use crate::query::adjust::{RankingConfig, RankingContext};
 use crate::query::filter::SearchTarget;
 use crate::query::rerank::RerankCandidate;
@@ -64,7 +64,11 @@ impl<'a> Retriever<'a> {
                 let embedder = FastEmbedModel::new()?;
                 let spec = EmbedSpec::resolve_stored(conn, embedder.max_length());
                 let index = ensure_embeddings(conn, &embedder, DEFAULT_BATCH_SIZE, &spec)?;
-                Ok(Retriever::Hybrid { conn, embedder, index })
+                Ok(Retriever::Hybrid {
+                    conn,
+                    embedder,
+                    index,
+                })
             }
             QualityMode::RerankJina | QualityMode::RerankBge => {
                 let embedder = FastEmbedModel::new()?;
@@ -76,7 +80,14 @@ impl<'a> Retriever<'a> {
                 };
                 let reranker = Box::new(FastEmbedReranker::new(model)?);
                 let ctx = RankingContext::load(conn)?;
-                Ok(Retriever::HybridRerank { conn, embedder, index, reranker, ctx, cfg })
+                Ok(Retriever::HybridRerank {
+                    conn,
+                    embedder,
+                    index,
+                    reranker,
+                    ctx,
+                    cfg,
+                })
             }
         }
     }
@@ -89,12 +100,19 @@ impl<'a> Retriever<'a> {
                 let query_vec = embedder.embed_query(query)?;
                 Ok(to_ranked(index.search(&query_vec, 0.0, None)))
             }
-            Retriever::Hybrid { conn, embedder, index } => {
-                retrieve_hybrid(conn, embedder, index, query)
-            }
-            Retriever::HybridRerank { conn, embedder, index, reranker, ctx, cfg } => {
-                retrieve_hybrid_rerank(conn, embedder, index, reranker.as_ref(), query, ctx, cfg)
-            }
+            Retriever::Hybrid {
+                conn,
+                embedder,
+                index,
+            } => retrieve_hybrid(conn, embedder, index, query),
+            Retriever::HybridRerank {
+                conn,
+                embedder,
+                index,
+                reranker,
+                ctx,
+                cfg,
+            } => retrieve_hybrid_rerank(conn, embedder, index, reranker.as_ref(), query, ctx, cfg),
         }
     }
 
@@ -102,17 +120,22 @@ impl<'a> Retriever<'a> {
     /// score) for modes with a rerank stage; `None` for the others.
     pub fn retrieve_detailed(&self, query: &str) -> Result<Option<Vec<RerankCandidate>>> {
         match self {
-            Retriever::HybridRerank { conn, embedder, index, reranker, ctx, cfg } => {
-                Ok(Some(retrieve_hybrid_rerank_detailed(
-                    conn,
-                    embedder,
-                    index,
-                    reranker.as_ref(),
-                    query,
-                    ctx,
-                    cfg,
-                )?))
-            }
+            Retriever::HybridRerank {
+                conn,
+                embedder,
+                index,
+                reranker,
+                ctx,
+                cfg,
+            } => Ok(Some(retrieve_hybrid_rerank_detailed(
+                conn,
+                embedder,
+                index,
+                reranker.as_ref(),
+                query,
+                ctx,
+                cfg,
+            )?)),
             _ => Ok(None),
         }
     }
@@ -143,9 +166,10 @@ fn retrieve_hybrid(
     query: &str,
 ) -> Result<Vec<RankedDoc>> {
     let targets = SearchTarget::all();
-    let fused =
-        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, None, false)?
-            .fused;
+    let fused = crate::query::hybrid::hybrid_ranked(
+        conn, embedder, index, query, &targets, None, None, false,
+    )?
+    .fused;
     Ok(fused
         .into_iter()
         .map(|d| RankedDoc {
@@ -168,8 +192,9 @@ fn retrieve_hybrid_rerank_detailed(
     cfg: &RankingConfig,
 ) -> Result<Vec<RerankCandidate>> {
     let targets = SearchTarget::all();
-    let ranking =
-        crate::query::hybrid::hybrid_ranked(conn, embedder, index, query, &targets, None, None, false)?;
+    let ranking = crate::query::hybrid::hybrid_ranked(
+        conn, embedder, index, query, &targets, None, None, false,
+    )?;
     crate::query::rerank::rerank_hybrid_detailed(conn, reranker, query, &ranking, ctx, cfg)
 }
 
@@ -184,13 +209,15 @@ fn retrieve_hybrid_rerank(
     ctx: &RankingContext,
     cfg: &RankingConfig,
 ) -> Result<Vec<RankedDoc>> {
-    Ok(retrieve_hybrid_rerank_detailed(conn, embedder, index, reranker, query, ctx, cfg)?
-        .into_iter()
-        .map(|c| RankedDoc {
-            document_id: c.document_id,
-            score: Some(c.rerank_score),
-        })
-        .collect())
+    Ok(
+        retrieve_hybrid_rerank_detailed(conn, embedder, index, reranker, query, ctx, cfg)?
+            .into_iter()
+            .map(|c| RankedDoc {
+                document_id: c.document_id,
+                score: Some(c.rerank_score),
+            })
+            .collect(),
+    )
 }
 
 /// Map document-level semantic results (already deduped and sorted by score
@@ -213,7 +240,10 @@ mod tests {
     /// Boost-free config so these tests pin fusion + cross-encoder
     /// behavior independent of the adopted default weights.
     fn no_boost() -> RankingConfig {
-        RankingConfig { title_boost_weight: 0.0, ..Default::default() }
+        RankingConfig {
+            title_boost_weight: 0.0,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -258,7 +288,10 @@ mod tests {
             }],
             stats: None,
         };
-        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+        let embedder = MockEmbedder {
+            dim: 2,
+            max_length: 512,
+        };
 
         // "machine learning" matches doc-1 by FTS too (notes), so doc-1 is
         // rank 1 in both lists: RRF score 2/(60 + 1).
@@ -273,8 +306,14 @@ mod tests {
     #[test]
     fn hybrid_retriever_empty_for_no_match() {
         let conn = build_test_db(&meetings_state());
-        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
-        let embedder = crate::embed::model::MockEmbedder { dim: 2, max_length: 512 };
+        let index = EmbeddingIndex {
+            vectors: Vec::new(),
+            stats: None,
+        };
+        let embedder = crate::embed::model::MockEmbedder {
+            dim: 2,
+            max_length: 512,
+        };
 
         let ranked = retrieve_hybrid(&conn, &embedder, &index, "zebra xylophone").unwrap();
 
@@ -309,10 +348,21 @@ mod tests {
             ],
             stats: None,
         };
-        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+        let embedder = MockEmbedder {
+            dim: 2,
+            max_length: 512,
+        };
 
-        let ranked =
-            retrieve_hybrid_rerank(&conn, &embedder, &index, &MockReranker, "standup", &RankingContext::default(), &no_boost()).unwrap();
+        let ranked = retrieve_hybrid_rerank(
+            &conn,
+            &embedder,
+            &index,
+            &MockReranker,
+            "standup",
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert_eq!(ranked.len(), 2);
         assert_eq!(ranked[0].document_id, "doc-1");
@@ -345,11 +395,21 @@ mod tests {
             ],
             stats: None,
         };
-        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+        let embedder = MockEmbedder {
+            dim: 2,
+            max_length: 512,
+        };
 
-        let detailed =
-            retrieve_hybrid_rerank_detailed(&conn, &embedder, &index, &MockReranker, "standup", &RankingContext::default(), &no_boost())
-                .unwrap();
+        let detailed = retrieve_hybrid_rerank_detailed(
+            &conn,
+            &embedder,
+            &index,
+            &MockReranker,
+            "standup",
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert_eq!(detailed.len(), 2);
         assert_eq!(detailed[0].document_id, "doc-1");
@@ -377,12 +437,25 @@ mod tests {
         use crate::embed::rerank::MockReranker;
 
         let conn = build_test_db(&meetings_state());
-        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
-        let embedder = MockEmbedder { dim: 2, max_length: 512 };
+        let index = EmbeddingIndex {
+            vectors: Vec::new(),
+            stats: None,
+        };
+        let embedder = MockEmbedder {
+            dim: 2,
+            max_length: 512,
+        };
 
-        let ranked =
-            retrieve_hybrid_rerank(&conn, &embedder, &index, &MockReranker, "zebra xylophone", &RankingContext::default(), &no_boost())
-                .unwrap();
+        let ranked = retrieve_hybrid_rerank(
+            &conn,
+            &embedder,
+            &index,
+            &MockReranker,
+            "zebra xylophone",
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert!(ranked.is_empty());
     }

--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -3,7 +3,9 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::cli::args::{BrowseAction, CalendarsAction, PeopleAction, RecipesAction, TemplatesAction};
+use crate::cli::args::{
+    BrowseAction, CalendarsAction, PeopleAction, RecipesAction, TemplatesAction,
+};
 use crate::cli::context::RunContext;
 use crate::output::format::OutputMode;
 
@@ -18,7 +20,9 @@ pub fn run(conn: &Connection, action: &BrowseAction, ctx: &RunContext) -> Result
 
 fn run_people(conn: &Connection, action: &PeopleAction, mode: OutputMode) -> Result<()> {
     match action {
-        PeopleAction::List { company } => crate::commands::people::list(conn, company.as_deref(), mode),
+        PeopleAction::List { company } => {
+            crate::commands::people::list(conn, company.as_deref(), mode)
+        }
         PeopleAction::Show { query } => crate::commands::people::show(conn, query, mode),
     }
 }

--- a/src/commands/embed.rs
+++ b/src/commands/embed.rs
@@ -123,10 +123,7 @@ fn print_status_tty(status: &EmbeddingStatus, spec: &EmbedSpec) {
     );
     println!();
 
-    println!(
-        "Total:     {} chunks",
-        format_number(status.total_chunks)
-    );
+    println!("Total:     {} chunks", format_number(status.total_chunks));
     if status.total_chunks > 0 {
         println!(
             "  Transcripts:  {} chunks ({}%)",
@@ -166,10 +163,7 @@ fn print_status_tty(status: &EmbeddingStatus, spec: &EmbedSpec) {
     }
     println!();
 
-    println!(
-        "Pending:   {} chunks",
-        format_number(status.pending_chunks)
-    );
+    println!("Pending:   {} chunks", format_number(status.pending_chunks));
     if status.pending_chunks > 0 {
         println!(
             "  Transcripts:  {} chunks",
@@ -251,24 +245,16 @@ fn print_status_tty(status: &EmbeddingStatus, spec: &EmbedSpec) {
         println!();
         println!("\x1b[1;33mWarning\x1b[0m");
         println!("\x1b[2m───────\x1b[0m");
-        println!(
-            "  \x1b[33m⚠\x1b[0m Embeddings were created with unknown max_length settings."
-        );
-        println!(
-            "    Run `grans embed` to re-embed with current settings."
-        );
+        println!("  \x1b[33m⚠\x1b[0m Embeddings were created with unknown max_length settings.");
+        println!("    Run `grans embed` to re-embed with current settings.");
     }
 
     if status.model_changed_warning {
         println!();
         println!("\x1b[1;33mWarning\x1b[0m");
         println!("\x1b[2m───────\x1b[0m");
-        println!(
-            "  \x1b[33m⚠\x1b[0m Embeddings were created by a different embedding model."
-        );
-        println!(
-            "    Run `grans embed` to rebuild them."
-        );
+        println!("  \x1b[33m⚠\x1b[0m Embeddings were created by a different embedding model.");
+        println!("    Run `grans embed` to rebuild them.");
     }
 
     if status.pending_chunks > 0 {
@@ -318,10 +304,7 @@ fn clear_embeddings(
             );
         } else {
             let total = status.embedded_chunks + status.orphaned_chunks;
-            eprintln!(
-                "\nThis will clear all {} embeddings.",
-                format_number(total)
-            );
+            eprintln!("\nThis will clear all {} embeddings.", format_number(total));
         }
         eprint!("Proceed? [y/N] ");
         io::stderr().flush()?;
@@ -412,7 +395,8 @@ fn embed_with_prompt(
     }
 
     // Prompt unless --yes or non-TTY
-    if !yes && mode == OutputMode::Tty && (status.pending_chunks > 0 || status.orphaned_chunks > 0) {
+    if !yes && mode == OutputMode::Tty && (status.pending_chunks > 0 || status.orphaned_chunks > 0)
+    {
         let needs_full_reembed = status.orphaned_chunks > 0
             || status.legacy_max_length_warning
             || status.model_changed_warning
@@ -460,7 +444,12 @@ fn embed_with_prompt(
 }
 
 /// Actually perform the embedding.
-fn do_embed(conn: &Connection, batch_size: usize, mode: OutputMode, spec: &EmbedSpec) -> Result<()> {
+fn do_embed(
+    conn: &Connection,
+    batch_size: usize,
+    mode: OutputMode,
+    spec: &EmbedSpec,
+) -> Result<()> {
     let embedder = embed::model::FastEmbedModel::new()?;
     let index = embed::ensure_embeddings(conn, &embedder, batch_size, spec)?;
 
@@ -537,9 +526,5 @@ fn format_number(n: usize) -> String {
 }
 
 fn percentage(part: usize, total: usize) -> usize {
-    if total == 0 {
-        0
-    } else {
-        (100 * part) / total
-    }
+    if total == 0 { 0 } else { (100 * part) / total }
 }

--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -4,16 +4,16 @@
 //! words is counted, and `--limit` only trims how many are shown. This path
 //! never loads an embedding model and never prompts.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
 use crate::commands::search_common::{print_shaped_cards, shape_and_page};
 use crate::models::Document;
-use crate::query::speaker::SpeakerFilter;
 use crate::output::format::OutputMode;
 use crate::query::dates::DateRange;
-use crate::query::filter::{filter_by_meeting, SearchTarget};
+use crate::query::filter::{SearchTarget, filter_by_meeting};
+use crate::query::speaker::SpeakerFilter;
 
 /// Options for a grep lookup.
 pub struct GrepOptions {
@@ -42,10 +42,15 @@ pub fn grep(
 ) -> Result<()> {
     check_speaker_targets(opts.speaker.is_some(), &opts.targets)?;
 
-    let results = fts_meetings(conn, query, &opts.targets, date_range.as_ref(), include_deleted)?;
+    let results = fts_meetings(
+        conn,
+        query,
+        &opts.targets,
+        date_range.as_ref(),
+        include_deleted,
+    )?;
     let results = filter_by_meeting(results, opts.meeting_filter.as_deref());
-    let docs: Vec<(Document, Option<f32>)> =
-        results.into_iter().map(|doc| (doc, None)).collect();
+    let docs: Vec<(Document, Option<f32>)> = results.into_iter().map(|doc| (doc, None)).collect();
 
     let tokens = crate::query::fts::parse_query(query);
     let evidence_opts = crate::query::evidence::EvidenceOptions {
@@ -120,7 +125,11 @@ fn render_grep_meeting_list(
                     shaped.len()
                 );
             } else {
-                println!("Found {} meeting(s) matching \"{}\":\n", shaped.len(), query);
+                println!(
+                    "Found {} meeting(s) matching \"{}\":\n",
+                    shaped.len(),
+                    query
+                );
             }
             print_shaped_cards(shaped, ctx);
             if total > shaped.len() {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -5,8 +5,8 @@ use chrono::{DateTime, FixedOffset};
 use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
-use crate::db::info::{get_info_db_only, DbInfo};
-use crate::output::format::{format_size, OutputMode};
+use crate::db::info::{DbInfo, get_info_db_only};
+use crate::output::format::{OutputMode, format_size};
 
 /// Run info command
 pub fn run(conn: &Connection, db_path: &Path, ctx: &RunContext) -> Result<()> {
@@ -58,12 +58,21 @@ fn print_tty(info: &DbInfo, tz: &FixedOffset) {
     }
 
     println!("People:             {}", format_number(info.total_people));
-    println!("Calendars:          {}", format_number(info.total_calendars));
+    println!(
+        "Calendars:          {}",
+        format_number(info.total_calendars)
+    );
     println!("Events:             {}", format_number(info.total_events));
-    println!("Templates:          {}", format_number(info.total_templates));
+    println!(
+        "Templates:          {}",
+        format_number(info.total_templates)
+    );
     println!("Recipes:            {}", format_number(info.total_recipes));
     println!("Panels:             {}", format_number(info.total_panels));
-    println!("Utterances:         {}", format_number(info.total_utterances));
+    println!(
+        "Utterances:         {}",
+        format_number(info.total_utterances)
+    );
 
     if info.total_chunks > 0 {
         if let Some(stats) = &info.chunk_size_stats {
@@ -83,18 +92,9 @@ fn print_tty(info: &DbInfo, tz: &FixedOffset) {
     println!("\x1b[1mDatabase\x1b[0m");
     println!("\x1b[2m────────\x1b[0m");
 
-    println!(
-        "Path:           {}",
-        info.db_path.display()
-    );
-    println!(
-        "Size:           {}",
-        format_size(info.db_size_bytes)
-    );
-    println!(
-        "Schema version: {}",
-        info.schema_version
-    );
+    println!("Path:           {}", info.db_path.display());
+    println!("Size:           {}", format_size(info.db_size_bytes));
+    println!("Schema version: {}", info.schema_version);
 }
 
 fn format_number(n: i64) -> String {

--- a/src/commands/meetings.rs
+++ b/src/commands/meetings.rs
@@ -1,11 +1,11 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use chrono::Utc;
 use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
-use crate::query::speaker::SpeakerFilter;
 use crate::output::format::OutputMode;
 use crate::query::dates::build_date_range;
+use crate::query::speaker::SpeakerFilter;
 
 pub fn list(
     conn: &Connection,
@@ -17,7 +17,8 @@ pub fn list(
     ctx: &RunContext,
 ) -> Result<()> {
     let date_range = build_date_range(from, to, date, Utc::now(), &ctx.tz);
-    let docs = crate::db::meetings::list_meetings(conn, person, date_range.as_ref(), include_deleted)?;
+    let docs =
+        crate::db::meetings::list_meetings(conn, person, date_range.as_ref(), include_deleted)?;
 
     let refs: Vec<_> = docs.iter().collect();
 
@@ -92,10 +93,7 @@ pub fn show(
                         // Build JSON with requested fields
                         let mut obj = serde_json::Map::new();
                         if notes_only {
-                            obj.insert(
-                                "notes_plain".into(),
-                                serde_json::json!(doc.notes_plain),
-                            );
+                            obj.insert("notes_plain".into(), serde_json::json!(doc.notes_plain));
                             obj.insert(
                                 "notes_markdown".into(),
                                 serde_json::json!(doc.notes_markdown),
@@ -132,7 +130,10 @@ pub fn show(
                     println!("{}", serde_json::to_string_pretty(&detail).unwrap());
                 }
                 OutputMode::Tty => {
-                    println!("{}", crate::output::table::format_meeting_detail(&doc, &ctx.tz));
+                    println!(
+                        "{}",
+                        crate::output::table::format_meeting_detail(&doc, &ctx.tz)
+                    );
 
                     let transcript = filter_by_speaker(
                         crate::db::meetings::get_transcript(conn, doc_id)?,
@@ -141,7 +142,10 @@ pub fn show(
                     if !transcript.is_empty() {
                         println!("\n{}", "Transcript:");
                         for utt in transcript.iter().take(10) {
-                            println!("{}", crate::output::table::format_utterance(utt, false, &ctx.tz));
+                            println!(
+                                "{}",
+                                crate::output::table::format_utterance(utt, false, &ctx.tz)
+                            );
                         }
                         if transcript.len() > 10 {
                             println!("  ... ({} more utterances)", transcript.len() - 10);

--- a/src/commands/people.rs
+++ b/src/commands/people.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 use crate::output::format::OutputMode;

--- a/src/commands/recipes.rs
+++ b/src/commands/recipes.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 use crate::output::format::OutputMode;

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -16,7 +16,7 @@ use crate::commands::search_common::{print_shaped_cards, shape_and_page};
 use crate::models::Document;
 use crate::output::format::OutputMode;
 use crate::query::dates::DateRange;
-use crate::query::filter::{targets_to_flag_value, SearchTarget, DEFAULT_SEARCH_TARGETS};
+use crate::query::filter::{DEFAULT_SEARCH_TARGETS, SearchTarget, targets_to_flag_value};
 
 /// Threshold for prompting before embedding during a search.
 const EMBED_WARN_THRESHOLD: usize = 200;
@@ -109,7 +109,8 @@ pub fn search(
     }
 
     let embedder = crate::embed::model::FastEmbedModel::new()?;
-    let spec = crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
+    let spec =
+        crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
     let index =
         crate::embed::ensure_embeddings(conn, &embedder, crate::embed::DEFAULT_BATCH_SIZE, &spec)?;
 
@@ -127,8 +128,9 @@ pub fn search(
     // Ranked (id, score) pairs; ordering is the pipeline's and is not
     // touched again below.
     let ordered: Vec<(String, Option<f32>)> = if opts.rerank {
-        let reranker =
-            crate::embed::rerank::FastEmbedReranker::new(crate::embed::rerank::DEFAULT_RERANK_MODEL)?;
+        let reranker = crate::embed::rerank::FastEmbedReranker::new(
+            crate::embed::rerank::DEFAULT_RERANK_MODEL,
+        )?;
         let ranking_ctx = crate::query::adjust::RankingContext::load(conn)?;
         let cfg = crate::query::adjust::RankingConfig::default();
         let mut reranked = crate::query::rerank::rerank_hybrid(
@@ -142,15 +144,24 @@ pub fn search(
         if let Some(min) = opts.min_score {
             reranked.retain(|d| d.score >= min);
         }
-        reranked.into_iter().map(|d| (d.document_id, Some(d.score))).collect()
+        reranked
+            .into_iter()
+            .map(|d| (d.document_id, Some(d.score)))
+            .collect()
     } else {
-        ranking.fused.iter().map(|d| (d.document_id.clone(), None)).collect()
+        ranking
+            .fused
+            .iter()
+            .map(|d| (d.document_id.clone(), None))
+            .collect()
     };
 
     let ids: Vec<String> = ordered.iter().map(|(id, _)| id.clone()).collect();
     let docs = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
-    let mut doc_by_id: std::collections::HashMap<String, Document> =
-        docs.into_iter().filter_map(|d| d.id.clone().map(|id| (id, d))).collect();
+    let mut doc_by_id: std::collections::HashMap<String, Document> = docs
+        .into_iter()
+        .filter_map(|d| d.id.clone().map(|id| (id, d)))
+        .collect();
     let ordered_docs: Vec<(Document, Option<f32>)> = ordered
         .into_iter()
         .filter_map(|(id, score)| doc_by_id.remove(&id).map(|doc| (doc, score)))
@@ -244,7 +255,12 @@ fn render_ranked_meeting_list(
         OutputMode::Json => {
             println!(
                 "{}",
-                crate::output::json::format_search_meetings(shaped, query, keyword_total, opts.limit)
+                crate::output::json::format_search_meetings(
+                    shaped,
+                    query,
+                    keyword_total,
+                    opts.limit
+                )
             );
         }
         OutputMode::Tty => {
@@ -267,7 +283,8 @@ fn render_ranked_meeting_list(
 fn confirm_embedding_work(conn: &Connection, yes: bool, ctx: &RunContext) -> Result<bool> {
     // Resolve via the model constant: this path must not load the ONNX
     // model just to count pending chunks.
-    let spec = crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
+    let spec =
+        crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
     let status = crate::embed::get_embedding_status(conn, crate::embed::model::MODEL_NAME, &spec)?;
     let needs_full_reembed = status.orphaned_chunks > 0
         || status.legacy_max_length_warning
@@ -287,12 +304,11 @@ fn confirm_embedding_work(conn: &Connection, yes: bool, ctx: &RunContext) -> Res
                     eprintln!("  - Existing embeddings use an outdated chunking strategy");
                 }
                 if status.model_changed_warning {
-                    eprintln!("  - Existing embeddings were created by a different embedding model");
+                    eprintln!(
+                        "  - Existing embeddings were created by a different embedding model"
+                    );
                 }
-                eprintln!(
-                    "  - {} new chunks need embedding",
-                    status.pending_chunks
-                );
+                eprintln!("  - {} new chunks need embedding", status.pending_chunks);
                 eprintln!();
                 eprintln!("Existing embeddings cannot be used. Run `grans embed` to rebuild.");
             } else {
@@ -300,7 +316,9 @@ fn confirm_embedding_work(conn: &Connection, yes: bool, ctx: &RunContext) -> Res
                     "\nWarning: {} chunks need embedding.",
                     status.pending_chunks
                 );
-                eprintln!("This may take a while. Run `grans embed` separately to control when this happens.");
+                eprintln!(
+                    "This may take a while. Run `grans embed` separately to control when this happens."
+                );
             }
             eprint!("Proceed anyway? [y/N] ");
             io::stderr().flush()?;
@@ -352,22 +370,14 @@ mod tests {
 
     #[test]
     fn from_cli_args_fast_skips_rerank() {
-        let opts =
-            SearchOptions::from_cli_args(true, None, 0, false, 10, 1, FilterEcho::default());
+        let opts = SearchOptions::from_cli_args(true, None, 0, false, 10, 1, FilterEcho::default());
         assert!(!opts.rerank);
     }
 
     #[test]
     fn from_cli_args_min_score_threads() {
-        let opts = SearchOptions::from_cli_args(
-            false,
-            Some(0.4),
-            0,
-            false,
-            10,
-            1,
-            FilterEcho::default(),
-        );
+        let opts =
+            SearchOptions::from_cli_args(false, Some(0.4), 0, false, 10, 1, FilterEcho::default());
         assert_eq!(opts.min_score, Some(0.4));
     }
 
@@ -395,7 +405,10 @@ mod tests {
 
     #[test]
     fn ranked_header_claims_only_the_shown_count() {
-        assert_eq!(ranked_header(7, "budget"), "Top 7 match(es) for \"budget\":");
+        assert_eq!(
+            ranked_header(7, "budget"),
+            "Top 7 match(es) for \"budget\":"
+        );
     }
 
     #[test]

--- a/src/commands/search_common.rs
+++ b/src/commands/search_common.rs
@@ -43,8 +43,10 @@ pub fn shape_and_page<'a>(
         let page = apply_limit(docs, limit);
         Ok((shape(&page)?, total))
     } else {
-        let survivors: Vec<_> =
-            shape(&docs)?.into_iter().filter(|m| m.total_matches > 0).collect();
+        let survivors: Vec<_> = shape(&docs)?
+            .into_iter()
+            .filter(|m| m.total_matches > 0)
+            .collect();
         let total = survivors.len();
         Ok((apply_limit(survivors, limit), total))
     }
@@ -70,11 +72,17 @@ mod tests {
     fn ranked_docs(conn: &Connection) -> Vec<(Document, Option<f32>)> {
         let docs = crate::db::meetings::get_meetings_by_ids(
             &conn,
-            &["doc-c".to_string(), "doc-a".to_string(), "doc-b".to_string()],
+            &[
+                "doc-c".to_string(),
+                "doc-a".to_string(),
+                "doc-b".to_string(),
+            ],
         )
         .unwrap();
-        let mut by_id: std::collections::HashMap<String, Document> =
-            docs.into_iter().map(|d| (d.id.clone().unwrap(), d)).collect();
+        let mut by_id: std::collections::HashMap<String, Document> = docs
+            .into_iter()
+            .map(|d| (d.id.clone().unwrap(), d))
+            .collect();
         vec![
             (by_id.remove("doc-c").unwrap(), Some(0.5)),
             (by_id.remove("doc-a").unwrap(), Some(0.9)),
@@ -82,8 +90,15 @@ mod tests {
         ]
     }
 
-    fn plain_facts<'a>(_: &Document, score: Option<f32>) -> crate::query::evidence::RankingFacts<'a> {
-        crate::query::evidence::RankingFacts { keyword: true, best_chunk: None, score }
+    fn plain_facts<'a>(
+        _: &Document,
+        score: Option<f32>,
+    ) -> crate::query::evidence::RankingFacts<'a> {
+        crate::query::evidence::RankingFacts {
+            keyword: true,
+            best_chunk: None,
+            score,
+        }
     }
 
     #[test]

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -10,27 +10,29 @@ use indicatif::{ProgressBar, ProgressStyle};
 use chrono::FixedOffset;
 
 use crate::cli::args::DropboxAction;
-use crate::output::format::{format_size, OutputMode};
-use crate::sync::config::{config_path, SyncConfig};
+use crate::db::integrity::check_pulled_database;
+use crate::output::format::{OutputMode, format_size};
+use crate::output::progress::create_spinner;
+use crate::pkce::PkceChallenge;
+use crate::sync::SyncError;
+use crate::sync::config::{SyncConfig, config_path};
+use crate::sync::content_hash::{HashingWriter, hash_file};
 use crate::sync::dropbox::DropboxClient;
 use crate::sync::metadata::SyncMetadata;
-use crate::pkce::PkceChallenge;
-use crate::sync::oauth::{
-    build_auth_url, exchange_code, refresh_access_token, PKCE_ENTROPY_BYTES,
-};
-use crate::db::integrity::check_pulled_database;
-use crate::output::progress::create_spinner;
-use crate::sync::content_hash::{hash_file, HashingWriter};
-use crate::sync::reconcile::{decide, TransferDecision};
-use crate::sync::transfer::{no_progress, verify_content_hash, verify_transfer_size, ProgressFn};
-use crate::sync::SyncError;
+use crate::sync::oauth::{PKCE_ENTROPY_BYTES, build_auth_url, exchange_code, refresh_access_token};
+use crate::sync::reconcile::{TransferDecision, decide};
+use crate::sync::transfer::{ProgressFn, no_progress, verify_content_hash, verify_transfer_size};
 
 /// Remote paths on Dropbox (within app folder)
 pub(super) const REMOTE_DB_PATH: &str = "/grans.db";
 pub(super) const REMOTE_METADATA_PATH: &str = "/sync_metadata.json";
 
 /// Run Dropbox commands (init, push, pull, status, logout)
-pub fn run_dropbox(action: &DropboxAction, output_mode: OutputMode, tz: &FixedOffset) -> Result<()> {
+pub fn run_dropbox(
+    action: &DropboxAction,
+    output_mode: OutputMode,
+    tz: &FixedOffset,
+) -> Result<()> {
     match action {
         DropboxAction::Init => init()?,
         DropboxAction::Push { force } => push(*force)?,
@@ -260,12 +262,13 @@ fn pull_file(
 
     // Verification needs the hash before the transfer starts; refusing early
     // beats discovering it after moving hundreds of megabytes.
-    let expected_hash = remote
-        .content_hash
-        .as_deref()
-        .ok_or_else(|| SyncError::MissingContentHash {
-            path: remote_path.to_string(),
-        })?;
+    let expected_hash =
+        remote
+            .content_hash
+            .as_deref()
+            .ok_or_else(|| SyncError::MissingContentHash {
+                path: remote_path.to_string(),
+            })?;
 
     let local_hash = local_path
         .exists()
@@ -274,7 +277,10 @@ fn pull_file(
 
     match decide(expected_hash, local_hash.as_deref(), last_synced) {
         TransferDecision::UpToDate => {
-            println!("The local {} already matches Dropbox; nothing to download.", name);
+            println!(
+                "The local {} already matches Dropbox; nothing to download.",
+                name
+            );
             return Ok(expected_hash.to_string());
         }
         TransferDecision::Diverged if !force => {

--- a/src/commands/sync_granola.rs
+++ b/src/commands/sync_granola.rs
@@ -10,8 +10,8 @@ use rusqlite::Connection;
 use crate::api::ApiClient;
 use crate::cli::args::SyncAction;
 use crate::db::sync::{
-    self, upsert_calendar_events, upsert_calendars_from_selection, upsert_documents, upsert_people,
-    upsert_recipes, upsert_templates, SyncStats,
+    self, SyncStats, upsert_calendar_events, upsert_calendars_from_selection, upsert_documents,
+    upsert_people, upsert_recipes, upsert_templates,
 };
 use crate::output::format::OutputMode;
 use crate::output::progress::create_spinner;
@@ -241,7 +241,12 @@ fn print_full_sync_summary(stats: &FullSyncStats, dry_run: bool, mode: OutputMod
 // Individual sync functions
 // ============================================================================
 
-fn sync_documents(conn: &Connection, dry_run: bool, token: Option<&str>, mode: OutputMode) -> Result<()> {
+fn sync_documents(
+    conn: &Connection,
+    dry_run: bool,
+    token: Option<&str>,
+    mode: OutputMode,
+) -> Result<()> {
     debug!("sync_documents (dry_run={})", dry_run);
     let token = crate::api::resolve_token(token)?;
     let client = ApiClient::new(token)?;
@@ -291,7 +296,12 @@ fn sync_documents_with_client(
     upsert_documents(conn, &documents)
 }
 
-fn sync_people(conn: &Connection, dry_run: bool, token: Option<&str>, mode: OutputMode) -> Result<()> {
+fn sync_people(
+    conn: &Connection,
+    dry_run: bool,
+    token: Option<&str>,
+    mode: OutputMode,
+) -> Result<()> {
     debug!("sync_people (dry_run={})", dry_run);
     let token = crate::api::resolve_token(token)?;
     let client = ApiClient::new(token)?;
@@ -341,7 +351,12 @@ fn sync_people_with_client(
     upsert_people(conn, &people)
 }
 
-fn sync_calendars(conn: &Connection, dry_run: bool, token: Option<&str>, mode: OutputMode) -> Result<()> {
+fn sync_calendars(
+    conn: &Connection,
+    dry_run: bool,
+    token: Option<&str>,
+    mode: OutputMode,
+) -> Result<()> {
     debug!("sync_calendars (dry_run={})", dry_run);
     let token = crate::api::resolve_token(token)?;
     let client = ApiClient::new(token)?;
@@ -412,7 +427,12 @@ fn sync_calendars_with_client(
     upsert_calendar_events(conn, &events)
 }
 
-fn sync_templates(conn: &Connection, dry_run: bool, token: Option<&str>, mode: OutputMode) -> Result<()> {
+fn sync_templates(
+    conn: &Connection,
+    dry_run: bool,
+    token: Option<&str>,
+    mode: OutputMode,
+) -> Result<()> {
     debug!("sync_templates (dry_run={})", dry_run);
     let token = crate::api::resolve_token(token)?;
     let client = ApiClient::new(token)?;
@@ -462,7 +482,12 @@ fn sync_templates_with_client(
     upsert_templates(conn, &templates)
 }
 
-fn sync_recipes(conn: &Connection, dry_run: bool, token: Option<&str>, mode: OutputMode) -> Result<()> {
+fn sync_recipes(
+    conn: &Connection,
+    dry_run: bool,
+    token: Option<&str>,
+    mode: OutputMode,
+) -> Result<()> {
     debug!("sync_recipes (dry_run={})", dry_run);
     let token = crate::api::resolve_token(token)?;
     let client = ApiClient::new(token)?;

--- a/src/commands/sync_status.rs
+++ b/src/commands/sync_status.rs
@@ -9,12 +9,12 @@ use anyhow::Result;
 use chrono::FixedOffset;
 use serde::Serialize;
 
-use crate::output::format::{format_size, OutputMode};
+use crate::output::format::{OutputMode, format_size};
 use crate::sync::config::SyncConfig;
-use crate::sync::dropbox::{format_timestamp, parse_dropbox_time, DropboxClient, FileMetadata};
+use crate::sync::dropbox::{DropboxClient, FileMetadata, format_timestamp, parse_dropbox_time};
 use crate::sync::metadata::SyncMetadata;
 
-use super::sync::{get_access_token, get_file_mtime, REMOTE_DB_PATH, REMOTE_METADATA_PATH};
+use super::sync::{REMOTE_DB_PATH, REMOTE_METADATA_PATH, get_access_token, get_file_mtime};
 
 /// File information for status display
 #[derive(Debug, Clone, Serialize)]
@@ -77,39 +77,26 @@ pub(super) fn status(output_mode: OutputMode, tz: &FixedOffset) -> Result<()> {
     let db_path = crate::db::connection::default_db_path()?;
 
     // Collect local metadata
-    let local_metadata = SyncMetadata::from_local_db(
-        db_path.exists().then_some(&db_path),
-    )
-    .ok();
+    let local_metadata = SyncMetadata::from_local_db(db_path.exists().then_some(&db_path)).ok();
 
     // Local file info
     let local_db_info = FileInfo::from_local(&db_path);
 
     // Remote info (only if authenticated)
-    let (remote_metadata, remote_db_info) =
-        if config.is_authenticated() {
-            match get_access_token(&config) {
-                Ok(access_token) => {
-                    let client = DropboxClient::new(access_token)?;
-                    let remote_meta = fetch_remote_metadata(&client);
-                    let db_meta = client.get_metadata(REMOTE_DB_PATH).ok().flatten();
+    let (remote_metadata, remote_db_info) = if config.is_authenticated() {
+        match get_access_token(&config) {
+            Ok(access_token) => {
+                let client = DropboxClient::new(access_token)?;
+                let remote_meta = fetch_remote_metadata(&client);
+                let db_meta = client.get_metadata(REMOTE_DB_PATH).ok().flatten();
 
-                    (
-                        remote_meta,
-                        FileInfo::from_remote(db_meta.as_ref()),
-                    )
-                }
-                Err(_) => (
-                    None,
-                    FileInfo::from_remote(None),
-                ),
+                (remote_meta, FileInfo::from_remote(db_meta.as_ref()))
             }
-        } else {
-            (
-                None,
-                FileInfo::from_remote(None),
-            )
-        };
+            Err(_) => (None, FileInfo::from_remote(None)),
+        }
+    } else {
+        (None, FileInfo::from_remote(None))
+    };
 
     let status_data = SyncStatusData {
         authenticated: config.is_authenticated(),
@@ -230,7 +217,8 @@ fn print_status_tty(data: &SyncStatusData, tz: &FixedOffset) {
     );
 
     // Date range
-    let local_range = local_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
+    let local_range =
+        local_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
     let remote_range =
         remote_idx.map(|i| format_date_range(&i.earliest_document, &i.latest_document));
     print_comparison_row("Date range:", local_range, remote_range);
@@ -257,14 +245,24 @@ fn print_status_tty(data: &SyncStatusData, tz: &FixedOffset) {
     // Database modified
     print_comparison_row(
         "Database modified:",
-        data.local_db.modified_time.map(|ts| format_short_time(ts, tz)),
-        data.remote_db.modified_time.map(|ts| format_short_time(ts, tz)),
+        data.local_db
+            .modified_time
+            .map(|ts| format_short_time(ts, tz)),
+        data.remote_db
+            .modified_time
+            .map(|ts| format_short_time(ts, tz)),
     );
 
     // Embeddings
     let local_emb_count = local_idx.map(|i| i.embedding_count).unwrap_or(0);
-    let remote_emb_count = remote_idx.map(|i| i.embedding_count)
-        .or_else(|| data.remote.as_ref().and_then(|m| m.embeddings_db.as_ref()).map(|e| e.embedding_count))
+    let remote_emb_count = remote_idx
+        .map(|i| i.embedding_count)
+        .or_else(|| {
+            data.remote
+                .as_ref()
+                .and_then(|m| m.embeddings_db.as_ref())
+                .map(|e| e.embedding_count)
+        })
         .unwrap_or(0);
     print_comparison_row(
         "Embeddings:",
@@ -274,13 +272,15 @@ fn print_status_tty(data: &SyncStatusData, tz: &FixedOffset) {
 
     // Embedding model
     let local_model = local_idx.and_then(|i| i.embedding_model.clone());
-    let remote_model = remote_idx.and_then(|i| i.embedding_model.clone())
-        .or_else(|| data.remote.as_ref().and_then(|m| m.embeddings_db.as_ref()).and_then(|e| e.model.clone()));
-    print_comparison_row(
-        "Embedding model:",
-        local_model,
-        remote_model,
-    );
+    let remote_model = remote_idx
+        .and_then(|i| i.embedding_model.clone())
+        .or_else(|| {
+            data.remote
+                .as_ref()
+                .and_then(|m| m.embeddings_db.as_ref())
+                .and_then(|e| e.model.clone())
+        });
+    print_comparison_row("Embedding model:", local_model, remote_model);
 
     if schema_mismatch {
         println!();

--- a/src/commands/sync_transcripts.rs
+++ b/src/commands/sync_transcripts.rs
@@ -118,10 +118,7 @@ pub(super) fn sync_transcripts(
                 );
             }
             OutputMode::Tty => {
-                println!(
-                    "[dry-run] Would sync {} document(s):\n",
-                    documents.len()
-                );
+                println!("[dry-run] Would sync {} document(s):\n", documents.len());
                 for doc in &documents {
                     let title = doc.title.as_deref().unwrap_or("(untitled)");
                     let date = doc.created_at.as_deref().unwrap_or("unknown");
@@ -289,7 +286,10 @@ pub(super) fn sync_single_transcript(
     let resolved_token = crate::api::resolve_token(token)?;
 
     if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
-        eprintln!("[grans] Fetching transcript for: {} ({})", title_display, doc_id);
+        eprintln!(
+            "[grans] Fetching transcript for: {} ({})",
+            title_display, doc_id
+        );
     }
 
     let outcome = match crate::api::fetch_transcript(&resolved_token, &doc_id) {
@@ -322,12 +322,7 @@ pub(super) fn sync_single_transcript(
     Ok(())
 }
 
-fn print_single_result(
-    doc_id: &str,
-    title: Option<&str>,
-    outcome: FetchOutcome,
-    mode: OutputMode,
-) {
+fn print_single_result(doc_id: &str, title: Option<&str>, outcome: FetchOutcome, mode: OutputMode) {
     match mode {
         OutputMode::Json => {
             let (result, utterances) = match outcome {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 use crate::output::format::OutputMode;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -7,11 +7,13 @@ use anyhow::Result;
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 
-use crate::update::download::{current_binary_hash, download_asset, replace_binary, verify_checksum};
-use crate::update::github::{find_asset, BuildStatus, Release};
+use crate::update::download::{
+    current_binary_hash, download_asset, replace_binary, verify_checksum,
+};
+use crate::update::github::{BuildStatus, Release, find_asset};
 use crate::update::platform::asset_name;
-use crate::update::wait::{display_build_info, wait_for_build, WaitConfig};
-use crate::update::{get_github_token_from_env, get_github_token_from_gh_cli, UpdateError};
+use crate::update::wait::{WaitConfig, display_build_info, wait_for_build};
+use crate::update::{UpdateError, get_github_token_from_env, get_github_token_from_gh_cli};
 
 /// Create a spinner with a consistent style for the update command.
 fn create_spinner(message: &str) -> ProgressBar {
@@ -27,7 +29,12 @@ fn create_spinner(message: &str) -> ProgressBar {
 }
 
 /// Run the update command.
-pub fn run(check_only: bool, use_gh_auth: bool, wait_for_build_flag: bool, timeout_secs: u64) -> Result<()> {
+pub fn run(
+    check_only: bool,
+    use_gh_auth: bool,
+    wait_for_build_flag: bool,
+    timeout_secs: u64,
+) -> Result<()> {
     let current_version = env!("GRANS_VERSION");
     println!("Current version: {}", current_version);
     println!();
@@ -38,7 +45,13 @@ pub fn run(check_only: bool, use_gh_auth: bool, wait_for_build_flag: bool, timeo
     let spinner = create_spinner("Checking build status...");
 
     // Try to check build status and fetch release, prompting for auth if needed
-    let (release, token) = fetch_with_auth_fallback(&mut token, check_only, wait_for_build_flag, timeout_secs, &spinner)?;
+    let (release, token) = fetch_with_auth_fallback(
+        &mut token,
+        check_only,
+        wait_for_build_flag,
+        timeout_secs,
+        &spinner,
+    )?;
 
     spinner.finish_and_clear();
 
@@ -159,7 +172,6 @@ fn fetch_with_auth_fallback(
     )
 }
 
-
 /// Handle the result of a build status check.
 fn handle_build_status_result(
     result: Result<BuildStatus, UpdateError>,
@@ -176,7 +188,10 @@ fn handle_build_status_result(
             // No active build, continue normally
         }
         Ok(BuildStatus::Failed(ref run)) => {
-            let conclusion = run.conclusion.clone().unwrap_or_else(|| "unknown".to_string());
+            let conclusion = run
+                .conclusion
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
             println!(
                 "{}: Recent build failed with: {}",
                 "Note".yellow(),
@@ -196,7 +211,6 @@ fn handle_build_status_result(
     }
     Ok(())
 }
-
 
 /// Handle an in-progress build: display info and optionally wait.
 fn handle_in_progress_build(
@@ -261,10 +275,7 @@ fn display_release_info(release: &Release, asset: &crate::update::github::Asset)
         println!("Published: {}", formatted.dimmed());
     }
 
-    println!(
-        "Size:     {:.2} MB",
-        asset.size as f64 / 1_048_576.0
-    );
+    println!("Size:     {:.2} MB", asset.size as f64 / 1_048_576.0);
 
     if asset.sha256().is_some() {
         println!("Checksum: {}", "SHA256 available".dimmed());
@@ -342,20 +353,26 @@ pub fn fetch_with_auth_fallback_impl<G: GitHubApi, A: AuthProvider, P: PromptPro
     let build_status_result = github.check_build_status(token.as_deref());
 
     // Check if we need auth (404 means private repo or auth required)
-    let needs_auth = matches!(&build_status_result, Err(UpdateError::GitHubApi(msg)) if msg.contains("404"));
+    let needs_auth =
+        matches!(&build_status_result, Err(UpdateError::GitHubApi(msg)) if msg.contains("404"));
 
     if needs_auth && token.is_none() {
         // Suspend spinner for interactive auth prompt
-        let new_token = spinner.suspend(|| {
-            prompt_for_gh_auth_impl(auth_provider, prompt_provider)
-        })?;
+        let new_token =
+            spinner.suspend(|| prompt_for_gh_auth_impl(auth_provider, prompt_provider))?;
         if let Some(new_token) = new_token {
             *token = Some(new_token);
             // Retry build status with auth
             let retry_result = github.check_build_status(token.as_deref());
             // Suspend spinner for build status handling (may prompt to wait)
             spinner.suspend(|| {
-                handle_build_status_result(retry_result, token.as_deref(), check_only, wait_for_build_flag, timeout_secs)
+                handle_build_status_result(
+                    retry_result,
+                    token.as_deref(),
+                    check_only,
+                    wait_for_build_flag,
+                    timeout_secs,
+                )
             })?;
         } else {
             // User declined auth, continue without (will likely fail on release fetch)
@@ -372,7 +389,13 @@ pub fn fetch_with_auth_fallback_impl<G: GitHubApi, A: AuthProvider, P: PromptPro
     } else {
         // No auth needed or we already have a token - handle the result
         spinner.suspend(|| {
-            handle_build_status_result(build_status_result, token.as_deref(), check_only, wait_for_build_flag, timeout_secs)
+            handle_build_status_result(
+                build_status_result,
+                token.as_deref(),
+                check_only,
+                wait_for_build_flag,
+                timeout_secs,
+            )
         })?;
     }
 
@@ -382,9 +405,8 @@ pub fn fetch_with_auth_fallback_impl<G: GitHubApi, A: AuthProvider, P: PromptPro
         Ok(release) => Ok((release, token.clone())),
         Err(UpdateError::NotFound { has_token: false }) if token.is_none() => {
             // Suspend spinner for interactive auth prompt
-            let new_token = spinner.suspend(|| {
-                prompt_for_gh_auth_impl(auth_provider, prompt_provider)
-            })?;
+            let new_token =
+                spinner.suspend(|| prompt_for_gh_auth_impl(auth_provider, prompt_provider))?;
             if let Some(new_token) = new_token {
                 *token = Some(new_token);
                 let release = github.fetch_latest_release(token.as_deref())?;
@@ -474,7 +496,10 @@ mod tests {
     }
 
     impl GitHubApi for MockGitHubApi {
-        fn fetch_latest_release(&self, _token: Option<&str>) -> crate::update::UpdateResult<Release> {
+        fn fetch_latest_release(
+            &self,
+            _token: Option<&str>,
+        ) -> crate::update::UpdateResult<Release> {
             self.release_calls.set(self.release_calls.get() + 1);
             self.release_responses
                 .borrow_mut()
@@ -482,8 +507,12 @@ mod tests {
                 .expect("Unexpected call to fetch_latest_release")
         }
 
-        fn check_build_status(&self, _token: Option<&str>) -> crate::update::UpdateResult<BuildStatus> {
-            self.build_status_calls.set(self.build_status_calls.get() + 1);
+        fn check_build_status(
+            &self,
+            _token: Option<&str>,
+        ) -> crate::update::UpdateResult<BuildStatus> {
+            self.build_status_calls
+                .set(self.build_status_calls.get() + 1);
             self.build_status_responses
                 .borrow_mut()
                 .pop_front()
@@ -552,17 +581,19 @@ mod tests {
     #[test]
     fn test_public_repo_no_auth_needed() {
         // Public repo: both build status and release work without auth
-        let github = MockGitHubApi::new(
-            vec![Ok(BuildStatus::Idle)],
-            vec![Ok(make_test_release())],
-        );
+        let github = MockGitHubApi::new(vec![Ok(BuildStatus::Idle)], vec![Ok(make_test_release())]);
         let auth = MockAuthProvider { token: None };
         let prompt = MockPromptProvider::new(vec![]);
 
         let mut token = None;
         let result = fetch_with_auth_fallback_impl(
-            &github, &auth, &prompt,
-            &mut token, true, false, 600,
+            &github,
+            &auth,
+            &prompt,
+            &mut token,
+            true,
+            false,
+            600,
             &ProgressBar::hidden(),
         );
 
@@ -582,13 +613,20 @@ mod tests {
             ],
             vec![Ok(make_test_release())],
         );
-        let auth = MockAuthProvider { token: Some("test_token".to_string()) };
+        let auth = MockAuthProvider {
+            token: Some("test_token".to_string()),
+        };
         let prompt = MockPromptProvider::new(vec![true]); // User says yes
 
         let mut token = None;
         let result = fetch_with_auth_fallback_impl(
-            &github, &auth, &prompt,
-            &mut token, true, false, 600,
+            &github,
+            &auth,
+            &prompt,
+            &mut token,
+            true,
+            false,
+            600,
             &ProgressBar::hidden(),
         );
 
@@ -602,16 +640,25 @@ mod tests {
     fn test_private_repo_auth_required_user_declines() {
         // Private repo: 404 without auth, user declines auth
         let github = MockGitHubApi::new(
-            vec![Err(UpdateError::GitHubApi("HTTP 404: Not Found".to_string()))],
+            vec![Err(UpdateError::GitHubApi(
+                "HTTP 404: Not Found".to_string(),
+            ))],
             vec![Err(UpdateError::NotFound { has_token: false })],
         );
-        let auth = MockAuthProvider { token: Some("test_token".to_string()) };
+        let auth = MockAuthProvider {
+            token: Some("test_token".to_string()),
+        };
         let prompt = MockPromptProvider::new(vec![false, false]); // User says no twice
 
         let mut token = None;
         let result = fetch_with_auth_fallback_impl(
-            &github, &auth, &prompt,
-            &mut token, true, false, 600,
+            &github,
+            &auth,
+            &prompt,
+            &mut token,
+            true,
+            false,
+            600,
             &ProgressBar::hidden(),
         );
 
@@ -622,17 +669,19 @@ mod tests {
     #[test]
     fn test_with_preexisting_token() {
         // User already has a token (from env or --use-gh-auth)
-        let github = MockGitHubApi::new(
-            vec![Ok(BuildStatus::Idle)],
-            vec![Ok(make_test_release())],
-        );
+        let github = MockGitHubApi::new(vec![Ok(BuildStatus::Idle)], vec![Ok(make_test_release())]);
         let auth = MockAuthProvider { token: None };
         let prompt = MockPromptProvider::new(vec![]); // Should not be called
 
         let mut token = Some("existing_token".to_string());
         let result = fetch_with_auth_fallback_impl(
-            &github, &auth, &prompt,
-            &mut token, true, false, 600,
+            &github,
+            &auth,
+            &prompt,
+            &mut token,
+            true,
+            false,
+            600,
             &ProgressBar::hidden(),
         );
 
@@ -652,14 +701,21 @@ mod tests {
             ],
             vec![Ok(make_test_release())],
         );
-        let auth = MockAuthProvider { token: Some("test_token".to_string()) };
+        let auth = MockAuthProvider {
+            token: Some("test_token".to_string()),
+        };
         let prompt = MockPromptProvider::new(vec![true]); // Accept auth
 
         let mut token = None;
         // check_only=true so we don't try to wait
         let result = fetch_with_auth_fallback_impl(
-            &github, &auth, &prompt,
-            &mut token, true, true, 600,
+            &github,
+            &auth,
+            &prompt,
+            &mut token,
+            true,
+            true,
+            600,
             &ProgressBar::hidden(),
         );
 
@@ -678,13 +734,20 @@ mod tests {
                 Ok(make_test_release()),
             ],
         );
-        let auth = MockAuthProvider { token: Some("test_token".to_string()) };
+        let auth = MockAuthProvider {
+            token: Some("test_token".to_string()),
+        };
         let prompt = MockPromptProvider::new(vec![true]); // Accept auth for release
 
         let mut token = None;
         let result = fetch_with_auth_fallback_impl(
-            &github, &auth, &prompt,
-            &mut token, true, false, 600,
+            &github,
+            &auth,
+            &prompt,
+            &mut token,
+            true,
+            false,
+            600,
             &ProgressBar::hidden(),
         );
 

--- a/src/db/calendars.rs
+++ b/src/db/calendars.rs
@@ -83,7 +83,9 @@ pub fn list_events(
     calendar: Option<&str>,
     date_range: Option<&DateRange>,
 ) -> Result<Vec<CalendarEvent>> {
-    let mut sql = String::from("SELECT id, summary, start_time, end_time, calendar_id, attendees_json, conference_data_json, description, extra_json FROM events WHERE 1=1");
+    let mut sql = String::from(
+        "SELECT id, summary, start_time, end_time, calendar_id, attendees_json, conference_data_json, description, extra_json FROM events WHERE 1=1",
+    );
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
     if let Some(cal) = calendar {
@@ -121,7 +123,10 @@ pub fn list_events(
         })
     })?;
 
-    Ok(rows.filter_map(|r| r.ok()).map(row_to_calendar_event).collect())
+    Ok(rows
+        .filter_map(|r| r.ok())
+        .map(row_to_calendar_event)
+        .collect())
 }
 
 #[cfg(test)]
@@ -173,7 +178,9 @@ mod tests {
             end_time: Some("2026-01-20T11:00:00Z".to_string()),
             calendar_id: Some("cal-1".to_string()),
             attendees_json: Some(r#"[{"email":"alice@example.com"}]"#.to_string()),
-            conference_data_json: Some(r#"{"entryPointUri":"https://meet.google.com/abc"}"#.to_string()),
+            conference_data_json: Some(
+                r#"{"entryPointUri":"https://meet.google.com/abc"}"#.to_string(),
+            ),
             description: Some("Discuss project".to_string()),
             extra_json: Some(r#"{"custom":"value"}"#.to_string()),
         };

--- a/src/db/info.rs
+++ b/src/db/info.rs
@@ -5,7 +5,7 @@ use rusqlite::Connection;
 use serde::Serialize;
 
 use crate::db::schema::get_schema_version;
-use crate::embed::{calculate_chunk_size_stats, ChunkSizeStats};
+use crate::embed::{ChunkSizeStats, calculate_chunk_size_stats};
 
 #[derive(Debug, Serialize)]
 pub struct DbInfo {
@@ -61,14 +61,12 @@ pub fn get_info_db_only(conn: &Connection, db_path: &Path) -> Result<DbInfo> {
     )?;
 
     // Other counts
-    let total_people: i64 =
-        conn.query_row("SELECT COUNT(*) FROM people", [], |row| row.get(0))?;
+    let total_people: i64 = conn.query_row("SELECT COUNT(*) FROM people", [], |row| row.get(0))?;
 
     let total_calendars: i64 =
         conn.query_row("SELECT COUNT(*) FROM calendars", [], |row| row.get(0))?;
 
-    let total_events: i64 =
-        conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+    let total_events: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
 
     let total_templates: i64 = conn.query_row(
         "SELECT COUNT(*) FROM templates WHERE deleted_at IS NULL",
@@ -84,11 +82,10 @@ pub fn get_info_db_only(conn: &Connection, db_path: &Path) -> Result<DbInfo> {
 
     let total_panels: i64 = crate::db::panels::count_panels(conn).unwrap_or(0);
 
-    let total_utterances: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM transcript_utterances",
-        [],
-        |row| row.get(0),
-    )?;
+    let total_utterances: i64 =
+        conn.query_row("SELECT COUNT(*) FROM transcript_utterances", [], |row| {
+            row.get(0)
+        })?;
 
     // Embedding stats
     let total_chunks: i64 = conn
@@ -109,9 +106,7 @@ pub fn get_info_db_only(conn: &Connection, db_path: &Path) -> Result<DbInfo> {
 
     let chunk_size_stats = calculate_chunk_size_stats(conn).unwrap_or(None);
 
-    let db_size_bytes = std::fs::metadata(db_path)
-        .map(|m| m.len())
-        .unwrap_or(0);
+    let db_size_bytes = std::fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
 
     let schema_version = get_schema_version(conn).unwrap_or(0);
 
@@ -189,8 +184,14 @@ mod tests {
         assert_eq!(info.total_documents, 2);
         assert_eq!(info.documents_with_transcripts, 1);
         assert_eq!(info.documents_without_transcripts, 1);
-        assert_eq!(info.earliest_document, Some("2024-01-15T10:00:00Z".to_string()));
-        assert_eq!(info.latest_document, Some("2024-06-20T10:00:00Z".to_string()));
+        assert_eq!(
+            info.earliest_document,
+            Some("2024-01-15T10:00:00Z".to_string())
+        );
+        assert_eq!(
+            info.latest_document,
+            Some("2024-06-20T10:00:00Z".to_string())
+        );
         assert_eq!(info.total_people, 1);
         assert_eq!(info.total_calendars, 1);
         assert_eq!(info.total_events, 0);

--- a/src/db/integrity.rs
+++ b/src/db/integrity.rs
@@ -4,7 +4,7 @@
 use std::path::Path;
 use std::time::Instant;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use log::debug;
 use rusqlite::{Connection, ErrorCode, OpenFlags};
 
@@ -46,9 +46,7 @@ pub struct FtsIndexReport {
 pub fn check_fts_indexes(conn: &Connection) -> Result<Vec<FtsIndexReport>> {
     MAINTAINED_FTS_TABLES
         .iter()
-        .map(|&table| {
-            check_fts_index(conn, table).map(|state| FtsIndexReport { table, state })
-        })
+        .map(|&table| check_fts_index(conn, table).map(|state| FtsIndexReport { table, state }))
         .collect()
 }
 
@@ -84,8 +82,11 @@ fn check_fts_index(conn: &Connection, table: &str) -> Result<FtsIndexState> {
 /// consistent one.
 pub fn rebuild_fts_indexes(conn: &Connection) -> Result<Vec<&'static str>> {
     for table in MAINTAINED_FTS_TABLES {
-        conn.execute(&format!("INSERT INTO {table}({table}) VALUES('rebuild')"), [])
-            .with_context(|| format!("rebuilding {table}"))?;
+        conn.execute(
+            &format!("INSERT INTO {table}({table}) VALUES('rebuild')"),
+            [],
+        )
+        .with_context(|| format!("rebuilding {table}"))?;
     }
 
     Ok(MAINTAINED_FTS_TABLES.to_vec())
@@ -202,7 +203,8 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("other.db");
         let conn = Connection::open(&path).unwrap();
-        conn.execute("CREATE TABLE unrelated (id INTEGER)", []).unwrap();
+        conn.execute("CREATE TABLE unrelated (id INTEGER)", [])
+            .unwrap();
         drop(conn);
 
         assert!(check_pulled_database(&path).is_err());
@@ -253,7 +255,10 @@ mod tests {
 
         let reports = check_fts_indexes(&conn).unwrap();
 
-        let transcripts = reports.iter().find(|r| r.table == "transcript_fts").unwrap();
+        let transcripts = reports
+            .iter()
+            .find(|r| r.table == "transcript_fts")
+            .unwrap();
         assert!(
             matches!(transcripts.state, FtsIndexState::Drifted(_)),
             "expected drift, got {:?}",

--- a/src/db/meetings.rs
+++ b/src/db/meetings.rs
@@ -133,21 +133,24 @@ pub fn show_meeting(conn: &Connection, query: &str) -> Result<Option<Document>> 
     )?;
 
     let result = stmt
-        .query_row(rusqlite::params![query, prefix_pattern, title_pattern], |row| {
-            Ok(DocumentRow {
-                id: row.get(0)?,
-                title: row.get(1)?,
-                created_at: row.get(2)?,
-                updated_at: row.get(3)?,
-                deleted_at: row.get(4)?,
-                doc_type: row.get(5)?,
-                notes_plain: row.get(6)?,
-                notes_markdown: row.get(7)?,
-                summary: row.get(8)?,
-                people_json: row.get(9)?,
-                google_calendar_event_json: row.get(10)?,
-            })
-        })
+        .query_row(
+            rusqlite::params![query, prefix_pattern, title_pattern],
+            |row| {
+                Ok(DocumentRow {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    created_at: row.get(2)?,
+                    updated_at: row.get(3)?,
+                    deleted_at: row.get(4)?,
+                    doc_type: row.get(5)?,
+                    notes_plain: row.get(6)?,
+                    notes_markdown: row.get(7)?,
+                    summary: row.get(8)?,
+                    people_json: row.get(9)?,
+                    google_calendar_event_json: row.get(10)?,
+                })
+            },
+        )
         .ok();
 
     Ok(result.map(row_to_document))
@@ -319,8 +322,10 @@ pub fn get_meetings_by_ids(conn: &Connection, ids: &[String]) -> Result<Vec<Docu
     );
 
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> =
-        ids.iter().map(|id| id as &dyn rusqlite::types::ToSql).collect();
+    let params: Vec<&dyn rusqlite::types::ToSql> = ids
+        .iter()
+        .map(|id| id as &dyn rusqlite::types::ToSql)
+        .collect();
     let rows = stmt.query_map(params.as_slice(), |row| {
         Ok(DocumentRow {
             id: row.get(0)?,
@@ -357,7 +362,9 @@ pub fn title_series_counts(conn: &Connection) -> Result<HashMap<String, u32>> {
          WHERE deleted_at IS NULL AND title IS NOT NULL AND trim(title) <> ''
          GROUP BY lower(trim(title))",
     )?;
-    let rows = stmt.query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?)))?;
+    let rows = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, u32>(1)?))
+    })?;
     Ok(rows.collect::<rusqlite::Result<HashMap<_, _>>>()?)
 }
 
@@ -570,7 +577,10 @@ mod tests {
         )
         .unwrap();
         let transcript = get_transcript(&conn, "doc-1").unwrap();
-        let mic_utt = transcript.iter().find(|u| u.id.as_deref() == Some("u-mic")).unwrap();
+        let mic_utt = transcript
+            .iter()
+            .find(|u| u.id.as_deref() == Some("u-mic"))
+            .unwrap();
         assert_eq!(mic_utt.source.as_deref(), Some("microphone"));
         assert_eq!(mic_utt.is_final, Some(true));
     }
@@ -585,8 +595,7 @@ mod tests {
     #[test]
     fn test_search_meetings_by_title() {
         let conn = build_test_db(&meetings_state());
-        let results =
-            search_meetings(&conn, "AI", true, false, false, false, None, false).unwrap();
+        let results = search_meetings(&conn, "AI", true, false, false, false, None, false).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].title.as_deref(), Some("AI Strategy Meeting"));
     }
@@ -609,8 +618,17 @@ mod tests {
         // Regression for #75: the old titles arm matched the whole query as
         // one substring, so "review budget" missed a "Budget review" title.
         let conn = build_test_db(&title_search_state());
-        let results =
-            search_meetings(&conn, "review budget", true, false, false, false, None, false).unwrap();
+        let results = search_meetings(
+            &conn,
+            "review budget",
+            true,
+            false,
+            false,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-budget"));
     }
@@ -620,9 +638,17 @@ mod tests {
         // Words separated by other words (and punctuation) in the title must
         // still match under implicit-AND word semantics.
         let conn = build_test_db(&title_search_state());
-        let results =
-            search_meetings(&conn, "integrations standup", true, false, false, false, None, false)
-                .unwrap();
+        let results = search_meetings(
+            &conn,
+            "integrations standup",
+            true,
+            false,
+            false,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-standup"));
     }
@@ -640,8 +666,17 @@ mod tests {
     #[test]
     fn test_search_meetings_by_transcript() {
         let conn = build_test_db(&meetings_state());
-        let results =
-            search_meetings(&conn, "neural networks", false, true, false, false, None, false).unwrap();
+        let results = search_meetings(
+            &conn,
+            "neural networks",
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-1"));
     }
@@ -733,9 +768,17 @@ mod tests {
         // Regression: the old sanitizer quoted the whole query as one FTS5
         // phrase, so reversed word order never matched.
         let conn = build_test_db(&meetings_state());
-        let results =
-            search_meetings(&conn, "networks neural", false, true, false, false, None, false)
-                .unwrap();
+        let results = search_meetings(
+            &conn,
+            "networks neural",
+            false,
+            true,
+            false,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-1"));
     }
@@ -760,8 +803,17 @@ mod tests {
     #[test]
     fn test_search_meetings_by_notes() {
         let conn = build_test_db(&meetings_state());
-        let results =
-            search_meetings(&conn, "machine learning", false, false, true, false, None, false).unwrap();
+        let results = search_meetings(
+            &conn,
+            "machine learning",
+            false,
+            false,
+            true,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id.as_deref(), Some("doc-1"));
     }
@@ -769,8 +821,17 @@ mod tests {
     #[test]
     fn test_search_meetings_no_results() {
         let conn = build_test_db(&meetings_state());
-        let results =
-            search_meetings(&conn, "quantum computing", true, true, true, false, None, false).unwrap();
+        let results = search_meetings(
+            &conn,
+            "quantum computing",
+            true,
+            true,
+            true,
+            false,
+            None,
+            false,
+        )
+        .unwrap();
         assert!(results.is_empty());
     }
 
@@ -781,8 +842,17 @@ mod tests {
             start: Some(Utc.with_ymd_and_hms(2026, 1, 22, 0, 0, 0).unwrap()),
             end: Some(Utc.with_ymd_and_hms(2026, 1, 23, 0, 0, 0).unwrap()),
         };
-        let results =
-            search_meetings(&conn, "Standup", true, false, false, false, Some(&range), false).unwrap();
+        let results = search_meetings(
+            &conn,
+            "Standup",
+            true,
+            false,
+            false,
+            false,
+            Some(&range),
+            false,
+        )
+        .unwrap();
         assert_eq!(results.len(), 1);
 
         // AI meeting is outside range even though title matches
@@ -813,16 +883,21 @@ mod tests {
             [],
         )
         .unwrap();
-        conn.execute(
-            "INSERT INTO panels_fts(panels_fts) VALUES('rebuild')",
-            [],
-        )
-        .unwrap();
+        conn.execute("INSERT INTO panels_fts(panels_fts) VALUES('rebuild')", [])
+            .unwrap();
 
         // Searching for the deleted panel's content via search_meetings should return nothing
-        let results =
-            search_meetings(&conn, "unique_deleted_content", false, false, false, true, None, false)
-                .unwrap();
+        let results = search_meetings(
+            &conn,
+            "unique_deleted_content",
+            false,
+            false,
+            false,
+            true,
+            None,
+            false,
+        )
+        .unwrap();
         assert!(
             results.is_empty(),
             "Soft-deleted panels should not appear in search_meetings results"

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use rusqlite::Connection;
-use rusqlite_migration::{Migrations, M};
+use rusqlite_migration::{M, Migrations};
 
 /// All migrations, in order. Each migration brings the schema from version N to N+1.
 /// The `user_version` pragma is used automatically by rusqlite_migration to track
@@ -45,7 +45,8 @@ pub fn open_and_migrate(db_path: &Path) -> Result<Connection> {
     let m = migrations();
 
     // Check if there are pending migrations
-    let current_version = m.current_version(&conn)
+    let current_version = m
+        .current_version(&conn)
         .context("Failed to check current schema version")?;
 
     // Check if we need to apply migrations by comparing current vs target
@@ -60,7 +61,10 @@ pub fn open_and_migrate(db_path: &Path) -> Result<Connection> {
         rusqlite_migration::SchemaVersion::Outside(_) => false,
     };
 
-    if needs_migration && db_exists && !matches!(current_version, rusqlite_migration::SchemaVersion::NoneSet) {
+    if needs_migration
+        && db_exists
+        && !matches!(current_version, rusqlite_migration::SchemaVersion::NoneSet)
+    {
         backup_database(db_path)?;
         eprintln!("[grans] Applying database migration(s)...");
     } else if needs_migration && !db_exists {
@@ -76,7 +80,8 @@ pub fn open_and_migrate(db_path: &Path) -> Result<Connection> {
 /// Get the current schema version from the database.
 pub fn get_schema_version(conn: &Connection) -> Result<usize> {
     let m = migrations();
-    let version = m.current_version(conn)
+    let version = m
+        .current_version(conn)
         .context("Failed to get schema version")?;
 
     Ok(match version {
@@ -410,11 +415,8 @@ mod tests {
         assert_eq!(attempts, 1);
 
         // Verify panels_fts virtual table exists and is searchable
-        conn.execute(
-            "INSERT INTO panels_fts(panels_fts) VALUES('rebuild')",
-            [],
-        )
-        .unwrap();
+        conn.execute("INSERT INTO panels_fts(panels_fts) VALUES('rebuild')", [])
+            .unwrap();
 
         let fts_count: i64 = conn
             .query_row(
@@ -442,27 +444,20 @@ mod tests {
 
         // Verify title can be retrieved as String (not Option<String>)
         let title: String = conn
-            .query_row(
-                "SELECT title FROM documents WHERE id = 'doc1'",
-                [],
-                |row| row.get(0),
-            )
+            .query_row("SELECT title FROM documents WHERE id = 'doc1'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(title, "Test Doc");
 
         // Insert a document with empty string title - should work fine
-        conn.execute(
-            "INSERT INTO documents (id, title) VALUES ('doc2', '')",
-            [],
-        )
-        .unwrap();
+        conn.execute("INSERT INTO documents (id, title) VALUES ('doc2', '')", [])
+            .unwrap();
 
         let title: String = conn
-            .query_row(
-                "SELECT title FROM documents WHERE id = 'doc2'",
-                [],
-                |row| row.get(0),
-            )
+            .query_row("SELECT title FROM documents WHERE id = 'doc2'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(title, "");
     }
@@ -504,7 +499,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(raw_json, Some("{\"id\":\"doc1\",\"title\":\"Test Doc\"}".to_string()));
+        assert_eq!(
+            raw_json,
+            Some("{\"id\":\"doc1\",\"title\":\"Test Doc\"}".to_string())
+        );
 
         // Verify NULL is allowed
         conn.execute(
@@ -538,14 +536,29 @@ mod tests {
         .unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM templates WHERE id = 't1'", [], |row| row.get(0))
+            .query_row(
+                "SELECT raw_json FROM templates WHERE id = 't1'",
+                [],
+                |row| row.get(0),
+            )
             .unwrap();
-        assert_eq!(raw_json, Some("{\"id\":\"t1\",\"title\":\"Test Template\"}".to_string()));
+        assert_eq!(
+            raw_json,
+            Some("{\"id\":\"t1\",\"title\":\"Test Template\"}".to_string())
+        );
 
         // Templates: NULL is allowed
-        conn.execute("INSERT INTO templates (id, title) VALUES ('t2', 'No Raw')", []).unwrap();
+        conn.execute(
+            "INSERT INTO templates (id, title) VALUES ('t2', 'No Raw')",
+            [],
+        )
+        .unwrap();
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM templates WHERE id = 't2'", [], |row| row.get(0))
+            .query_row(
+                "SELECT raw_json FROM templates WHERE id = 't2'",
+                [],
+                |row| row.get(0),
+            )
             .unwrap();
         assert!(raw_json.is_none());
 
@@ -557,14 +570,22 @@ mod tests {
         .unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM recipes WHERE id = 'r1'", [], |row| row.get(0))
+            .query_row("SELECT raw_json FROM recipes WHERE id = 'r1'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
-        assert_eq!(raw_json, Some("{\"id\":\"r1\",\"slug\":\"test-recipe\"}".to_string()));
+        assert_eq!(
+            raw_json,
+            Some("{\"id\":\"r1\",\"slug\":\"test-recipe\"}".to_string())
+        );
 
         // Recipes: NULL is allowed
-        conn.execute("INSERT INTO recipes (id, slug) VALUES ('r2', 'no-raw')", []).unwrap();
+        conn.execute("INSERT INTO recipes (id, slug) VALUES ('r2', 'no-raw')", [])
+            .unwrap();
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM recipes WHERE id = 'r2'", [], |row| row.get(0))
+            .query_row("SELECT raw_json FROM recipes WHERE id = 'r2'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert!(raw_json.is_none());
 
@@ -576,14 +597,25 @@ mod tests {
         .unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM events WHERE id = 'e1'", [], |row| row.get(0))
+            .query_row("SELECT raw_json FROM events WHERE id = 'e1'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
-        assert_eq!(raw_json, Some("{\"id\":\"e1\",\"summary\":\"Test Event\"}".to_string()));
+        assert_eq!(
+            raw_json,
+            Some("{\"id\":\"e1\",\"summary\":\"Test Event\"}".to_string())
+        );
 
         // Events: NULL is allowed
-        conn.execute("INSERT INTO events (id, summary) VALUES ('e2', 'No Raw')", []).unwrap();
+        conn.execute(
+            "INSERT INTO events (id, summary) VALUES ('e2', 'No Raw')",
+            [],
+        )
+        .unwrap();
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM events WHERE id = 'e2'", [], |row| row.get(0))
+            .query_row("SELECT raw_json FROM events WHERE id = 'e2'", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert!(raw_json.is_none());
     }
@@ -876,7 +908,10 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(chat_url, Some("https://notes.granola.ai/t/abc123".to_string()));
+        assert_eq!(
+            chat_url,
+            Some("https://notes.granola.ai/t/abc123".to_string())
+        );
 
         // Verify NULL is allowed
         conn.execute(
@@ -929,8 +964,11 @@ mod tests {
 
         // Exactly the shape an interrupted sync left behind: source rows
         // committed, the trailing FTS insert never reached.
-        conn.execute("INSERT INTO documents (id, title) VALUES ('doc1', 'Test')", [])
-            .unwrap();
+        conn.execute(
+            "INSERT INTO documents (id, title) VALUES ('doc1', 'Test')",
+            [],
+        )
+        .unwrap();
         conn.execute(
             "INSERT INTO transcript_utterances (id, document_id, text)
              VALUES ('u1', 'doc1', 'deployment rollback')",
@@ -961,8 +999,11 @@ mod tests {
         let db_path = dir.path().join("test.db");
         let conn = open_and_migrate(&db_path).unwrap();
 
-        conn.execute("INSERT INTO documents (id, title) VALUES ('doc1', 'Test')", [])
-            .unwrap();
+        conn.execute(
+            "INSERT INTO documents (id, title) VALUES ('doc1', 'Test')",
+            [],
+        )
+        .unwrap();
         conn.execute(
             "INSERT INTO transcript_utterances (id, document_id, text)
              VALUES ('u1', 'doc1', 'deployment rollback')",

--- a/src/db/panels.rs
+++ b/src/db/panels.rs
@@ -80,7 +80,10 @@ fn redact_panel_snapshot(panel: &ApiPanel) -> Option<String> {
     for &key in PANEL_REDACT_KEYS {
         if let Some(v) = obj.get(key) {
             if !v.is_null() {
-                obj.insert(key.to_string(), serde_json::Value::String("[stored]".to_string()));
+                obj.insert(
+                    key.to_string(),
+                    serde_json::Value::String("[stored]".to_string()),
+                );
             }
         }
     }
@@ -184,9 +187,7 @@ pub fn find_documents_without_panels(
     );
 
     if skip_logged_failures {
-        sql.push_str(
-            " AND NOT EXISTS (SELECT 1 FROM panel_sync_log l WHERE l.document_id = d.id)",
-        );
+        sql.push_str(" AND NOT EXISTS (SELECT 1 FROM panel_sync_log l WHERE l.document_id = d.id)");
     }
 
     if since.is_some() {
@@ -251,10 +252,7 @@ pub fn insert_panels_from_api(
         .context("Failed to begin panel replacement")?;
 
     // Delete existing panels for this document
-    tx.execute(
-        "DELETE FROM panels WHERE document_id = ?1",
-        [document_id],
-    )?;
+    tx.execute("DELETE FROM panels WHERE document_id = ?1", [document_id])?;
 
     let mut stmt = tx.prepare(
         "INSERT INTO panels (id, document_id, title, content_json, content_markdown,
@@ -290,18 +288,13 @@ pub fn insert_panels_from_api(
     }
 
     drop(stmt);
-    tx.commit()
-        .context("Failed to commit panel replacement")?;
+    tx.commit().context("Failed to commit panel replacement")?;
 
     Ok(inserted)
 }
 
 /// Record a panel sync failure for a document.
-pub fn log_panel_sync_failure(
-    conn: &Connection,
-    document_id: &str,
-    status: &str,
-) -> Result<()> {
+pub fn log_panel_sync_failure(conn: &Connection, document_id: &str, status: &str) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     conn.execute(
         "INSERT INTO panel_sync_log (document_id, status, last_attempted_at, attempts)
@@ -391,16 +384,14 @@ mod tests {
     fn test_find_documents_without_panels_with_since() {
         let conn = build_test_db(&panels_state());
         // doc-2 is at 2026-01-21, filter since 2026-01-21
-        let docs =
-            find_documents_without_panels(&conn, Some("2026-01-21T00:00:00Z"), None, false)
-                .unwrap();
+        let docs = find_documents_without_panels(&conn, Some("2026-01-21T00:00:00Z"), None, false)
+            .unwrap();
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].id, "doc-2");
 
         // Filter since 2026-01-22, should find nothing
-        let docs =
-            find_documents_without_panels(&conn, Some("2026-01-22T00:00:00Z"), None, false)
-                .unwrap();
+        let docs = find_documents_without_panels(&conn, Some("2026-01-22T00:00:00Z"), None, false)
+            .unwrap();
         assert!(docs.is_empty());
     }
 
@@ -455,22 +446,20 @@ mod tests {
         let old_panels = load_panels(&conn, "doc-1").unwrap();
         assert_eq!(old_panels.len(), 1);
 
-        let api_panels = vec![
-            crate::api::ApiPanel {
-                id: Some("panel-replaced-1".to_string()),
-                document_id: Some("doc-1".to_string()),
-                title: Some("New Panel".to_string()),
-                content: Some(json!({"type": "doc", "content": [
-                    {"type": "paragraph", "content": [{"type": "text", "text": "Replaced content"}]}
-                ]})),
-                original_content: None,
-                template_slug: None,
-                created_at: None,
-                updated_at: None,
-                deleted_at: None,
-                extra: Default::default(),
-            },
-        ];
+        let api_panels = vec![crate::api::ApiPanel {
+            id: Some("panel-replaced-1".to_string()),
+            document_id: Some("doc-1".to_string()),
+            title: Some("New Panel".to_string()),
+            content: Some(json!({"type": "doc", "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": "Replaced content"}]}
+            ]})),
+            original_content: None,
+            template_slug: None,
+            created_at: None,
+            updated_at: None,
+            deleted_at: None,
+            extra: Default::default(),
+        }];
 
         let inserted = insert_panels_from_api(&conn, "doc-1", &api_panels).unwrap();
         assert_eq!(inserted, 1);
@@ -552,11 +541,19 @@ mod tests {
             [],
         )
         .unwrap();
-        assert_eq!(hits("photosynthesis"), 1, "the insert alone should index it");
+        assert_eq!(
+            hits("photosynthesis"),
+            1,
+            "the insert alone should index it"
+        );
 
         conn.execute("DELETE FROM panels WHERE id = 'panel-bare'", [])
             .unwrap();
-        assert_eq!(hits("photosynthesis"), 0, "the delete alone should unindex it");
+        assert_eq!(
+            hits("photosynthesis"),
+            0,
+            "the delete alone should unindex it"
+        );
 
         for report in crate::db::integrity::check_fts_indexes(&conn).unwrap() {
             assert_eq!(
@@ -800,7 +797,10 @@ mod tests {
         assert_eq!(panel.title.as_deref(), Some("Summary"));
         assert!(panel.content_markdown.unwrap().contains("Key Points"));
         assert_eq!(panel.template_slug.as_deref(), Some("summary"));
-        assert_eq!(panel.chat_url.as_deref(), Some("https://notes.granola.ai/t/abc123"));
+        assert_eq!(
+            panel.chat_url.as_deref(),
+            Some("https://notes.granola.ai/t/abc123")
+        );
         assert!(panel.deleted_at.is_none());
         assert!(panel.extra.is_empty());
     }
@@ -827,7 +827,10 @@ mod tests {
         let write_row = api_panel_to_write_row(&panel).unwrap();
         assert_eq!(write_row.id.as_deref(), Some("panel-1"));
         assert_eq!(write_row.title.as_deref(), Some("Action Items"));
-        assert_eq!(write_row.content_markdown.as_deref(), Some("Review the proposal"));
+        assert_eq!(
+            write_row.content_markdown.as_deref(),
+            Some("Review the proposal")
+        );
         assert!(write_row.content_json.is_some());
         assert!(write_row.original_content_json.is_some());
         assert!(write_row.chat_url.is_none());
@@ -877,7 +880,10 @@ mod tests {
             extra: Default::default(),
         };
         let write_row = api_panel_to_write_row(&panel).unwrap();
-        assert_eq!(write_row.chat_url.as_deref(), Some("https://notes.granola.ai/t/abc123"));
+        assert_eq!(
+            write_row.chat_url.as_deref(),
+            Some("https://notes.granola.ai/t/abc123")
+        );
         let md = write_row.content_markdown.unwrap();
         assert!(!md.contains("notes.granola.ai"));
         assert!(md.contains("Key decisions."));
@@ -902,7 +908,8 @@ mod tests {
         };
         let write_row = api_panel_to_write_row(&panel).unwrap();
         assert!(write_row.extra_json.is_some());
-        let parsed: serde_json::Value = serde_json::from_str(&write_row.extra_json.unwrap()).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&write_row.extra_json.unwrap()).unwrap();
         assert_eq!(parsed["custom"], "value");
     }
 

--- a/src/db/people.rs
+++ b/src/db/people.rs
@@ -32,8 +32,9 @@ fn row_to_person(row: PersonRow) -> Person {
 }
 
 pub fn list_people(conn: &Connection, company: Option<&str>) -> Result<Vec<Person>> {
-    let mut sql =
-        String::from("SELECT id, name, email, company_name, job_title, extra_json FROM people WHERE 1=1");
+    let mut sql = String::from(
+        "SELECT id, name, email, company_name, job_title, extra_json FROM people WHERE 1=1",
+    );
     let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
 
     if let Some(company_q) = company {
@@ -87,7 +88,11 @@ pub fn find_meetings_by_person(
     include_deleted: bool,
 ) -> Result<Vec<Document>> {
     let pattern = format!("%{}%", query);
-    let deleted_filter = if include_deleted { "" } else { " AND d.deleted_at IS NULL" };
+    let deleted_filter = if include_deleted {
+        ""
+    } else {
+        " AND d.deleted_at IS NULL"
+    };
     let sql = format!(
         "SELECT DISTINCT d.id, d.title, d.created_at, d.updated_at, d.deleted_at, d.doc_type, d.notes_plain, d.notes_markdown, d.summary, d.people_json, d.google_calendar_event_json
          FROM documents d

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -24,12 +24,20 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
     conn.execute_batch(include_str!("migrations/v004_make_title_not_null.sql"))?;
     conn.execute_batch(include_str!("migrations/v005_transcript_sync_log.sql"))?;
     conn.execute_batch(include_str!("migrations/v006_panels.sql"))?;
-    conn.execute_batch(include_str!("migrations/v007_transcript_utterance_index.sql"))?;
+    conn.execute_batch(include_str!(
+        "migrations/v007_transcript_utterance_index.sql"
+    ))?;
     conn.execute_batch(include_str!("migrations/v008_panel_chat_url.sql"))?;
     conn.execute_batch(include_str!("migrations/v009_document_raw_json.sql"))?;
-    conn.execute_batch(include_str!("migrations/v010_rename_audio_source_to_source.sql"))?;
-    conn.execute_batch(include_str!("migrations/v011_raw_json_templates_recipes_events.sql"))?;
-    conn.execute_batch(include_str!("migrations/v012_rename_is_primary_to_primary.sql"))?;
+    conn.execute_batch(include_str!(
+        "migrations/v010_rename_audio_source_to_source.sql"
+    ))?;
+    conn.execute_batch(include_str!(
+        "migrations/v011_raw_json_templates_recipes_events.sql"
+    ))?;
+    conn.execute_batch(include_str!(
+        "migrations/v012_rename_is_primary_to_primary.sql"
+    ))?;
     conn.execute_batch(include_str!("migrations/v013_api_snapshot.sql"))?;
     conn.execute_batch(include_str!("migrations/v014_utterance_speaker_name.sql"))?;
     conn.execute_batch(include_str!("migrations/v015_fts_triggers.sql"))?;

--- a/src/db/sync.rs
+++ b/src/db/sync.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::api::types::GetRecipesResponse;
-use crate::models::{
-    CalendarEvent, Document, DocumentPeople, PanelTemplate, Person, Recipe,
-};
+use crate::models::{CalendarEvent, Document, DocumentPeople, PanelTemplate, Person, Recipe};
 
 // ============================================================================
 // Sync Statistics
@@ -37,9 +35,19 @@ struct DocumentJsonFields {
 
 fn serialize_document_json(doc: &Document) -> DocumentJsonFields {
     DocumentJsonFields {
-        people_json: doc.people.as_ref().and_then(|p| serde_json::to_string(p).ok()),
-        event_json: doc.google_calendar_event.as_ref().and_then(|e| serde_json::to_string(e).ok()),
-        extra_json: if doc.extra.is_empty() { None } else { serde_json::to_string(&doc.extra).ok() },
+        people_json: doc
+            .people
+            .as_ref()
+            .and_then(|p| serde_json::to_string(p).ok()),
+        event_json: doc
+            .google_calendar_event
+            .as_ref()
+            .and_then(|e| serde_json::to_string(e).ok()),
+        extra_json: if doc.extra.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&doc.extra).ok()
+        },
         raw_json: serde_json::to_string(doc).ok(),
     }
 }
@@ -57,9 +65,19 @@ fn serialize_event_json(event: &CalendarEvent) -> EventJsonFields {
     EventJsonFields {
         start_time: event.start.as_ref().and_then(|s| s.date_time.clone()),
         end_time: event.end.as_ref().and_then(|e| e.date_time.clone()),
-        attendees_json: event.attendees.as_ref().and_then(|a| serde_json::to_string(a).ok()),
-        conference_data_json: event.conference_data.as_ref().and_then(|c| serde_json::to_string(c).ok()),
-        extra_json: if event.extra.is_empty() { None } else { serde_json::to_string(&event.extra).ok() },
+        attendees_json: event
+            .attendees
+            .as_ref()
+            .and_then(|a| serde_json::to_string(a).ok()),
+        conference_data_json: event
+            .conference_data
+            .as_ref()
+            .and_then(|c| serde_json::to_string(c).ok()),
+        extra_json: if event.extra.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&event.extra).ok()
+        },
         raw_json: serde_json::to_string(event).ok(),
     }
 }
@@ -73,9 +91,19 @@ struct TemplateJsonFields {
 
 fn serialize_template_json(template: &PanelTemplate) -> TemplateJsonFields {
     TemplateJsonFields {
-        sections_json: template.sections.as_ref().and_then(|s| serde_json::to_string(s).ok()),
-        chat_suggestions_json: template.chat_suggestions.as_ref().and_then(|c| serde_json::to_string(c).ok()),
-        extra_json: if template.extra.is_empty() { None } else { serde_json::to_string(&template.extra).ok() },
+        sections_json: template
+            .sections
+            .as_ref()
+            .and_then(|s| serde_json::to_string(s).ok()),
+        chat_suggestions_json: template
+            .chat_suggestions
+            .as_ref()
+            .and_then(|c| serde_json::to_string(c).ok()),
+        extra_json: if template.extra.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&template.extra).ok()
+        },
         raw_json: serde_json::to_string(template).ok(),
     }
 }
@@ -88,8 +116,15 @@ struct RecipeJsonFields {
 
 fn serialize_recipe_json(recipe: &Recipe) -> RecipeJsonFields {
     RecipeJsonFields {
-        config_json: recipe.config.as_ref().and_then(|c| serde_json::to_string(c).ok()),
-        extra_json: if recipe.extra.is_empty() { None } else { serde_json::to_string(&recipe.extra).ok() },
+        config_json: recipe
+            .config
+            .as_ref()
+            .and_then(|c| serde_json::to_string(c).ok()),
+        extra_json: if recipe.extra.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&recipe.extra).ok()
+        },
         raw_json: serde_json::to_string(recipe).ok(),
     }
 }
@@ -103,9 +138,7 @@ fn serialize_recipe_json(recipe: &Recipe) -> RecipeJsonFields {
 pub fn upsert_documents(conn: &Connection, documents: &[Document]) -> Result<SyncStats> {
     let mut stats = SyncStats::default();
 
-    let initial_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM documents", [], |r| r.get(0),
-    )?;
+    let initial_count: i64 = conn.query_row("SELECT COUNT(*) FROM documents", [], |r| r.get(0))?;
 
     let mut upsert_stmt = conn.prepare(
         "INSERT INTO documents (id, title, created_at, updated_at, deleted_at, doc_type, notes_plain, notes_markdown, summary, people_json, google_calendar_event_json, extra_json, raw_json)
@@ -153,7 +186,10 @@ pub fn upsert_documents(conn: &Connection, documents: &[Document]) -> Result<Syn
             // Upsert document_people on insert or update
             if let Some(people) = &doc.people {
                 if let Err(e) = upsert_document_people(conn, doc_id, people) {
-                    eprintln!("[grans] Warning: Failed to upsert people for {}: {}", doc_id, e);
+                    eprintln!(
+                        "[grans] Warning: Failed to upsert people for {}: {}",
+                        doc_id, e
+                    );
                 }
             }
         } else {
@@ -161,19 +197,22 @@ pub fn upsert_documents(conn: &Connection, documents: &[Document]) -> Result<Syn
         }
     }
 
-    let final_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM documents", [], |r| r.get(0),
-    )?;
+    let final_count: i64 = conn.query_row("SELECT COUNT(*) FROM documents", [], |r| r.get(0))?;
     stats.inserted = (final_count - initial_count) as usize;
-    stats.updated = documents.len() - stats.unchanged - stats.inserted
+    stats.updated = documents.len()
+        - stats.unchanged
+        - stats.inserted
         - documents.iter().filter(|d| d.id.is_none()).count();
-
 
     Ok(stats)
 }
 
 /// Upsert document_people entries for a document
-fn upsert_document_people(conn: &Connection, document_id: &str, people: &DocumentPeople) -> Result<()> {
+fn upsert_document_people(
+    conn: &Connection,
+    document_id: &str,
+    people: &DocumentPeople,
+) -> Result<()> {
     // Delete existing entries for this document
     conn.execute(
         "DELETE FROM document_people WHERE document_id = ?1",
@@ -220,9 +259,7 @@ fn upsert_document_people(conn: &Connection, document_id: &str, people: &Documen
 pub fn upsert_people(conn: &Connection, people: &[Person]) -> Result<SyncStats> {
     let mut stats = SyncStats::default();
 
-    let initial_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM people", [], |r| r.get(0),
-    )?;
+    let initial_count: i64 = conn.query_row("SELECT COUNT(*) FROM people", [], |r| r.get(0))?;
 
     let mut upsert_stmt = conn.prepare(
         "INSERT INTO people (id, name, email, company_name, job_title, extra_json)
@@ -240,7 +277,11 @@ pub fn upsert_people(conn: &Connection, people: &[Person]) -> Result<SyncStats> 
             eprintln!("Warning: skipping person without ID");
             continue;
         };
-        let extra_json = if person.extra.is_empty() { None } else { serde_json::to_string(&person.extra).ok() };
+        let extra_json = if person.extra.is_empty() {
+            None
+        } else {
+            serde_json::to_string(&person.extra).ok()
+        };
 
         upsert_stmt.execute(rusqlite::params![
             person_id,
@@ -252,12 +293,10 @@ pub fn upsert_people(conn: &Connection, people: &[Person]) -> Result<SyncStats> 
         ])?;
     }
 
-    let final_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM people", [], |r| r.get(0),
-    )?;
+    let final_count: i64 = conn.query_row("SELECT COUNT(*) FROM people", [], |r| r.get(0))?;
     stats.inserted = (final_count - initial_count) as usize;
-    stats.updated = people.len() - stats.inserted
-        - people.iter().filter(|p| p.id.is_none()).count();
+    stats.updated =
+        people.len() - stats.inserted - people.iter().filter(|p| p.id.is_none()).count();
 
     Ok(stats)
 }
@@ -270,9 +309,7 @@ pub fn upsert_people(conn: &Connection, people: &[Person]) -> Result<SyncStats> 
 pub fn upsert_calendar_events(conn: &Connection, events: &[CalendarEvent]) -> Result<SyncStats> {
     let mut stats = SyncStats::default();
 
-    let initial_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM events", [], |r| r.get(0),
-    )?;
+    let initial_count: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))?;
 
     let mut upsert_stmt = conn.prepare(
         "INSERT INTO events (id, summary, start_time, end_time, calendar_id, attendees_json, conference_data_json, description, extra_json, raw_json)
@@ -310,12 +347,10 @@ pub fn upsert_calendar_events(conn: &Connection, events: &[CalendarEvent]) -> Re
         ])?;
     }
 
-    let final_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM events", [], |r| r.get(0),
-    )?;
+    let final_count: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))?;
     stats.inserted = (final_count - initial_count) as usize;
-    stats.updated = events.len() - stats.inserted
-        - events.iter().filter(|e| e.id.is_none()).count();
+    stats.updated =
+        events.len() - stats.inserted - events.iter().filter(|e| e.id.is_none()).count();
 
     Ok(stats)
 }
@@ -334,9 +369,7 @@ pub fn upsert_calendars_from_selection(
 ) -> Result<SyncStats> {
     let mut stats = SyncStats::default();
 
-    let initial_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM calendars", [], |r| r.get(0),
-    )?;
+    let initial_count: i64 = conn.query_row("SELECT COUNT(*) FROM calendars", [], |r| r.get(0))?;
 
     // For calendars, we store the selection state. The full calendar info comes from events.
     for (calendar_id, selected) in calendars_selected {
@@ -364,9 +397,7 @@ pub fn upsert_calendars_from_selection(
         }
     }
 
-    let final_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM calendars", [], |r| r.get(0),
-    )?;
+    let final_count: i64 = conn.query_row("SELECT COUNT(*) FROM calendars", [], |r| r.get(0))?;
     stats.inserted = (final_count - initial_count) as usize;
     stats.updated = calendars_selected.len() - stats.inserted;
 
@@ -381,9 +412,7 @@ pub fn upsert_calendars_from_selection(
 pub fn upsert_templates(conn: &Connection, templates: &[PanelTemplate]) -> Result<SyncStats> {
     let mut stats = SyncStats::default();
 
-    let initial_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM templates", [], |r| r.get(0),
-    )?;
+    let initial_count: i64 = conn.query_row("SELECT COUNT(*) FROM templates", [], |r| r.get(0))?;
 
     let mut upsert_stmt = conn.prepare(
         "INSERT INTO templates (id, title, category, symbol, color, description, is_granola, owner_id, sections_json, created_at, updated_at, deleted_at, chat_suggestions_json, extra_json, raw_json)
@@ -437,11 +466,11 @@ pub fn upsert_templates(conn: &Connection, templates: &[PanelTemplate]) -> Resul
         }
     }
 
-    let final_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM templates", [], |r| r.get(0),
-    )?;
+    let final_count: i64 = conn.query_row("SELECT COUNT(*) FROM templates", [], |r| r.get(0))?;
     stats.inserted = (final_count - initial_count) as usize;
-    stats.updated = templates.len() - stats.unchanged - stats.inserted
+    stats.updated = templates.len()
+        - stats.unchanged
+        - stats.inserted
         - templates.iter().filter(|t| t.id.is_none()).count();
 
     Ok(stats)
@@ -455,9 +484,7 @@ pub fn upsert_templates(conn: &Connection, templates: &[PanelTemplate]) -> Resul
 pub fn upsert_recipes(conn: &Connection, response: &GetRecipesResponse) -> Result<SyncStats> {
     let mut stats = SyncStats::default();
 
-    let initial_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM recipes", [], |r| r.get(0),
-    )?;
+    let initial_count: i64 = conn.query_row("SELECT COUNT(*) FROM recipes", [], |r| r.get(0))?;
 
     let mut upsert_stmt = conn.prepare(
         "INSERT INTO recipes (id, slug, visibility, publisher_slug, creator_name, config_json, created_at, updated_at, deleted_at, user_id, workspace_id, extra_json, raw_json)
@@ -481,7 +508,11 @@ pub fn upsert_recipes(conn: &Connection, response: &GetRecipesResponse) -> Resul
     let mut skipped = 0usize;
 
     // Process all recipes from the response
-    let mut process_recipes = |recipes: &[Recipe], visibility: &str, stats: &mut SyncStats, skipped: &mut usize| -> Result<()> {
+    let mut process_recipes = |recipes: &[Recipe],
+                               visibility: &str,
+                               stats: &mut SyncStats,
+                               skipped: &mut usize|
+     -> Result<()> {
         for recipe in recipes {
             let Some(recipe_id) = recipe.id.as_deref() else {
                 eprintln!("Warning: skipping recipe without ID");
@@ -516,15 +547,23 @@ pub fn upsert_recipes(conn: &Connection, response: &GetRecipesResponse) -> Resul
         Ok(())
     };
 
-    process_recipes(&response.default_recipes, "default", &mut stats, &mut skipped)?;
+    process_recipes(
+        &response.default_recipes,
+        "default",
+        &mut stats,
+        &mut skipped,
+    )?;
     process_recipes(&response.public_recipes, "public", &mut stats, &mut skipped)?;
     process_recipes(&response.user_recipes, "user", &mut stats, &mut skipped)?;
     process_recipes(&response.shared_recipes, "shared", &mut stats, &mut skipped)?;
-    process_recipes(&response.unlisted_recipes, "unlisted", &mut stats, &mut skipped)?;
-
-    let final_count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM recipes", [], |r| r.get(0),
+    process_recipes(
+        &response.unlisted_recipes,
+        "unlisted",
+        &mut stats,
+        &mut skipped,
     )?;
+
+    let final_count: i64 = conn.query_row("SELECT COUNT(*) FROM recipes", [], |r| r.get(0))?;
     let total_recipes = response.default_recipes.len()
         + response.public_recipes.len()
         + response.user_recipes.len()
@@ -600,7 +639,9 @@ mod tests {
 
         // Verify insertion
         let title: String = conn
-            .query_row("SELECT title FROM documents WHERE id = 'doc-1'", [], |r| r.get(0))
+            .query_row("SELECT title FROM documents WHERE id = 'doc-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(title, "Test Meeting");
     }
@@ -663,7 +704,9 @@ mod tests {
         assert_eq!(stats.updated, 1);
 
         let title: String = conn
-            .query_row("SELECT title FROM documents WHERE id = 'doc-1'", [], |r| r.get(0))
+            .query_row("SELECT title FROM documents WHERE id = 'doc-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(title, "Updated Title");
     }
@@ -768,7 +811,9 @@ mod tests {
         assert_eq!(stats.inserted, 1);
 
         let summary: String = conn
-            .query_row("SELECT summary FROM events WHERE id = 'e-1'", [], |r| r.get(0))
+            .query_row("SELECT summary FROM events WHERE id = 'e-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(summary, "Team Meeting");
     }
@@ -801,7 +846,9 @@ mod tests {
         assert_eq!(stats.inserted, 1);
 
         let title: String = conn
-            .query_row("SELECT title FROM templates WHERE id = 't-1'", [], |r| r.get(0))
+            .query_row("SELECT title FROM templates WHERE id = 't-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(title, "Meeting Notes");
     }
@@ -840,7 +887,9 @@ mod tests {
         assert_eq!(stats.inserted, 1);
 
         let slug: String = conn
-            .query_row("SELECT slug FROM recipes WHERE id = 'r-1'", [], |r| r.get(0))
+            .query_row("SELECT slug FROM recipes WHERE id = 'r-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert_eq!(slug, "test-recipe");
     }
@@ -920,7 +969,11 @@ mod tests {
         upsert_documents(&conn, &docs).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM documents WHERE id = 'doc-1'", [], |r| r.get(0))
+            .query_row(
+                "SELECT raw_json FROM documents WHERE id = 'doc-1'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!(raw_json.is_some());
 
@@ -984,7 +1037,11 @@ mod tests {
         upsert_documents(&conn, &updated_docs).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM documents WHERE id = 'doc-1'", [], |r| r.get(0))
+            .query_row(
+                "SELECT raw_json FROM documents WHERE id = 'doc-1'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw_json.unwrap()).unwrap();
         assert_eq!(parsed["title"], "Updated Title");
@@ -1025,7 +1082,11 @@ mod tests {
 
         // Verify extra_json was persisted
         let extra_json: Option<String> = conn
-            .query_row("SELECT extra_json FROM documents WHERE id = 'doc-1'", [], |r| r.get(0))
+            .query_row(
+                "SELECT extra_json FROM documents WHERE id = 'doc-1'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!(extra_json.is_some());
         let parsed: serde_json::Value = serde_json::from_str(&extra_json.unwrap()).unwrap();
@@ -1050,16 +1111,14 @@ mod tests {
                 time_zone: None,
                 extra: Default::default(),
             }),
-            attendees: Some(vec![
-                crate::models::EventAttendee {
-                    email: Some("alice@example.com".to_string()),
-                    display_name: Some("Alice".to_string()),
-                    response_status: Some("accepted".to_string()),
-                    is_self: None,
-                    organizer: None,
-                    extra: Default::default(),
-                }
-            ]),
+            attendees: Some(vec![crate::models::EventAttendee {
+                email: Some("alice@example.com".to_string()),
+                display_name: Some("Alice".to_string()),
+                response_status: Some("accepted".to_string()),
+                is_self: None,
+                organizer: None,
+                extra: Default::default(),
+            }]),
             creator: None,
             organizer: None,
             conference_data: Some(json!({"entryPointUri": "https://meet.google.com/abc-def"})),
@@ -1085,12 +1144,17 @@ mod tests {
 
         assert_eq!(description.as_deref(), Some("Discuss project updates"));
 
-        let attendees: Vec<serde_json::Value> = serde_json::from_str(&attendees_json.unwrap()).unwrap();
+        let attendees: Vec<serde_json::Value> =
+            serde_json::from_str(&attendees_json.unwrap()).unwrap();
         assert_eq!(attendees.len(), 1);
         assert_eq!(attendees[0]["email"], "alice@example.com");
 
-        let conf_data: serde_json::Value = serde_json::from_str(&conference_data_json.unwrap()).unwrap();
-        assert_eq!(conf_data["entryPointUri"], "https://meet.google.com/abc-def");
+        let conf_data: serde_json::Value =
+            serde_json::from_str(&conference_data_json.unwrap()).unwrap();
+        assert_eq!(
+            conf_data["entryPointUri"],
+            "https://meet.google.com/abc-def"
+        );
     }
 
     #[test]
@@ -1112,12 +1176,10 @@ mod tests {
             deleted_at: None,
             shared_with: None,
             copied_from: None,
-            chat_suggestions: Some(vec![
-                crate::models::ChatSuggestion {
-                    label: Some("Summarize".to_string()),
-                    message: Some("Please summarize this meeting".to_string()),
-                }
-            ]),
+            chat_suggestions: Some(vec![crate::models::ChatSuggestion {
+                label: Some("Summarize".to_string()),
+                message: Some("Please summarize this meeting".to_string()),
+            }]),
             user_types: None,
             extra: Default::default(),
         }];
@@ -1127,10 +1189,15 @@ mod tests {
 
         // Verify chat_suggestions_json was persisted
         let chat_suggestions_json: Option<String> = conn
-            .query_row("SELECT chat_suggestions_json FROM templates WHERE id = 't-1'", [], |r| r.get(0))
+            .query_row(
+                "SELECT chat_suggestions_json FROM templates WHERE id = 't-1'",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!(chat_suggestions_json.is_some());
-        let parsed: Vec<serde_json::Value> = serde_json::from_str(&chat_suggestions_json.unwrap()).unwrap();
+        let parsed: Vec<serde_json::Value> =
+            serde_json::from_str(&chat_suggestions_json.unwrap()).unwrap();
         assert_eq!(parsed.len(), 1);
         assert_eq!(parsed[0]["label"], "Summarize");
     }
@@ -1140,7 +1207,10 @@ mod tests {
         let conn = build_test_db(&empty_state());
 
         let mut extra = std::collections::HashMap::new();
-        extra.insert("linkedin_url".to_string(), json!("https://linkedin.com/in/alice"));
+        extra.insert(
+            "linkedin_url".to_string(),
+            json!("https://linkedin.com/in/alice"),
+        );
 
         let people = vec![Person {
             id: Some("p-1".to_string()),
@@ -1164,7 +1234,9 @@ mod tests {
 
         // Verify extra_json was persisted
         let extra_json: Option<String> = conn
-            .query_row("SELECT extra_json FROM people WHERE id = 'p-1'", [], |r| r.get(0))
+            .query_row("SELECT extra_json FROM people WHERE id = 'p-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert!(extra_json.is_some());
         let parsed: serde_json::Value = serde_json::from_str(&extra_json.unwrap()).unwrap();
@@ -1198,7 +1270,9 @@ mod tests {
         upsert_templates(&conn, &templates).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM templates WHERE id = 't-1'", [], |r| r.get(0))
+            .query_row("SELECT raw_json FROM templates WHERE id = 't-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert!(raw_json.is_some());
 
@@ -1230,7 +1304,9 @@ mod tests {
         upsert_templates(&conn, &updated_templates).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM templates WHERE id = 't-1'", [], |r| r.get(0))
+            .query_row("SELECT raw_json FROM templates WHERE id = 't-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw_json.unwrap()).unwrap();
         assert_eq!(parsed["title"], "Updated Title");
@@ -1269,7 +1345,9 @@ mod tests {
         upsert_calendar_events(&conn, &events).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM events WHERE id = 'e-1'", [], |r| r.get(0))
+            .query_row("SELECT raw_json FROM events WHERE id = 'e-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert!(raw_json.is_some());
 
@@ -1320,7 +1398,9 @@ mod tests {
         upsert_calendar_events(&conn, &updated_events).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM events WHERE id = 'e-1'", [], |r| r.get(0))
+            .query_row("SELECT raw_json FROM events WHERE id = 'e-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw_json.unwrap()).unwrap();
         assert_eq!(parsed["summary"], "Updated Meeting");
@@ -1359,7 +1439,9 @@ mod tests {
         upsert_recipes(&conn, &response).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM recipes WHERE id = 'r-1'", [], |r| r.get(0))
+            .query_row("SELECT raw_json FROM recipes WHERE id = 'r-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert!(raw_json.is_some());
 
@@ -1406,7 +1488,9 @@ mod tests {
         upsert_recipes(&conn, &updated_response).unwrap();
 
         let raw_json: Option<String> = conn
-            .query_row("SELECT raw_json FROM recipes WHERE id = 'r-1'", [], |r| r.get(0))
+            .query_row("SELECT raw_json FROM recipes WHERE id = 'r-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw_json.unwrap()).unwrap();
         assert_eq!(parsed["slug"], "updated-recipe");
@@ -1450,7 +1534,9 @@ mod tests {
 
         // Verify extra_json was persisted
         let extra_json: Option<String> = conn
-            .query_row("SELECT extra_json FROM recipes WHERE id = 'r-1'", [], |r| r.get(0))
+            .query_row("SELECT extra_json FROM recipes WHERE id = 'r-1'", [], |r| {
+                r.get(0)
+            })
             .unwrap();
         assert!(extra_json.is_some());
         let parsed: serde_json::Value = serde_json::from_str(&extra_json.unwrap()).unwrap();
@@ -1526,7 +1612,11 @@ mod tests {
         assert_eq!(json.start_time.as_deref(), Some("2026-01-20T10:00:00Z"));
         assert_eq!(json.end_time.as_deref(), Some("2026-01-20T11:00:00Z"));
         assert!(json.attendees_json.unwrap().contains("alice@example.com"));
-        assert!(json.conference_data_json.unwrap().contains("meet.google.com"));
+        assert!(
+            json.conference_data_json
+                .unwrap()
+                .contains("meet.google.com")
+        );
         assert!(json.extra_json.is_none());
     }
 

--- a/src/db/test_fixtures.rs
+++ b/src/db/test_fixtures.rs
@@ -6,7 +6,7 @@
 #[cfg(test)]
 use rusqlite::Connection;
 #[cfg(test)]
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 /// Creates a comprehensive test state with data for all collections
 #[cfg(test)]
@@ -304,7 +304,8 @@ pub fn build_test_db(state: &Value) -> Connection {
                     person.get("job_title").and_then(|v| v.as_str()),
                     extra_json,
                 ],
-            ).unwrap();
+            )
+            .unwrap();
         }
     }
 
@@ -443,7 +444,8 @@ pub fn build_test_db(state: &Value) -> Connection {
     // hide a broken trigger behind a fixture, which is how #85 went unnoticed.
     //
     // notes_fts has no write path at all yet (#85), so it still needs this.
-    conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')", []).unwrap();
+    conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')", [])
+        .unwrap();
 
     conn
 }

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -229,7 +229,10 @@ fn redact_utterance_snapshot(utt: &crate::models::TranscriptUtterance) -> Option
     let obj = value.as_object_mut()?;
     if let Some(v) = obj.get("text") {
         if !v.is_null() {
-            obj.insert("text".to_string(), serde_json::Value::String("[stored]".to_string()));
+            obj.insert(
+                "text".to_string(),
+                serde_json::Value::String("[stored]".to_string()),
+            );
         }
     }
     serde_json::to_string(&value).ok()
@@ -342,7 +345,9 @@ mod tests {
             [],
         ).unwrap();
 
-        let docs = find_documents_without_transcripts(&conn, Some("2026-01-20T00:00:00Z"), None, false).unwrap();
+        let docs =
+            find_documents_without_transcripts(&conn, Some("2026-01-20T00:00:00Z"), None, false)
+                .unwrap();
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].id, "doc-new");
     }
@@ -402,19 +407,23 @@ mod tests {
         assert_eq!(inserted, 2);
 
         // Verify insertion
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcript_utterances WHERE document_id = 'doc-api'",
-            [],
-            |r| r.get(0),
-        ).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcript_utterances WHERE document_id = 'doc-api'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 2);
 
         // Verify source is 'api'
-        let source: String = conn.query_row(
-            "SELECT transcript_source FROM transcript_utterances WHERE id = 'api-u1'",
-            [],
-            |r| r.get(0),
-        ).unwrap();
+        let source: String = conn
+            .query_row(
+                "SELECT transcript_source FROM transcript_utterances WHERE id = 'api-u1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert_eq!(source, "api");
     }
 
@@ -423,36 +432,38 @@ mod tests {
         let conn = build_test_db(&transcripts_state());
 
         // doc-1 already has transcripts from transcripts_state
-        let old_count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcript_utterances WHERE document_id = 'doc-1'",
-            [],
-            |r| r.get(0),
-        ).unwrap();
+        let old_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcript_utterances WHERE document_id = 'doc-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert!(old_count > 0);
 
-        let utterances = vec![
-            crate::models::TranscriptUtterance {
-                id: Some("new-u1".to_string()),
-                document_id: Some("doc-1".to_string()),
-                start_timestamp: None,
-                end_timestamp: None,
-                text: Some("Replaced transcript".to_string()),
-                source: None,
-                is_final: None,
-                detected_speaker_name: None,
-                extra: Default::default(),
-            },
-        ];
+        let utterances = vec![crate::models::TranscriptUtterance {
+            id: Some("new-u1".to_string()),
+            document_id: Some("doc-1".to_string()),
+            start_timestamp: None,
+            end_timestamp: None,
+            text: Some("Replaced transcript".to_string()),
+            source: None,
+            is_final: None,
+            detected_speaker_name: None,
+            extra: Default::default(),
+        }];
 
         let inserted = insert_transcript_from_api(&conn, "doc-1", &utterances).unwrap();
         assert_eq!(inserted, 1);
 
         // Verify only the new transcript exists
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcript_utterances WHERE document_id = 'doc-1'",
-            [],
-            |r| r.get(0),
-        ).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcript_utterances WHERE document_id = 'doc-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 1);
     }
 
@@ -470,22 +481,24 @@ mod tests {
         };
 
         // transcripts_state has doc-1 with text "neural networks" - verify it's searchable
-        assert_eq!(fts_count("neural networks"), 1, "Should find 'neural networks' before replacement");
+        assert_eq!(
+            fts_count("neural networks"),
+            1,
+            "Should find 'neural networks' before replacement"
+        );
 
         // Replace with completely different text
-        let utterances = vec![
-            crate::models::TranscriptUtterance {
-                id: Some("new-u1".to_string()),
-                document_id: Some("doc-1".to_string()),
-                start_timestamp: None,
-                end_timestamp: None,
-                text: Some("quantum computing breakthroughs".to_string()),
-                source: None,
-                is_final: None,
-                detected_speaker_name: None,
-                extra: Default::default(),
-            },
-        ];
+        let utterances = vec![crate::models::TranscriptUtterance {
+            id: Some("new-u1".to_string()),
+            document_id: Some("doc-1".to_string()),
+            start_timestamp: None,
+            end_timestamp: None,
+            text: Some("quantum computing breakthroughs".to_string()),
+            source: None,
+            is_final: None,
+            detected_speaker_name: None,
+            extra: Default::default(),
+        }];
 
         insert_transcript_from_api(&conn, "doc-1", &utterances).unwrap();
 
@@ -497,7 +510,11 @@ mod tests {
         );
 
         // NEW text SHOULD be searchable
-        assert_eq!(fts_count("quantum computing"), 1, "Should find 'quantum computing' after replacement");
+        assert_eq!(
+            fts_count("quantum computing"),
+            1,
+            "Should find 'quantum computing' after replacement"
+        );
 
         // And the index agrees with the source, which the old hand-maintained
         // path could not promise.
@@ -536,15 +553,27 @@ mod tests {
             [],
         )
         .unwrap();
-        assert_eq!(hits("photosynthesis"), 1, "the insert alone should index it");
+        assert_eq!(
+            hits("photosynthesis"),
+            1,
+            "the insert alone should index it"
+        );
 
         conn.execute(
             "UPDATE transcript_utterances SET text = 'respiration' WHERE id = 'u-bare'",
             [],
         )
         .unwrap();
-        assert_eq!(hits("photosynthesis"), 0, "the update should unindex the old text");
-        assert_eq!(hits("respiration"), 1, "the update should index the new text");
+        assert_eq!(
+            hits("photosynthesis"),
+            0,
+            "the update should unindex the old text"
+        );
+        assert_eq!(
+            hits("respiration"),
+            1,
+            "the update should index the new text"
+        );
 
         conn.execute("DELETE FROM transcript_utterances WHERE id = 'u-bare'", [])
             .unwrap();
@@ -564,19 +593,17 @@ mod tests {
     fn test_insert_transcript_from_api_nonexistent_document() {
         let conn = build_test_db(&transcripts_state());
 
-        let utterances = vec![
-            crate::models::TranscriptUtterance {
-                id: Some("u1".to_string()),
-                document_id: Some("nonexistent".to_string()),
-                start_timestamp: None,
-                end_timestamp: None,
-                text: Some("test".to_string()),
-                source: None,
-                is_final: None,
-                detected_speaker_name: None,
-                extra: Default::default(),
-            },
-        ];
+        let utterances = vec![crate::models::TranscriptUtterance {
+            id: Some("u1".to_string()),
+            document_id: Some("nonexistent".to_string()),
+            start_timestamp: None,
+            end_timestamp: None,
+            text: Some("test".to_string()),
+            source: None,
+            is_final: None,
+            detected_speaker_name: None,
+            extra: Default::default(),
+        }];
 
         let result = insert_transcript_from_api(&conn, "nonexistent", &utterances);
         assert!(result.is_err());
@@ -621,19 +648,23 @@ mod tests {
         assert_eq!(inserted, 2);
 
         // Verify the metadata was stored correctly
-        let (source1, is_final1): (Option<String>, Option<bool>) = conn.query_row(
-            "SELECT source, is_final FROM transcript_utterances WHERE id = 'meta-u1'",
-            [],
-            |r| Ok((r.get(0)?, r.get(1)?)),
-        ).unwrap();
+        let (source1, is_final1): (Option<String>, Option<bool>) = conn
+            .query_row(
+                "SELECT source, is_final FROM transcript_utterances WHERE id = 'meta-u1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
         assert_eq!(source1, Some("microphone".to_string()));
         assert_eq!(is_final1, Some(true));
 
-        let (source2, is_final2): (Option<String>, Option<bool>) = conn.query_row(
-            "SELECT source, is_final FROM transcript_utterances WHERE id = 'meta-u2'",
-            [],
-            |r| Ok((r.get(0)?, r.get(1)?)),
-        ).unwrap();
+        let (source2, is_final2): (Option<String>, Option<bool>) = conn
+            .query_row(
+                "SELECT source, is_final FROM transcript_utterances WHERE id = 'meta-u2'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
         assert_eq!(source2, Some("system".to_string()));
         assert_eq!(is_final2, Some(false));
     }
@@ -683,11 +714,13 @@ mod tests {
 
         log_transcript_sync_failure(&conn, "doc-3", "not_found").unwrap();
 
-        let (status, attempts): (String, i64) = conn.query_row(
-            "SELECT status, attempts FROM transcript_sync_log WHERE document_id = 'doc-3'",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        ).unwrap();
+        let (status, attempts): (String, i64) = conn
+            .query_row(
+                "SELECT status, attempts FROM transcript_sync_log WHERE document_id = 'doc-3'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
 
         assert_eq!(status, "not_found");
         assert_eq!(attempts, 1);
@@ -705,11 +738,13 @@ mod tests {
         log_transcript_sync_failure(&conn, "doc-3", "not_found").unwrap();
         log_transcript_sync_failure(&conn, "doc-3", "error").unwrap();
 
-        let (status, attempts): (String, i64) = conn.query_row(
-            "SELECT status, attempts FROM transcript_sync_log WHERE document_id = 'doc-3'",
-            [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        ).unwrap();
+        let (status, attempts): (String, i64) = conn
+            .query_row(
+                "SELECT status, attempts FROM transcript_sync_log WHERE document_id = 'doc-3'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
 
         assert_eq!(status, "error");
         assert_eq!(attempts, 2);
@@ -727,21 +762,25 @@ mod tests {
         log_transcript_sync_failure(&conn, "doc-3", "not_found").unwrap();
 
         // Verify it exists
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcript_sync_log WHERE document_id = 'doc-3'",
-            [],
-            |row| row.get(0),
-        ).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcript_sync_log WHERE document_id = 'doc-3'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 1);
 
         clear_transcript_sync_log_entry(&conn, "doc-3").unwrap();
 
         // Verify it's gone
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM transcript_sync_log WHERE document_id = 'doc-3'",
-            [],
-            |row| row.get(0),
-        ).unwrap();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM transcript_sync_log WHERE document_id = 'doc-3'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 0);
     }
 
@@ -827,7 +866,10 @@ mod tests {
         }
 
         // Only count failures for documents created since 2026-01-24
-        assert_eq!(count_transcript_sync_failures(&conn, Some("2026-01-24T00:00:00Z")).unwrap(), 2);
+        assert_eq!(
+            count_transcript_sync_failures(&conn, Some("2026-01-24T00:00:00Z")).unwrap(),
+            2
+        );
     }
 
     #[test]
@@ -923,27 +965,27 @@ mod tests {
             [],
         ).unwrap();
 
-        let utterances = vec![
-            crate::models::TranscriptUtterance {
-                id: Some("snap-u1".to_string()),
-                document_id: Some("doc-snap".to_string()),
-                start_timestamp: Some("2026-01-25T10:00:00Z".to_string()),
-                end_timestamp: Some("2026-01-25T10:00:30Z".to_string()),
-                text: Some("Hello from snapshot test".to_string()),
-                source: Some("microphone".to_string()),
-                is_final: Some(true),
-                detected_speaker_name: None,
-                extra: Default::default(),
-            },
-        ];
+        let utterances = vec![crate::models::TranscriptUtterance {
+            id: Some("snap-u1".to_string()),
+            document_id: Some("doc-snap".to_string()),
+            start_timestamp: Some("2026-01-25T10:00:00Z".to_string()),
+            end_timestamp: Some("2026-01-25T10:00:30Z".to_string()),
+            text: Some("Hello from snapshot test".to_string()),
+            source: Some("microphone".to_string()),
+            is_final: Some(true),
+            detected_speaker_name: None,
+            extra: Default::default(),
+        }];
 
         insert_transcript_from_api(&conn, "doc-snap", &utterances).unwrap();
 
-        let snapshot: Option<String> = conn.query_row(
-            "SELECT api_snapshot FROM transcript_utterances WHERE id = 'snap-u1'",
-            [],
-            |row| row.get(0),
-        ).unwrap();
+        let snapshot: Option<String> = conn
+            .query_row(
+                "SELECT api_snapshot FROM transcript_utterances WHERE id = 'snap-u1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         assert!(snapshot.is_some());
 
         let parsed: serde_json::Value = serde_json::from_str(&snapshot.unwrap()).unwrap();
@@ -998,7 +1040,10 @@ mod tests {
         ).unwrap();
 
         let utterances = load_transcript(&conn, "doc-attr").unwrap();
-        assert_eq!(utterances[0].detected_speaker_name.as_deref(), Some("Jane Doe"));
+        assert_eq!(
+            utterances[0].detected_speaker_name.as_deref(),
+            Some("Jane Doe")
+        );
         // The microphone channel is the local user and is never attributed.
         assert!(utterances[1].detected_speaker_name.is_none());
     }
@@ -1023,11 +1068,13 @@ mod tests {
 
         insert_transcript_from_api(&conn, "doc-attr", &utterances).unwrap();
 
-        let name: Option<String> = conn.query_row(
-            "SELECT speaker_name FROM transcript_utterances WHERE id = 'attr-u1'",
-            [],
-            |r| r.get(0),
-        ).unwrap();
+        let name: Option<String> = conn
+            .query_row(
+                "SELECT speaker_name FROM transcript_utterances WHERE id = 'attr-u1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
         assert_eq!(name, Some("Jane Doe".to_string()));
     }
 
@@ -1085,11 +1132,15 @@ mod tests {
                 "INSERT INTO transcript_utterances (id, document_id, text, source, speaker_name)
                  VALUES (?1, 'doc-attr', 'x', 'system', ?2)",
                 rusqlite::params![id, name],
-            ).unwrap();
+            )
+            .unwrap();
         }
 
         let names = distinct_speaker_names(&conn).unwrap();
-        assert_eq!(names, vec!["Jane Doe".to_string(), "Marcus Webb".to_string()]);
+        assert_eq!(
+            names,
+            vec!["Jane Doe".to_string(), "Marcus Webb".to_string()]
+        );
     }
 
     #[test]

--- a/src/embed/chunker.rs
+++ b/src/embed/chunker.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 use rusqlite::Connection;
 
-use super::chunk::{hash_embed_input, Chunk, ChunkSourceType};
+use super::chunk::{Chunk, ChunkSourceType, hash_embed_input};
 
 /// How consecutive transcript chunks overlap.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -202,7 +202,12 @@ pub fn transcript_window_chunker_adaptive(
                 }
 
                 // Start new buffer with overlap
-                buffer = overlap_carryover(config.overlap_mode, &buffer, &mut buffer_utts, overlap_chars);
+                buffer = overlap_carryover(
+                    config.overlap_mode,
+                    &buffer,
+                    &mut buffer_utts,
+                    overlap_chars,
+                );
                 buffer_start_idx = i;
             }
 
@@ -245,7 +250,12 @@ pub fn transcript_window_chunker_adaptive(
                 // Start fresh buffer with overlap. The buffer ends in a
                 // split fragment here, so utterance mode carries nothing.
                 buffer_utts.clear();
-                buffer = overlap_carryover(config.overlap_mode, &buffer, &mut buffer_utts, overlap_chars);
+                buffer = overlap_carryover(
+                    config.overlap_mode,
+                    &buffer,
+                    &mut buffer_utts,
+                    overlap_chars,
+                );
                 buffer_start_idx = i;
                 buffer_start_ts = None;
                 remaining = rest.to_string();
@@ -281,7 +291,12 @@ pub fn transcript_window_chunker_adaptive(
                     }
 
                     // Start new buffer with overlap
-                    buffer = overlap_carryover(config.overlap_mode, &buffer, &mut buffer_utts, overlap_chars);
+                    buffer = overlap_carryover(
+                        config.overlap_mode,
+                        &buffer,
+                        &mut buffer_utts,
+                        overlap_chars,
+                    );
                     buffer_start_idx = i;
                     buffer_start_ts = None;
                 }
@@ -775,9 +790,24 @@ mod tests {
         // Create utterances that together exceed target but not max
         // Use a config with small target to force splits
         let utts = vec![
-            ("doc1", "2025-01-01T10:00:00Z", "First utterance with some content.", None),
-            ("doc1", "2025-01-01T10:01:00Z", "Second utterance with more content.", None),
-            ("doc1", "2025-01-01T10:02:00Z", "Third utterance continues on.", None),
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "First utterance with some content.",
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "Second utterance with more content.",
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:02:00Z",
+                "Third utterance continues on.",
+                None,
+            ),
         ];
         let conn = setup_test_db(&utts);
         // Small target: ~20 tokens = ~80 chars
@@ -791,7 +821,11 @@ mod tests {
         };
         let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
         // Should have multiple chunks
-        assert!(chunks.len() >= 2, "Expected multiple chunks, got {}", chunks.len());
+        assert!(
+            chunks.len() >= 2,
+            "Expected multiple chunks, got {}",
+            chunks.len()
+        );
     }
 
     #[test]
@@ -810,7 +844,11 @@ mod tests {
         };
         let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
         // The huge text should result in multiple chunks
-        assert!(chunks.len() > 1, "Expected split chunks, got {}", chunks.len());
+        assert!(
+            chunks.len() > 1,
+            "Expected split chunks, got {}",
+            chunks.len()
+        );
         // Each chunk should not exceed max_chars
         for chunk in &chunks {
             assert!(
@@ -826,8 +864,13 @@ mod tests {
     fn test_adaptive_very_small_chunks_dropped() {
         // Chunks below min_chars should be dropped
         let conn = setup_test_db(&[
-            ("doc1", "2025-01-01T10:00:00Z", "ok", None),  // 2 chars - too small
-            ("doc1", "2025-01-01T10:01:00Z", "This is adequate content for a chunk.", None),
+            ("doc1", "2025-01-01T10:00:00Z", "ok", None), // 2 chars - too small
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "This is adequate content for a chunk.",
+                None,
+            ),
         ]);
         let config = ChunkingConfig {
             target_tokens: 100,
@@ -848,8 +891,18 @@ mod tests {
     #[test]
     fn test_adaptive_multiple_documents() {
         let utts = vec![
-            ("doc1", "2025-01-01T10:00:00Z", "Document one content that is long enough to meet the minimum chunk size requirements.", None),
-            ("doc2", "2025-01-01T11:00:00Z", "Document two content that is also long enough to meet the minimum chunk size requirements.", None),
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "Document one content that is long enough to meet the minimum chunk size requirements.",
+                None,
+            ),
+            (
+                "doc2",
+                "2025-01-01T11:00:00Z",
+                "Document two content that is also long enough to meet the minimum chunk size requirements.",
+                None,
+            ),
         ];
         let conn = setup_test_db(&utts);
         let config = ChunkingConfig::default();
@@ -888,8 +941,18 @@ mod tests {
     #[test]
     fn test_adaptive_metadata_tracks_timestamps() {
         let utts = vec![
-            ("doc1", "2025-01-01T10:00:00Z", "First utterance with enough content to pass the minimum.", None),
-            ("doc1", "2025-01-01T10:05:00Z", "Last utterance with additional content to meet requirements.", None),
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "First utterance with enough content to pass the minimum.",
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:05:00Z",
+                "Last utterance with additional content to meet requirements.",
+                None,
+            ),
         ];
         let conn = setup_test_db(&utts);
         let config = ChunkingConfig::default();
@@ -902,7 +965,12 @@ mod tests {
 
     #[test]
     fn test_adaptive_source_id_format() {
-        let conn = setup_test_db(&[("doc1", "2025-01-01T10:00:00Z", "Content here that is long enough to meet minimum chunk size requirements for the test.", None)]);
+        let conn = setup_test_db(&[(
+            "doc1",
+            "2025-01-01T10:00:00Z",
+            "Content here that is long enough to meet minimum chunk size requirements for the test.",
+            None,
+        )]);
         let config = ChunkingConfig::default();
         let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
 
@@ -924,7 +992,8 @@ mod tests {
         conn.execute(
             "INSERT INTO panels (id, document_id, content_markdown) VALUES (?1, ?2, ?3)",
             rusqlite::params![panel_id, doc_id, markdown],
-        ).unwrap();
+        )
+        .unwrap();
     }
 
     #[test]
@@ -941,7 +1010,10 @@ mod tests {
         let markdown = "### Action Items\n\nWe need to complete the deployment process for the new release version.\n\n### Key Decisions\n\nThe team agreed to postpone the feature release until after testing is complete.";
         insert_test_panel(&conn, "panel1", "doc1", markdown);
 
-        let config = ChunkingConfig { min_chars: 20, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 20,
+            ..ChunkingConfig::default()
+        };
         let chunks = panel_section_chunker(&conn, &config, None).unwrap();
 
         assert_eq!(chunks.len(), 2);
@@ -958,7 +1030,10 @@ mod tests {
         let markdown = "### Action Items\n\nComplete the deployment process for the entire team.\n\n---\nChat with Granola for more details.";
         insert_test_panel(&conn, "panel1", "doc1", markdown);
 
-        let config = ChunkingConfig { min_chars: 20, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 20,
+            ..ChunkingConfig::default()
+        };
         let chunks = panel_section_chunker(&conn, &config, None).unwrap();
 
         assert_eq!(chunks.len(), 1);
@@ -971,7 +1046,10 @@ mod tests {
         let markdown = "### Action Items\n\nOk.\n\n### Key Decisions\n\nWe decided to postpone the feature release until after quality testing is complete.";
         insert_test_panel(&conn, "panel1", "doc1", markdown);
 
-        let config = ChunkingConfig { min_chars: 50, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 50,
+            ..ChunkingConfig::default()
+        };
         let chunks = panel_section_chunker(&conn, &config, None).unwrap();
 
         // "Ok." section is too short, only "Key Decisions" should remain
@@ -992,7 +1070,10 @@ mod tests {
             [markdown],
         ).unwrap();
 
-        let config = ChunkingConfig { min_chars: 20, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 20,
+            ..ChunkingConfig::default()
+        };
         let chunks = panel_section_chunker(&conn, &config, None).unwrap();
         assert!(chunks.is_empty());
     }
@@ -1003,7 +1084,10 @@ mod tests {
         let markdown = "### Budget Review\n\nThe quarterly budget needs revision for the marketing department.";
         insert_test_panel(&conn, "panel1", "doc1", markdown);
 
-        let config = ChunkingConfig { min_chars: 20, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 20,
+            ..ChunkingConfig::default()
+        };
         let chunks = panel_section_chunker(&conn, &config, None).unwrap();
 
         let meta = chunks[0].metadata.as_ref().unwrap();
@@ -1083,7 +1167,10 @@ mod tests {
         let markdown = "# Announcements\n\nNew hire starting Monday and onboarding schedule is ready.\n\n# Updates\n\nProject is on track for the quarterly deadline.\n\n# Action Items\n\n- Send welcome email to the new team member";
         insert_test_panel(&conn, "panel1", "doc1", markdown);
 
-        let config = ChunkingConfig { min_chars: 20, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 20,
+            ..ChunkingConfig::default()
+        };
         let chunks = panel_section_chunker(&conn, &config, None).unwrap();
 
         assert_eq!(chunks.len(), 3);
@@ -1129,10 +1216,16 @@ mod tests {
 
         let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
 
-        assert!(chunks.len() >= 2, "expected a split, got {} chunks", chunks.len());
+        assert!(
+            chunks.len() >= 2,
+            "expected a split, got {} chunks",
+            chunks.len()
+        );
         for chunk in &chunks {
             assert!(
-                [utt_a, utt_b, utt_c].iter().any(|u| chunk.text.starts_with(u)),
+                [utt_a, utt_b, utt_c]
+                    .iter()
+                    .any(|u| chunk.text.starts_with(u)),
                 "chunk must start at an utterance boundary, got: {:?}",
                 &chunk.text[..chunk.text.len().min(60)]
             );
@@ -1143,7 +1236,10 @@ mod tests {
         assert!(all_text.matches(utt_b).count() >= 2 || all_text.matches(utt_a).count() >= 2);
 
         // Contrast: chars mode slices mid-utterance under the same config.
-        let chars_config = ChunkingConfig { overlap_mode: OverlapMode::Chars, ..config };
+        let chars_config = ChunkingConfig {
+            overlap_mode: OverlapMode::Chars,
+            ..config
+        };
         let chars_chunks = transcript_window_chunker_adaptive(&conn, &chars_config, None).unwrap();
         assert!(
             chars_chunks
@@ -1158,7 +1254,8 @@ mod tests {
         // The trailing utterance is bigger than the overlap budget, so
         // nothing is carried: the next chunk starts with the new utterance.
         let utt_a = "Utterance alpha talks about the quarterly budget and it keeps going for a while longer.";
-        let utt_b = "Utterance bravo is the next one and stands alone with plenty of content of its own.";
+        let utt_b =
+            "Utterance bravo is the next one and stands alone with plenty of content of its own.";
         let utts = vec![
             ("doc1", "2025-01-01T10:00:00Z", utt_a, None),
             ("doc1", "2025-01-01T10:01:00Z", utt_b, None),
@@ -1182,7 +1279,10 @@ mod tests {
 
     #[test]
     fn test_overlap_mode_roundtrip() {
-        assert_eq!(OverlapMode::parse(OverlapMode::Chars.as_str()), Some(OverlapMode::Chars));
+        assert_eq!(
+            OverlapMode::parse(OverlapMode::Chars.as_str()),
+            Some(OverlapMode::Chars)
+        );
         assert_eq!(
             OverlapMode::parse(OverlapMode::Utterances.as_str()),
             Some(OverlapMode::Utterances)
@@ -1204,8 +1304,7 @@ mod tests {
         let config = ChunkingConfig::default();
         let headers = headers_for("doc1", "Meeting: Sync\n\n");
 
-        let chunks =
-            transcript_window_chunker_adaptive(&conn, &config, Some(&headers)).unwrap();
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, Some(&headers)).unwrap();
 
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].header.as_deref(), Some("Meeting: Sync\n\n"));
@@ -1219,8 +1318,7 @@ mod tests {
         let config = ChunkingConfig::default();
 
         let conn = setup_test_db(&[("doc1", "2025-01-01T10:00:00Z", text, None)]);
-        let without =
-            transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
+        let without = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
         let with_a = transcript_window_chunker_adaptive(
             &conn,
             &config,
@@ -1243,7 +1341,8 @@ mod tests {
     #[test]
     fn test_adaptive_header_shrinks_chunk_budget() {
         // With a header, header + text must stay within max_chars.
-        let long_text = "This is a fairly long sentence that keeps going with more words. ".repeat(10);
+        let long_text =
+            "This is a fairly long sentence that keeps going with more words. ".repeat(10);
         let conn = setup_test_db(&[("doc1", "2025-01-01T10:00:00Z", &long_text, None)]);
         let config = ChunkingConfig {
             target_tokens: 30,
@@ -1256,8 +1355,7 @@ mod tests {
         let header = "Meeting: Budget Review Session\nDate: 2026-02-01\n\n";
         let headers = headers_for("doc1", header);
 
-        let chunks =
-            transcript_window_chunker_adaptive(&conn, &config, Some(&headers)).unwrap();
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, Some(&headers)).unwrap();
 
         assert!(chunks.len() > 1);
         for chunk in &chunks {
@@ -1277,8 +1375,7 @@ mod tests {
         let config = ChunkingConfig::default();
         let headers = headers_for("other-doc", "Meeting: Other\n\n");
 
-        let chunks =
-            transcript_window_chunker_adaptive(&conn, &config, Some(&headers)).unwrap();
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, Some(&headers)).unwrap();
 
         assert_eq!(chunks[0].header, None);
     }
@@ -1288,7 +1385,10 @@ mod tests {
         let conn = setup_panel_test_db();
         let markdown = "### Action Items\n\nComplete the deployment process for the entire team.";
         insert_test_panel(&conn, "panel1", "doc1", markdown);
-        let config = ChunkingConfig { min_chars: 20, ..ChunkingConfig::default() };
+        let config = ChunkingConfig {
+            min_chars: 20,
+            ..ChunkingConfig::default()
+        };
         let headers = headers_for("doc1", "Meeting: Sync\n\n");
 
         let chunks = panel_section_chunker(&conn, &config, Some(&headers)).unwrap();
@@ -1393,12 +1493,18 @@ mod tests {
     // Tests for format_utterance_text
     #[test]
     fn test_format_utterance_text_microphone() {
-        assert_eq!(format_utterance_text("hello", Some("microphone")), "[You] hello");
+        assert_eq!(
+            format_utterance_text("hello", Some("microphone")),
+            "[You] hello"
+        );
     }
 
     #[test]
     fn test_format_utterance_text_system() {
-        assert_eq!(format_utterance_text("hello", Some("system")), "[Other] hello");
+        assert_eq!(
+            format_utterance_text("hello", Some("system")),
+            "[Other] hello"
+        );
     }
 
     #[test]
@@ -1408,7 +1514,10 @@ mod tests {
 
     #[test]
     fn test_format_utterance_text_unknown() {
-        assert_eq!(format_utterance_text("hello", Some("unknown_source")), "hello");
+        assert_eq!(
+            format_utterance_text("hello", Some("unknown_source")),
+            "hello"
+        );
     }
 
     #[test]
@@ -1439,16 +1548,35 @@ mod tests {
             overlap_mode: OverlapMode::Chars,
         };
         let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
-        assert!(chunks.is_empty(), "Empty text with source should produce no chunks, got {}", chunks.len());
+        assert!(
+            chunks.is_empty(),
+            "Empty text with source should produce no chunks, got {}",
+            chunks.len()
+        );
     }
 
     // Integration tests for speaker labels in chunkers
     #[test]
     fn test_adaptive_speaker_labels_in_chunks() {
         let utts = vec![
-            ("doc1", "2025-01-01T10:00:00Z", "I think we should proceed with the plan.", Some("microphone")),
-            ("doc1", "2025-01-01T10:01:00Z", "That sounds good, let me check the timeline.", Some("system")),
-            ("doc1", "2025-01-01T10:02:00Z", "Great, I will send the details after this meeting.", Some("microphone")),
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "I think we should proceed with the plan.",
+                Some("microphone"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "That sounds good, let me check the timeline.",
+                Some("system"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:02:00Z",
+                "Great, I will send the details after this meeting.",
+                Some("microphone"),
+            ),
         ];
         let conn = setup_test_db(&utts);
         let config = ChunkingConfig {
@@ -1470,8 +1598,18 @@ mod tests {
     #[test]
     fn test_adaptive_no_labels_when_source_null() {
         let utts = vec![
-            ("doc1", "2025-01-01T10:00:00Z", "First utterance with enough content for chunking.", None),
-            ("doc1", "2025-01-01T10:01:00Z", "Second utterance also with enough content here.", None),
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "First utterance with enough content for chunking.",
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "Second utterance also with enough content here.",
+                None,
+            ),
         ];
         let conn = setup_test_db(&utts);
         let config = ChunkingConfig {
@@ -1494,9 +1632,24 @@ mod tests {
     #[test]
     fn test_adaptive_mixed_sources_and_null() {
         let utts = vec![
-            ("doc1", "2025-01-01T10:00:00Z", "Labeled utterance from the user.", Some("microphone")),
-            ("doc1", "2025-01-01T10:01:00Z", "Unlabeled utterance with no source.", None),
-            ("doc1", "2025-01-01T10:02:00Z", "Labeled utterance from other person.", Some("system")),
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "Labeled utterance from the user.",
+                Some("microphone"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "Unlabeled utterance with no source.",
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:02:00Z",
+                "Labeled utterance from other person.",
+                Some("system"),
+            ),
         ];
         let conn = setup_test_db(&utts);
         let config = ChunkingConfig {
@@ -1510,26 +1663,32 @@ mod tests {
         let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
 
         assert_eq!(chunks.len(), 1);
-        assert!(chunks[0].text.contains("[You] Labeled utterance from the user."));
-        assert!(chunks[0].text.contains("Unlabeled utterance with no source."));
+        assert!(
+            chunks[0]
+                .text
+                .contains("[You] Labeled utterance from the user.")
+        );
+        assert!(
+            chunks[0]
+                .text
+                .contains("Unlabeled utterance with no source.")
+        );
         assert!(!chunks[0].text.contains("[You] Unlabeled"));
         assert!(!chunks[0].text.contains("[Other] Unlabeled"));
-        assert!(chunks[0].text.contains("[Other] Labeled utterance from other person."));
+        assert!(
+            chunks[0]
+                .text
+                .contains("[Other] Labeled utterance from other person.")
+        );
     }
 
     #[test]
     fn test_content_hash_changes_with_speaker_label() {
         // Same text but different source → different hash
         let text = "This is a test utterance with enough content to meet minimum chunk size requirements for the test.";
-        let utts_mic = vec![
-            ("doc1", "2025-01-01T10:00:00Z", text, Some("microphone")),
-        ];
-        let utts_sys = vec![
-            ("doc1", "2025-01-01T10:00:00Z", text, Some("system")),
-        ];
-        let utts_none = vec![
-            ("doc1", "2025-01-01T10:00:00Z", text, None),
-        ];
+        let utts_mic = vec![("doc1", "2025-01-01T10:00:00Z", text, Some("microphone"))];
+        let utts_sys = vec![("doc1", "2025-01-01T10:00:00Z", text, Some("system"))];
+        let utts_none = vec![("doc1", "2025-01-01T10:00:00Z", text, None)];
         let config = ChunkingConfig::default();
 
         let conn_mic = setup_test_db(&utts_mic);
@@ -1546,5 +1705,4 @@ mod tests {
         assert_ne!(chunks_mic[0].content_hash, chunks_none[0].content_hash);
         assert_ne!(chunks_sys[0].content_hash, chunks_none[0].content_hash);
     }
-
 }

--- a/src/embed/config.rs
+++ b/src/embed/config.rs
@@ -4,7 +4,7 @@
 //! and keep embedding with that scheme instead of silently re-chunking
 //! to its own compiled-in defaults.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 use super::chunker::{ChunkingConfig, OverlapMode};
@@ -120,10 +120,18 @@ impl EmbedSpec {
         }
         let defaults = Self::default_for(self.chunking.max_tokens);
         let stored_fields = (
-            stored.target_tokens.unwrap_or(defaults.chunking.target_tokens),
-            stored.overlap_tokens.unwrap_or(defaults.chunking.overlap_tokens),
-            stored.overlap_mode.unwrap_or(defaults.chunking.overlap_mode),
-            stored.contextual_headers.unwrap_or(defaults.contextual_headers),
+            stored
+                .target_tokens
+                .unwrap_or(defaults.chunking.target_tokens),
+            stored
+                .overlap_tokens
+                .unwrap_or(defaults.chunking.overlap_tokens),
+            stored
+                .overlap_mode
+                .unwrap_or(defaults.chunking.overlap_mode),
+            stored
+                .contextual_headers
+                .unwrap_or(defaults.contextual_headers),
         );
         self.persisted_fields() != stored_fields
     }
@@ -152,7 +160,10 @@ mod tests {
     fn resolve_stored_defaults_when_nothing_stored() {
         let conn = test_db();
         let spec = EmbedSpec::resolve_stored(&conn, 512);
-        assert_eq!(spec.persisted_fields(), EmbedSpec::default_for(512).persisted_fields());
+        assert_eq!(
+            spec.persisted_fields(),
+            EmbedSpec::default_for(512).persisted_fields()
+        );
     }
 
     #[test]
@@ -190,7 +201,10 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(spec.persisted_fields(), (192, 48, OverlapMode::Utterances, true));
+        assert_eq!(
+            spec.persisted_fields(),
+            (192, 48, OverlapMode::Utterances, true)
+        );
     }
 
     #[test]

--- a/src/embed/headers.rs
+++ b/src/embed/headers.rs
@@ -37,9 +37,8 @@ pub fn build_doc_headers(conn: &Connection) -> Result<HashMap<String, String>> {
         names.dedup();
     }
 
-    let mut stmt = conn.prepare(
-        "SELECT id, title, created_at FROM documents WHERE deleted_at IS NULL",
-    )?;
+    let mut stmt =
+        conn.prepare("SELECT id, title, created_at FROM documents WHERE deleted_at IS NULL")?;
     let rows = stmt.query_map([], |row| {
         Ok((
             row.get::<_, String>(0)?,
@@ -93,7 +92,11 @@ fn assemble_header(title: &str, created_at: Option<&str>, names: &[String]) -> O
         let prefix = "Attendees: ";
         let mut line = String::new();
         for name in names {
-            let addition = if line.is_empty() { name.len() } else { name.len() + 2 };
+            let addition = if line.is_empty() {
+                name.len()
+            } else {
+                name.len() + 2
+            };
             // +2 accounts for this line's '\n' and the trailing blank line.
             if header.len() + prefix.len() + line.len() + addition + 2 > HEADER_MAX_CHARS {
                 break;
@@ -149,7 +152,9 @@ mod tests {
 
         assert_eq!(
             headers.get("doc-1").map(String::as_str),
-            Some("Meeting: AI Strategy Meeting\nDate: 2026-01-20\nAttendees: Alice Smith, Bob Jones, Zoe Adams\n\n")
+            Some(
+                "Meeting: AI Strategy Meeting\nDate: 2026-01-20\nAttendees: Alice Smith, Bob Jones, Zoe Adams\n\n"
+            )
         );
     }
 
@@ -264,8 +269,15 @@ mod tests {
         let headers = build_doc_headers(&conn).unwrap();
 
         let header = headers.get("doc-1").unwrap();
-        assert!(header.len() <= HEADER_MAX_CHARS, "header is {} bytes", header.len());
-        assert!(header.starts_with("Meeting: All Hands\nDate: 2026-02-01\nAttendees: Attendee Number 00"));
+        assert!(
+            header.len() <= HEADER_MAX_CHARS,
+            "header is {} bytes",
+            header.len()
+        );
+        assert!(
+            header
+                .starts_with("Meeting: All Hands\nDate: 2026-02-01\nAttendees: Attendee Number 00")
+        );
         assert!(header.ends_with("\n\n"));
     }
 
@@ -284,7 +296,11 @@ mod tests {
         let headers = build_doc_headers(&conn).unwrap();
 
         let header = headers.get("doc-1").unwrap();
-        assert!(header.len() <= HEADER_MAX_CHARS, "header is {} bytes", header.len());
+        assert!(
+            header.len() <= HEADER_MAX_CHARS,
+            "header is {} bytes",
+            header.len()
+        );
         assert!(header.starts_with("Meeting: Budget"));
         assert!(header.contains("\nDate: 2026-02-01\n"));
         assert!(header.ends_with("\n\n"));

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -149,7 +149,10 @@ pub fn calculate_chunk_size_stats(conn: &Connection) -> Result<Option<ChunkSizeS
 
     // Count problematic chunks
     let max_chars_for_limit = (MODEL_MAX_TOKENS as f64 * CHARS_PER_TOKEN) as usize;
-    let chunks_over_limit = lengths.iter().filter(|&&len| len > max_chars_for_limit).count();
+    let chunks_over_limit = lengths
+        .iter()
+        .filter(|&&len| len > max_chars_for_limit)
+        .count();
 
     // Very small chunks (< 50 chars, roughly < 12 tokens)
     let chunks_very_small = lengths.iter().filter(|&&len| len < 50).count();
@@ -291,7 +294,11 @@ fn desired_chunks_for_spec(conn: &Connection, spec: &config::EmbedSpec) -> Resul
 
     let mut chunks =
         chunker::transcript_window_chunker_adaptive(conn, &spec.chunking, doc_headers)?;
-    chunks.extend(chunker::panel_section_chunker(conn, &spec.chunking, doc_headers)?);
+    chunks.extend(chunker::panel_section_chunker(
+        conn,
+        &spec.chunking,
+        doc_headers,
+    )?);
     chunks.extend(chunker::notes_paragraph_chunker(conn, 20, doc_headers)?);
     Ok(chunks)
 }
@@ -299,7 +306,9 @@ fn desired_chunks_for_spec(conn: &Connection, spec: &config::EmbedSpec) -> Resul
 /// Wipe all embeddings from the database.
 /// Used by `grans embed --force` to force re-embedding.
 pub fn wipe_all_embeddings(conn: &Connection) -> Result<()> {
-    conn.execute_batch("DELETE FROM embeddings; DELETE FROM chunks; DELETE FROM embedding_metadata;")?;
+    conn.execute_batch(
+        "DELETE FROM embeddings; DELETE FROM chunks; DELETE FROM embedding_metadata;",
+    )?;
     Ok(())
 }
 
@@ -322,7 +331,12 @@ pub struct EmbeddingIndex {
 }
 
 impl EmbeddingIndex {
-    pub fn search(&self, query_vec: &[f32], min_score: f32, source_type_filter: Option<&[&str]>) -> Vec<SemanticSearchResult> {
+    pub fn search(
+        &self,
+        query_vec: &[f32],
+        min_score: f32,
+        source_type_filter: Option<&[&str]>,
+    ) -> Vec<SemanticSearchResult> {
         search::rank_results(query_vec, &self.vectors, min_score, source_type_filter)
     }
 
@@ -355,7 +369,12 @@ pub fn ensure_embeddings(
 
     if desired_chunks.is_empty() {
         if !model_consistent {
-            store::set_model_metadata(conn, embedder.model_name(), embedder.dimension(), embedder.max_length())?;
+            store::set_model_metadata(
+                conn,
+                embedder.model_name(),
+                embedder.dimension(),
+                embedder.max_length(),
+            )?;
         }
         eprintln!("[grans] No embeddable content found.");
         return Ok(EmbeddingIndex {
@@ -465,7 +484,12 @@ pub fn ensure_embeddings(
     };
 
     // Store model metadata and the chunking scheme the chunks now reflect
-    store::set_model_metadata(conn, embedder.model_name(), embedder.dimension(), embedder.max_length())?;
+    store::set_model_metadata(
+        conn,
+        embedder.model_name(),
+        embedder.dimension(),
+        embedder.max_length(),
+    )?;
     store::set_chunking_metadata(conn, spec)?;
 
     // Load all vectors for search
@@ -493,14 +517,21 @@ fn filter_results_by_date(
 
     // Query documents table to get created_at dates
     let placeholders = doc_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
-    let deleted_filter = if include_deleted { "" } else { " AND deleted_at IS NULL" };
+    let deleted_filter = if include_deleted {
+        ""
+    } else {
+        " AND deleted_at IS NULL"
+    };
     let sql = format!(
         "SELECT id, created_at FROM documents WHERE id IN ({}){}",
         placeholders, deleted_filter
     );
 
     let mut stmt = conn.prepare(&sql)?;
-    let params: Vec<&dyn rusqlite::types::ToSql> = doc_ids.iter().map(|id| id as &dyn rusqlite::types::ToSql).collect();
+    let params: Vec<&dyn rusqlite::types::ToSql> = doc_ids
+        .iter()
+        .map(|id| id as &dyn rusqlite::types::ToSql)
+        .collect();
 
     let mut valid_doc_ids = HashSet::new();
     let rows = stmt.query_map(params.as_slice(), |row| {
@@ -605,8 +636,8 @@ pub fn semantic_search_with_embedder_and_limit(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::model::MockEmbedder;
+    use super::*;
 
     fn setup_test_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
@@ -618,7 +649,11 @@ mod tests {
         // First ensure the document exists (for foreign key constraint)
         conn.execute(
             "INSERT OR IGNORE INTO documents (id, title, created_at) VALUES (?1, ?2, ?3)",
-            rusqlite::params![doc_id, format!("Test Doc {}", doc_id), "2025-01-01T00:00:00Z"],
+            rusqlite::params![
+                doc_id,
+                format!("Test Doc {}", doc_id),
+                "2025-01-01T00:00:00Z"
+            ],
         )
         .unwrap();
 
@@ -646,7 +681,13 @@ mod tests {
         let conn = setup_test_db();
         let embedder = MockEmbedder::default();
 
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert!(index.is_empty());
     }
 
@@ -654,13 +695,23 @@ mod tests {
     fn test_ensure_embeddings_creates_vectors() {
         let conn = setup_test_db();
         // Use content long enough to pass min_chars threshold (50 chars)
-        insert_utterances(&conn, "doc1", &[
-            "This is a longer utterance that contains enough characters to meet the minimum chunk size requirement for embedding."
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is a longer utterance that contains enough characters to meet the minimum chunk size requirement for embedding.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
 
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert!(!index.is_empty());
     }
 
@@ -668,19 +719,35 @@ mod tests {
     fn test_ensure_embeddings_incremental() {
         let conn = setup_test_db();
         // Use content long enough to pass min_chars threshold
-        insert_utterances(&conn, "doc1", &[
-            "First document content that is long enough to pass the minimum character threshold for embedding chunks."
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "First document content that is long enough to pass the minimum character threshold for embedding chunks.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
 
         // First run
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         let count1 = index.vectors.len();
         assert!(count1 > 0);
 
         // Second run with same data — should not re-embed
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert_eq!(index.vectors.len(), count1);
 
         // Add more data (with document first for foreign key)
@@ -696,7 +763,13 @@ mod tests {
         )
         .unwrap();
 
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert!(index.vectors.len() > count1);
     }
 
@@ -707,15 +780,22 @@ mod tests {
         insert_utterances(
             &conn,
             "doc1",
-            &["We had a detailed deployment strategy discussion today about how to deploy the application to production servers efficiently."],
+            &[
+                "We had a detailed deployment strategy discussion today about how to deploy the application to production servers efficiently.",
+            ],
         );
         insert_utterances(
             &conn,
             "doc2",
-            &["We discussed lunch plans for tomorrow and various options for what we should eat together as a team."],
+            &[
+                "We discussed lunch plans for tomorrow and various options for what we should eat together as a team.",
+            ],
         );
 
-        let embedder = MockEmbedder { dim: 8, max_length: 512 };
+        let embedder = MockEmbedder {
+            dim: 8,
+            max_length: 512,
+        };
 
         let (results, total_count) =
             semantic_search_with_embedder(&conn, "deploy", &embedder).unwrap();
@@ -736,11 +816,17 @@ mod tests {
             insert_utterances(
                 &conn,
                 &format!("doc{}", i),
-                &[&format!("This is document {} with content about topic {} that is long enough to meet the minimum character threshold for embedding.", i, i)],
+                &[&format!(
+                    "This is document {} with content about topic {} that is long enough to meet the minimum character threshold for embedding.",
+                    i, i
+                )],
             );
         }
 
-        let embedder = MockEmbedder { dim: 8, max_length: 512 };
+        let embedder = MockEmbedder {
+            dim: 8,
+            max_length: 512,
+        };
 
         // Search with limit=2
         let (results, total_count) =
@@ -767,17 +853,29 @@ mod tests {
     #[test]
     fn test_ensure_embeddings_returns_stats_when_embedding() {
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &[
-            "This is document content that is long enough to meet the minimum character threshold for the embedding chunker."
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is document content that is long enough to meet the minimum character threshold for the embedding chunker.",
+            ],
+        );
 
         let embedder = MockEmbedder {
             dim: 4,
             ..Default::default()
         };
 
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
-        let stats = index.stats.expect("stats should be present after embedding");
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
+        let stats = index
+            .stats
+            .expect("stats should be present after embedding");
         assert!(stats.chunks_embedded > 0);
         assert!(stats.elapsed_secs >= 0.0);
         assert!(stats.chunks_per_sec >= 0.0);
@@ -786,9 +884,13 @@ mod tests {
     #[test]
     fn test_ensure_embeddings_no_stats_when_already_embedded() {
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &[
-            "This is document content that is long enough to meet the minimum character threshold for the embedding chunker."
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is document content that is long enough to meet the minimum character threshold for the embedding chunker.",
+            ],
+        );
 
         let embedder = MockEmbedder {
             dim: 4,
@@ -796,11 +898,26 @@ mod tests {
         };
 
         // First run embeds everything
-        ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
 
         // Second run — nothing to embed
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
-        assert!(index.stats.is_none(), "stats should be None when no new chunks embedded");
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
+        assert!(
+            index.stats.is_none(),
+            "stats should be None when no new chunks embedded"
+        );
     }
 
     #[test]
@@ -811,22 +928,41 @@ mod tests {
             ..Default::default()
         };
 
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
-        assert!(index.stats.is_none(), "stats should be None when no content exists");
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
+        assert!(
+            index.stats.is_none(),
+            "stats should be None when no content exists"
+        );
     }
 
     #[test]
     fn test_orphan_cleanup() {
         let conn = setup_test_db();
         // Use content long enough to pass min_chars threshold
-        insert_utterances(&conn, "doc1", &[
-            "This is document content that is long enough to meet the minimum character threshold for the embedding chunker."
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is document content that is long enough to meet the minimum character threshold for the embedding chunker.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
 
         // First run creates embeddings for doc1
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert_eq!(index.vectors.len(), 1);
 
         // Remove doc1's utterances
@@ -834,7 +970,13 @@ mod tests {
             .unwrap();
 
         // Re-run — should clean up orphan
-        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        let index = ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert!(index.is_empty());
     }
 
@@ -845,10 +987,14 @@ mod tests {
         // back to defaults when a search/benchmark path opens it, because
         // those paths resolve the spec from stored metadata.
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &[
-            "First utterance about the deployment strategy with enough content to chunk.",
-            "Second utterance continuing the discussion with plenty of additional words here.",
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "First utterance about the deployment strategy with enough content to chunk.",
+                "Second utterance continuing the discussion with plenty of additional words here.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
         let variant = config::EmbedSpec {
@@ -875,15 +1021,13 @@ mod tests {
         assert_eq!(index.vectors.len(), variant_count);
 
         // And status agrees: nothing pending, no scheme-change warning.
-        let status =
-            get_embedding_status(&conn, embedder.model_name(), &resolved).unwrap();
+        let status = get_embedding_status(&conn, embedder.model_name(), &resolved).unwrap();
         assert_eq!(status.pending_chunks, 0);
         assert!(!status.chunking_changed_warning);
 
         // A default-spec embed WOULD be a scheme change, and status says so.
         let default_spec = config::EmbedSpec::default_for(512);
-        let status =
-            get_embedding_status(&conn, embedder.model_name(), &default_spec).unwrap();
+        let status = get_embedding_status(&conn, embedder.model_name(), &default_spec).unwrap();
         assert!(status.chunking_changed_warning);
         assert!(status.pending_chunks > 0);
     }
@@ -893,9 +1037,11 @@ mod tests {
         // With headers on, the text sent to the embedder carries the
         // meeting context while the stored chunk text stays raw.
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &[
-            "A single utterance long enough to form a chunk for the header test.",
-        ]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &["A single utterance long enough to form a chunk for the header test."],
+        );
 
         let embedder = MockEmbedder::default();
         let spec = config::EmbedSpec {
@@ -926,10 +1072,10 @@ mod tests {
         // 10 elements (indices 0-9)
         // Formula: idx = ((len-1) * p / 100).round()
         let sorted = vec![10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
-        assert_eq!(percentile(&sorted, 0.0), 10);   // idx = 0
-        assert_eq!(percentile(&sorted, 10.0), 20);  // idx = round(9 * 0.1) = 1
-        assert_eq!(percentile(&sorted, 50.0), 60);  // idx = round(9 * 0.5) = 5
-        assert_eq!(percentile(&sorted, 90.0), 90);  // idx = round(9 * 0.9) = 8
+        assert_eq!(percentile(&sorted, 0.0), 10); // idx = 0
+        assert_eq!(percentile(&sorted, 10.0), 20); // idx = round(9 * 0.1) = 1
+        assert_eq!(percentile(&sorted, 50.0), 60); // idx = round(9 * 0.5) = 5
+        assert_eq!(percentile(&sorted, 90.0), 90); // idx = round(9 * 0.9) = 8
         assert_eq!(percentile(&sorted, 100.0), 100); // idx = 9
     }
 
@@ -1031,13 +1177,29 @@ mod tests {
     #[test]
     fn test_embedding_status_includes_max_length() {
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &["Hello world, this is a test with enough content to meet minimum chunk size requirements."]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "Hello world, this is a test with enough content to meet minimum chunk size requirements.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
-        ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
 
-        let status =
-            get_embedding_status(&conn, embedder.model_name(), &config::EmbedSpec::default_for(512)).unwrap();
+        let status = get_embedding_status(
+            &conn,
+            embedder.model_name(),
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert_eq!(status.max_length, Some(512));
         assert!(!status.legacy_max_length_warning);
     }
@@ -1054,7 +1216,9 @@ mod tests {
         )
         .unwrap();
 
-        let status = get_embedding_status(&conn, "mock-embedder", &config::EmbedSpec::default_for(512)).unwrap();
+        let status =
+            get_embedding_status(&conn, "mock-embedder", &config::EmbedSpec::default_for(512))
+                .unwrap();
         assert_eq!(status.max_length, None);
         // Model exists but no max_length -> warning
         assert!(status.legacy_max_length_warning);
@@ -1064,7 +1228,9 @@ mod tests {
     fn test_embedding_status_no_warning_when_no_model() {
         let conn = setup_test_db();
         // No embeddings at all - no model name, no max_length
-        let status = get_embedding_status(&conn, "mock-embedder", &config::EmbedSpec::default_for(512)).unwrap();
+        let status =
+            get_embedding_status(&conn, "mock-embedder", &config::EmbedSpec::default_for(512))
+                .unwrap();
         assert_eq!(status.max_length, None);
         // No model means no warning (nothing to warn about)
         assert!(!status.legacy_max_length_warning);
@@ -1075,12 +1241,29 @@ mod tests {
     #[test]
     fn test_embedding_status_matching_model_no_rebuild() {
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &["Hello world, this is a test with enough content to meet minimum chunk size requirements."]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "Hello world, this is a test with enough content to meet minimum chunk size requirements.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
-        ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
 
-        let status = get_embedding_status(&conn, embedder.model_name(), &config::EmbedSpec::default_for(512)).unwrap();
+        let status = get_embedding_status(
+            &conn,
+            embedder.model_name(),
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
         assert!(!status.model_changed_warning);
         assert_eq!(status.pending_chunks, 0);
     }
@@ -1088,12 +1271,26 @@ mod tests {
     #[test]
     fn test_embedding_status_model_change_marks_all_pending() {
         let conn = setup_test_db();
-        insert_utterances(&conn, "doc1", &["Hello world, this is a test with enough content to meet minimum chunk size requirements."]);
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "Hello world, this is a test with enough content to meet minimum chunk size requirements.",
+            ],
+        );
 
         let embedder = MockEmbedder::default();
-        ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &config::EmbedSpec::default_for(512)).unwrap();
+        ensure_embeddings(
+            &conn,
+            &embedder,
+            DEFAULT_BATCH_SIZE,
+            &config::EmbedSpec::default_for(512),
+        )
+        .unwrap();
 
-        let status = get_embedding_status(&conn, "other-model", &config::EmbedSpec::default_for(512)).unwrap();
+        let status =
+            get_embedding_status(&conn, "other-model", &config::EmbedSpec::default_for(512))
+                .unwrap();
         assert!(status.model_changed_warning);
         assert_eq!(status.pending_chunks, status.total_chunks);
         assert_eq!(status.embedded_chunks, 0);

--- a/src/embed/model.rs
+++ b/src/embed/model.rs
@@ -119,7 +119,10 @@ impl Embedder for FastEmbedModel {
     }
 
     fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
-        let results = self.model.borrow_mut().embed(vec![text.to_string()], None)?;
+        let results = self
+            .model
+            .borrow_mut()
+            .embed(vec![text.to_string()], None)?;
         results
             .into_iter()
             .next()
@@ -271,5 +274,4 @@ mod tests {
         let v2 = embedder.embed_query("goodbye").unwrap();
         assert_ne!(v1, v2);
     }
-
 }

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -68,7 +68,9 @@ fn init_options(choice: RerankModel) -> Result<fastembed::RerankInitOptions> {
 impl FastEmbedReranker {
     pub fn new(choice: RerankModel) -> Result<Self> {
         let model = fastembed::TextRerank::try_new(init_options(choice)?)?;
-        Ok(Self { model: RefCell::new(model) })
+        Ok(Self {
+            model: RefCell::new(model),
+        })
     }
 }
 
@@ -79,7 +81,10 @@ impl Reranker for FastEmbedReranker {
         }
         // fastembed returns results sorted by score; `index` maps each back
         // to its input position.
-        let results = self.model.borrow_mut().rerank(query, documents, false, None)?;
+        let results = self
+            .model
+            .borrow_mut()
+            .rerank(query, documents, false, None)?;
         let mut scores = vec![0.0_f32; documents.len()];
         for r in results {
             scores[r.index] = sigmoid(r.score);
@@ -144,7 +149,9 @@ mod tests {
 
     #[test]
     fn mock_reranker_is_case_insensitive() {
-        let scores = MockReranker.rerank("Budget", &["the BUDGET meeting"]).unwrap();
+        let scores = MockReranker
+            .rerank("Budget", &["the BUDGET meeting"])
+            .unwrap();
         assert_eq!(scores, vec![1.0]);
     }
 

--- a/src/embed/search.rs
+++ b/src/embed/search.rs
@@ -34,19 +34,21 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     }
 
     let denom = norm_a.sqrt() * norm_b.sqrt();
-    if denom == 0.0 {
-        0.0
-    } else {
-        dot / denom
-    }
+    if denom == 0.0 { 0.0 } else { dot / denom }
 }
 
 /// Parse window indices from metadata JSON.
 fn parse_window_indices(metadata_json: &Option<String>) -> (Option<usize>, Option<usize>) {
     if let Some(json_str) = metadata_json {
         if let Ok(meta) = serde_json::from_str::<serde_json::Value>(json_str) {
-            let start = meta.get("window_start_idx").and_then(|v| v.as_u64()).map(|v| v as usize);
-            let end = meta.get("window_end_idx").and_then(|v| v.as_u64()).map(|v| v as usize);
+            let start = meta
+                .get("window_start_idx")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize);
+            let end = meta
+                .get("window_end_idx")
+                .and_then(|v| v.as_u64())
+                .map(|v| v as usize);
             return (start, end);
         }
     }
@@ -131,7 +133,11 @@ pub fn rank_results(
     }
 
     let mut results: Vec<SemanticSearchResult> = doc_best.into_values().collect();
-    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     results
 }
 
@@ -372,7 +378,12 @@ mod tests {
         assert_eq!(results[0].document_id, "doc2");
 
         // Filter to transcript + notes
-        let results = rank_results(&query, &stored, 0.0, Some(&["transcript_window", "notes_paragraph"]));
+        let results = rank_results(
+            &query,
+            &stored,
+            0.0,
+            Some(&["transcript_window", "notes_paragraph"]),
+        );
         assert_eq!(results.len(), 2);
 
         // No filter = all results

--- a/src/embed/store.rs
+++ b/src/embed/store.rs
@@ -351,9 +351,7 @@ pub fn check_model_consistency(conn: &Connection, current_model: &str) -> Result
         Some(stored) if stored == current_model => Ok(true),
         Some(_) => {
             // Model changed — wipe embeddings
-            conn.execute_batch(
-                "DELETE FROM embeddings; DELETE FROM chunks;",
-            )?;
+            conn.execute_batch("DELETE FROM embeddings; DELETE FROM chunks;")?;
             Ok(false)
         }
         None => Ok(false),
@@ -406,7 +404,7 @@ pub fn get_stored_chunks_by_source(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::embed::chunk::{hash_content, ChunkSourceType};
+    use crate::embed::chunk::{ChunkSourceType, hash_content};
 
     fn test_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,19 +41,21 @@ fn main() -> Result<()> {
 
     // Resolve the token override once, here at the boundary, so nothing below
     // reads the environment for itself.
-    let token_override = api::token_override(
-        cli.token.as_deref(),
-        std::env::var(api::TOKEN_ENV_VAR).ok(),
-    );
+    let token_override =
+        api::token_override(cli.token.as_deref(), std::env::var(api::TOKEN_ENV_VAR).ok());
 
     // Admin DB commands don't need a database connection
     if let Commands::Admin {
         action: AdminAction::Db { action },
     } = &cli.command
     {
-        let db_path = cli.db.as_deref().map(|p| p.to_path_buf()).unwrap_or_else(|| {
-            db::connection::default_db_path().expect("Failed to get default db path")
-        });
+        let db_path = cli
+            .db
+            .as_deref()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| {
+                db::connection::default_db_path().expect("Failed to get default db path")
+            });
         commands::db::run_with_path(action, &db_path)?;
         return Ok(());
     }
@@ -98,10 +100,19 @@ fn main() -> Result<()> {
         let overrides = embed::config::EmbedOverrides {
             target_tokens: *chunk_target_tokens,
             overlap_tokens: *chunk_overlap_tokens,
-            overlap_mode: overlap_mode.as_deref().and_then(embed::chunker::OverlapMode::parse),
+            overlap_mode: overlap_mode
+                .as_deref()
+                .and_then(embed::chunker::OverlapMode::parse),
             contextual_headers: *contextual_headers,
         };
-        commands::embed::run(&conn, action.as_ref(), *yes, *batch_size, ctx.output_mode, &overrides)?;
+        commands::embed::run(
+            &conn,
+            action.as_ref(),
+            *yes,
+            *batch_size,
+            ctx.output_mode,
+            &overrides,
+        )?;
         return Ok(());
     }
 
@@ -141,13 +152,7 @@ fn main() -> Result<()> {
                 include_deleted: *include_deleted,
             };
             let opts = SearchOptions::from_cli_args(
-                *fast,
-                *min_score,
-                *context,
-                *yes,
-                *limit,
-                *matches,
-                echo,
+                *fast, *min_score, *context, *yes, *limit, *matches, echo,
             );
             let date_range = query::dates::build_date_range(
                 from.as_deref(),
@@ -237,15 +242,7 @@ fn main() -> Result<()> {
         }
 
         Commands::Recent => {
-            commands::meetings::list(
-                &conn,
-                None,
-                None,
-                None,
-                Some("this-week"),
-                false,
-                &ctx,
-            )?;
+            commands::meetings::list(&conn, None, None, None, Some("this-week"), false, &ctx)?;
         }
 
         Commands::Today => {
@@ -253,18 +250,22 @@ fn main() -> Result<()> {
         }
 
         Commands::Info => {
-            let db_path = cli.db.as_deref().map(|p| p.to_path_buf()).unwrap_or_else(|| {
-                db::connection::default_db_path().expect("Failed to get default db path")
-            });
+            let db_path = cli
+                .db
+                .as_deref()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| {
+                    db::connection::default_db_path().expect("Failed to get default db path")
+                });
             commands::info::run(&conn, &db_path, &ctx)?;
         }
 
         Commands::Benchmark { .. } => unreachable!(), // Handled above
-        Commands::Dropbox { .. } => unreachable!(), // Handled above
-        Commands::Auth { .. } => unreachable!(), // Handled above
-        Commands::Update { .. } => unreachable!(), // Handled above
-        Commands::Sync { .. } => unreachable!(), // Handled above
-        Commands::Embed { .. } => unreachable!(), // Handled above
+        Commands::Dropbox { .. } => unreachable!(),   // Handled above
+        Commands::Auth { .. } => unreachable!(),      // Handled above
+        Commands::Update { .. } => unreachable!(),    // Handled above
+        Commands::Sync { .. } => unreachable!(),      // Handled above
+        Commands::Embed { .. } => unreachable!(),     // Handled above
 
         // === Browse Commands ===
         Commands::Browse { action } => {

--- a/src/models.rs
+++ b/src/models.rs
@@ -490,4 +490,3 @@ pub struct RecipeConfig {
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
-

--- a/src/output/card.rs
+++ b/src/output/card.rs
@@ -9,7 +9,7 @@ use chrono::FixedOffset;
 use colored::Colorize;
 
 use crate::query::shape::{ContextUnit, EvidenceSource, Excerpt, MatchEvidence, ShapedMeeting};
-use crate::query::speaker::{label as speaker_label, SpeakerLabel};
+use crate::query::speaker::{SpeakerLabel, label as speaker_label};
 
 /// Card body indent, sized to clear the rank gutter.
 const INDENT: &str = "    ";
@@ -78,8 +78,10 @@ fn source_line(evidence: &MatchEvidence, tz: &FixedOffset) -> String {
     if let Some(ts) = evidence.timestamp.as_deref() {
         details.push(super::table::format_time_only(ts, tz).dimmed().to_string());
     }
-    if let Some(label) = speaker_label(evidence.speaker.as_deref(), evidence.speaker_name.as_deref())
-    {
+    if let Some(label) = speaker_label(
+        evidence.speaker.as_deref(),
+        evidence.speaker_name.as_deref(),
+    ) {
         details.push(match label {
             SpeakerLabel::You => label.as_str().cyan().to_string(),
             _ => label.as_str().dimmed().to_string(),
@@ -230,7 +232,11 @@ mod tests {
             title: Some("Weekly Infra Sync".to_string()),
             created_at: Some("2026-05-12T14:30:00Z".to_string()),
             score: Some(0.63),
-            signals: Signals { keyword: true, semantic: true, title: false },
+            signals: Signals {
+                keyword: true,
+                semantic: true,
+                title: false,
+            },
             total_matches: 1,
             matches: vec![MatchEvidence {
                 source: EvidenceSource::Panel,
@@ -293,7 +299,10 @@ mod tests {
         let mut m = base_meeting();
         m.matches = vec![MatchEvidence {
             source: EvidenceSource::Transcript,
-            excerpt: Excerpt { text: "say the migration runs".to_string(), highlights: vec![] },
+            excerpt: Excerpt {
+                text: "say the migration runs".to_string(),
+                highlights: vec![],
+            },
             speaker: Some("microphone".to_string()),
             speaker_name: None,
             timestamp: Some("2026-05-12T14:31:07Z".to_string()),
@@ -310,7 +319,10 @@ mod tests {
         let mut m = base_meeting();
         m.matches = vec![MatchEvidence {
             source: EvidenceSource::Transcript,
-            excerpt: Excerpt { text: "the migration runs tonight".to_string(), highlights: vec![] },
+            excerpt: Excerpt {
+                text: "the migration runs tonight".to_string(),
+                highlights: vec![],
+            },
             speaker: Some("system".to_string()),
             speaker_name: Some("Jane Doe".to_string()),
             timestamp: Some("2026-07-22T14:31:07Z".to_string()),
@@ -319,8 +331,14 @@ mod tests {
             context_after: Vec::new(),
         }];
         let out = strip(&format_shaped_meeting(&m, 1, &utc()));
-        assert!(out.contains("    transcript › 14:31:07 Jane Doe"), "got:\n{out}");
-        assert!(!out.contains("Other"), "name should replace the channel label:\n{out}");
+        assert!(
+            out.contains("    transcript › 14:31:07 Jane Doe"),
+            "got:\n{out}"
+        );
+        assert!(
+            !out.contains("Other"),
+            "name should replace the channel label:\n{out}"
+        );
     }
 
     #[test]
@@ -329,7 +347,10 @@ mod tests {
         let mut m = base_meeting();
         m.matches = vec![MatchEvidence {
             source: EvidenceSource::Transcript,
-            excerpt: Excerpt { text: "the migration runs tonight".to_string(), highlights: vec![] },
+            excerpt: Excerpt {
+                text: "the migration runs tonight".to_string(),
+                highlights: vec![],
+            },
             speaker: Some("system".to_string()),
             speaker_name: None,
             timestamp: Some("2026-05-12T14:31:07Z".to_string()),
@@ -338,7 +359,10 @@ mod tests {
             context_after: Vec::new(),
         }];
         let out = strip(&format_shaped_meeting(&m, 1, &utc()));
-        assert!(out.contains("    transcript › 14:31:07 Other"), "got:\n{out}");
+        assert!(
+            out.contains("    transcript › 14:31:07 Other"),
+            "got:\n{out}"
+        );
     }
 
     #[test]
@@ -346,7 +370,10 @@ mod tests {
         let mut m = base_meeting();
         m.matches = vec![MatchEvidence {
             source: EvidenceSource::Transcript,
-            excerpt: Excerpt { text: "run it tonight".to_string(), highlights: vec![] },
+            excerpt: Excerpt {
+                text: "run it tonight".to_string(),
+                highlights: vec![],
+            },
             speaker: Some("microphone".to_string()),
             speaker_name: None,
             timestamp: Some("2026-07-22T14:31:07Z".to_string()),
@@ -486,14 +513,16 @@ mod tests {
             highlights: vec![],
         };
         let out = strip(&format_shaped_meeting(&m, 1, &utc()));
-        let snippet_lines: Vec<&str> =
-            out.lines().filter(|l| l.contains("alpha")).collect();
+        let snippet_lines: Vec<&str> = out.lines().filter(|l| l.contains("alpha")).collect();
         assert!(snippet_lines.len() > 1, "expected wrapping:\n{out}");
         assert!(snippet_lines[0].starts_with("    \""));
         assert!(snippet_lines[1].starts_with("     "));
         assert!(out.trim_end().ends_with('"'));
         for line in &snippet_lines {
-            assert!(line.chars().count() <= 4 + 1 + SNIPPET_WRAP + 1, "overlong: {line}");
+            assert!(
+                line.chars().count() <= 4 + 1 + SNIPPET_WRAP + 1,
+                "overlong: {line}"
+            );
         }
     }
 
@@ -505,8 +534,10 @@ mod tests {
         let text = format!("{} {}", "x".repeat(SNIPPET_WRAP - 4), word);
         let start = text.chars().count() - word.len();
         let mut m = base_meeting();
-        m.matches[0].excerpt =
-            Excerpt { text: text.clone(), highlights: vec![(start, start + word.len())] };
+        m.matches[0].excerpt = Excerpt {
+            text: text.clone(),
+            highlights: vec![(start, start + word.len())],
+        };
         let out = strip(&format_shaped_meeting(&m, 1, &utc()));
         assert!(out.contains(word), "highlighted word lost:\n{out}");
     }

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -1,8 +1,6 @@
 use serde::Serialize;
 
-use crate::models::{
-    Calendar, CalendarEvent, Document, PanelTemplate, Person, Recipe,
-};
+use crate::models::{Calendar, CalendarEvent, Document, PanelTemplate, Person, Recipe};
 
 /// Serialize any serializable value to pretty JSON string.
 pub fn to_json<T: Serialize>(value: &T) -> String {
@@ -160,8 +158,16 @@ impl ShapedMeetingJson {
                     section: ev.section.clone(),
                     snippet: ev.excerpt.text.clone(),
                     highlights: ev.excerpt.highlights.clone(),
-                    context_before: ev.context_before.iter().map(ContextUnitJson::from_unit).collect(),
-                    context_after: ev.context_after.iter().map(ContextUnitJson::from_unit).collect(),
+                    context_before: ev
+                        .context_before
+                        .iter()
+                        .map(ContextUnitJson::from_unit)
+                        .collect(),
+                    context_after: ev
+                        .context_after
+                        .iter()
+                        .map(ContextUnitJson::from_unit)
+                        .collect(),
                 })
                 .collect(),
         }
@@ -234,9 +240,7 @@ pub fn format_recipes(recipes: &[&Recipe]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query::shape::{
-        EvidenceSource, Excerpt, MatchEvidence, ShapedMeeting, Signals,
-    };
+    use crate::query::shape::{EvidenceSource, Excerpt, MatchEvidence, ShapedMeeting, Signals};
 
     fn shaped() -> ShapedMeeting {
         ShapedMeeting {
@@ -244,7 +248,11 @@ mod tests {
             title: Some("Infra Sync".to_string()),
             created_at: Some("2026-05-12T14:30:00Z".to_string()),
             score: Some(0.63),
-            signals: Signals { keyword: true, semantic: false, title: true },
+            signals: Signals {
+                keyword: true,
+                semantic: false,
+                title: true,
+            },
             total_matches: 3,
             matches: vec![MatchEvidence {
                 source: EvidenceSource::Transcript,

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use crate::models::{
     Calendar, CalendarEvent, Document, PanelTemplate, Person, Recipe, TranscriptUtterance,
 };
-use crate::query::speaker::{label as speaker_label, SpeakerLabel};
+use crate::query::speaker::{SpeakerLabel, label as speaker_label};
 
 /// Format a meeting list entry for TTY display.
 pub fn format_meeting_row(doc: &Document, tz: &FixedOffset) -> String {
@@ -43,7 +43,11 @@ pub fn format_meeting_detail(doc: &Document, tz: &FixedOffset) -> String {
     lines.push("─".repeat(title.len()));
 
     if let Some(date) = &doc.created_at {
-        lines.push(format!("{} {}", "Date:".dimmed(), format_date_short(date, tz)));
+        lines.push(format!(
+            "{} {}",
+            "Date:".dimmed(),
+            format_date_short(date, tz)
+        ));
     }
     if let Some(id) = &doc.id {
         lines.push(format!("{}   {}", "ID:".dimmed(), id));
@@ -101,13 +105,25 @@ pub fn format_utterance(utt: &TranscriptUtterance, highlight: bool, tz: &FixedOf
         };
 
     if highlight {
-        format!("  {} {} {}{}", "▶".green(), timestamp.dimmed(), speaker_prefix, text.bold())
+        format!(
+            "  {} {} {}{}",
+            "▶".green(),
+            timestamp.dimmed(),
+            speaker_prefix,
+            text.bold()
+        )
     } else {
         let styled_text = match utt.source.as_deref() {
             Some("microphone") => text.cyan().to_string(),
             _ => text.to_string(),
         };
-        format!("  {} {} {}{}", " ", timestamp.dimmed(), speaker_prefix, styled_text)
+        format!(
+            "  {} {} {}{}",
+            " ",
+            timestamp.dimmed(),
+            speaker_prefix,
+            styled_text
+        )
     }
 }
 
@@ -128,12 +144,7 @@ pub fn format_person_row(person: &Person) -> String {
         .unwrap_or("(unknown)")
         .bold()
         .to_string();
-    let email = person
-        .email
-        .as_deref()
-        .unwrap_or("")
-        .dimmed()
-        .to_string();
+    let email = person.email.as_deref().unwrap_or("").dimmed().to_string();
     let company = person
         .company_name
         .as_deref()
@@ -283,8 +294,16 @@ mod tests {
             ..Default::default()
         };
         let output = strip(&format_utterance(&utt, false, &utc()));
-        assert!(output.contains("You:"), "Expected 'You:' label, got: {}", output);
-        assert!(output.contains("Hello from me"), "Expected text, got: {}", output);
+        assert!(
+            output.contains("You:"),
+            "Expected 'You:' label, got: {}",
+            output
+        );
+        assert!(
+            output.contains("Hello from me"),
+            "Expected text, got: {}",
+            output
+        );
     }
 
     #[test]
@@ -295,7 +314,11 @@ mod tests {
             ..Default::default()
         };
         let output = strip(&format_utterance(&utt, false, &utc()));
-        assert!(output.contains("Other:"), "Expected 'Other:' label, got: {}", output);
+        assert!(
+            output.contains("Other:"),
+            "Expected 'Other:' label, got: {}",
+            output
+        );
     }
 
     #[test]
@@ -307,8 +330,16 @@ mod tests {
             ..Default::default()
         };
         let output = strip(&format_utterance(&utt, false, &utc()));
-        assert!(output.contains("Jane Doe:"), "Expected the name, got: {}", output);
-        assert!(!output.contains("Other:"), "Name should replace 'Other:', got: {}", output);
+        assert!(
+            output.contains("Jane Doe:"),
+            "Expected the name, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("Other:"),
+            "Name should replace 'Other:', got: {}",
+            output
+        );
     }
 
     #[test]
@@ -331,7 +362,10 @@ mod tests {
         };
         let output = strip(&format_utterance(&utt, true, &utc()));
         assert!(output.contains("▶"), "Expected highlight marker");
-        assert!(output.contains("You:"), "Expected 'You:' label in highlighted");
+        assert!(
+            output.contains("You:"),
+            "Expected 'You:' label in highlighted"
+        );
     }
 
     // === Timezone-aware display tests ===

--- a/src/pkce.rs
+++ b/src/pkce.rs
@@ -1,7 +1,7 @@
 //! PKCE challenge generation (RFC 7636), shared by the OAuth flows.
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use rand::{rngs::OsRng, RngCore};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::{RngCore, rngs::OsRng};
 use sha2::{Digest, Sha256};
 
 /// PKCE verifier/challenge pair for an OAuth flow.
@@ -29,7 +29,10 @@ impl PkceChallenge {
         hasher.update(verifier.as_bytes());
         let challenge = URL_SAFE_NO_PAD.encode(hasher.finalize());
 
-        Self { verifier, challenge }
+        Self {
+            verifier,
+            challenge,
+        }
     }
 }
 
@@ -48,9 +51,11 @@ mod tests {
     fn test_verifier_is_unreserved_charset() {
         // RFC 7636 restricts the verifier to [A-Za-z0-9-._~]
         let verifier = PkceChallenge::generate(32).verifier;
-        assert!(verifier
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~')));
+        assert!(
+            verifier
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~'))
+        );
     }
 
     #[test]

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 
 fn dirs_home() -> Option<PathBuf> {
     env::var("HOME")
@@ -17,7 +17,9 @@ pub fn data_dir() -> Result<PathBuf> {
         PathBuf::from(xdg).join("grans")
     } else if let Some(home) = dirs_home() {
         if cfg!(target_os = "macos") {
-            home.join("Library").join("Application Support").join("grans")
+            home.join("Library")
+                .join("Application Support")
+                .join("grans")
         } else {
             // Linux (including WSL)
             home.join(".local").join("share").join("grans")

--- a/src/query/adjust.rs
+++ b/src/query/adjust.rs
@@ -14,8 +14,9 @@ use crate::query::rerank::RerankCandidate;
 /// Words too common to signal which meeting a query is about. The Phase 5
 /// sweep showed the boost is insensitive to the exact list, so it stays
 /// minimal.
-const STOPWORDS: &[&str] =
-    &["a", "an", "the", "of", "in", "on", "at", "to", "for", "with", "and", "or"];
+const STOPWORDS: &[&str] = &[
+    "a", "an", "the", "of", "in", "on", "at", "to", "for", "with", "and", "or",
+];
 
 /// Weights for the ordering score. Defaults are the winners of recorded
 /// sweeps on the 93-query golden set; a weight of 0.0 disables that
@@ -44,14 +45,20 @@ pub struct RankingConfig {
 
 impl Default for RankingConfig {
     fn default() -> Self {
-        Self { fusion_blend_weight: 30.0, title_boost_weight: 0.2 }
+        Self {
+            fusion_blend_weight: 30.0,
+            title_boost_weight: 0.2,
+        }
     }
 }
 
 impl RankingConfig {
     /// Apply experiment-flag overrides; `None` keeps the default.
     pub fn with_overrides(self, title_boost_weight: Option<f32>) -> Self {
-        Self { title_boost_weight: title_boost_weight.unwrap_or(self.title_boost_weight), ..self }
+        Self {
+            title_boost_weight: title_boost_weight.unwrap_or(self.title_boost_weight),
+            ..self
+        }
     }
 }
 
@@ -65,7 +72,9 @@ pub struct RankingContext {
 
 impl RankingContext {
     pub fn load(conn: &Connection) -> Result<Self> {
-        Ok(Self { title_counts: crate::db::meetings::title_series_counts(conn)? })
+        Ok(Self {
+            title_counts: crate::db::meetings::title_series_counts(conn)?,
+        })
     }
 }
 
@@ -99,8 +108,8 @@ fn title_signal(query_tokens: &HashSet<String>, title: Option<&str>, series_coun
     if title_tokens.is_empty() {
         return 0.0;
     }
-    let overlap = query_tokens.intersection(&title_tokens).count() as f64
-        / query_tokens.len() as f64;
+    let overlap =
+        query_tokens.intersection(&title_tokens).count() as f64 / query_tokens.len() as f64;
     (overlap / f64::from(1 + series_count).log2()) as f32
 }
 
@@ -159,7 +168,10 @@ mod tests {
     }
 
     fn no_boost() -> RankingConfig {
-        RankingConfig { title_boost_weight: 0.0, ..Default::default() }
+        RankingConfig {
+            title_boost_weight: 0.0,
+            ..Default::default()
+        }
     }
 
     #[test]
@@ -182,8 +194,10 @@ mod tests {
     #[test]
     fn content_tokens_drop_stopwords_short_tokens_and_case() {
         let tokens = content_tokens("The Kumquat & Q1 Review of x");
-        let expected: HashSet<String> =
-            ["kumquat", "q1", "review"].into_iter().map(str::to_string).collect();
+        let expected: HashSet<String> = ["kumquat", "q1", "review"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
         assert_eq!(tokens, expected);
     }
 
@@ -196,8 +210,10 @@ mod tests {
 
     #[test]
     fn title_signal_is_overlap_fraction_damped_by_series() {
-        let q: HashSet<String> =
-            ["kumquat", "sync"].into_iter().map(str::to_string).collect();
+        let q: HashSet<String> = ["kumquat", "sync"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
         // Full overlap, unique title: log2(1 + 1) = 1, no damping.
         assert_eq!(title_signal(&q, Some("Kumquat Sync"), 1), 1.0);
         // Full overlap in a 3-meeting series: damped by log2(4) = 2.
@@ -225,7 +241,10 @@ mod tests {
             cand("c", 0.0, -1.5, Some("Unrelated")),
         ] {
             let expected = c.rerank_score + 30.0 * c.fused_score as f32;
-            assert_eq!(ordering_score(&c, &q, &ctx, &cfg).to_bits(), expected.to_bits());
+            assert_eq!(
+                ordering_score(&c, &q, &ctx, &cfg).to_bits(),
+                expected.to_bits()
+            );
         }
     }
 
@@ -237,7 +256,10 @@ mod tests {
             cand("titled", 0.016, 0.5, Some("Kumquat Sync")),
         ];
         let ctx = RankingContext::default();
-        let cfg = RankingConfig { title_boost_weight: 0.2, ..Default::default() };
+        let cfg = RankingConfig {
+            title_boost_weight: 0.2,
+            ..Default::default()
+        };
 
         let sorted = sort_candidates(candidates, "kumquat sync", &ctx, &cfg);
 
@@ -258,7 +280,10 @@ mod tests {
                 ("kumquat deep dive".to_string(), 1),
             ]),
         };
-        let cfg = RankingConfig { title_boost_weight: 0.2, ..Default::default() };
+        let cfg = RankingConfig {
+            title_boost_weight: 0.2,
+            ..Default::default()
+        };
 
         let sorted = sort_candidates(candidates, "kumquat", &ctx, &cfg);
 
@@ -272,8 +297,12 @@ mod tests {
             cand("second", 0.02, 0.5, None),
             cand("third", 0.02, 0.5, None),
         ];
-        let sorted =
-            sort_candidates(candidates, "kumquat", &RankingContext::default(), &no_boost());
+        let sorted = sort_candidates(
+            candidates,
+            "kumquat",
+            &RankingContext::default(),
+            &no_boost(),
+        );
         let ids: Vec<&str> = sorted.iter().map(|c| c.document_id.as_str()).collect();
         assert_eq!(ids, vec!["first", "second", "third"]);
     }

--- a/src/query/dates.rs
+++ b/src/query/dates.rs
@@ -134,8 +134,8 @@ fn subtract_months(dt: DateTime<Utc>, months: u32, tz: &FixedOffset) -> Option<D
     let max_day = days_in_month(target_year, target_month);
     let target_day = local.day().min(max_day);
 
-    let naive = NaiveDate::from_ymd_opt(target_year, target_month, target_day)?
-        .and_hms_opt(0, 0, 0)?;
+    let naive =
+        NaiveDate::from_ymd_opt(target_year, target_month, target_day)?.and_hms_opt(0, 0, 0)?;
     let local_dt = tz.from_local_datetime(&naive).single()?;
     Some(local_dt.with_timezone(&Utc))
 }
@@ -235,8 +235,7 @@ fn next_month(dt: DateTime<Utc>, tz: &FixedOffset) -> DateTime<Utc> {
     } else {
         (local.year(), local.month() + 1)
     };
-    let naive = NaiveDate::from_ymd_opt(year, month, 1)
-        .and_then(|d| d.and_hms_opt(0, 0, 0));
+    let naive = NaiveDate::from_ymd_opt(year, month, 1).and_then(|d| d.and_hms_opt(0, 0, 0));
     match naive {
         Some(nm) => tz
             .from_local_datetime(&nm)
@@ -255,8 +254,7 @@ fn prev_month(dt: DateTime<Utc>, tz: &FixedOffset) -> DateTime<Utc> {
     } else {
         (local.year(), local.month() - 1)
     };
-    let naive = NaiveDate::from_ymd_opt(year, month, 1)
-        .and_then(|d| d.and_hms_opt(0, 0, 0));
+    let naive = NaiveDate::from_ymd_opt(year, month, 1).and_then(|d| d.and_hms_opt(0, 0, 0));
     match naive {
         Some(nm) => tz
             .from_local_datetime(&nm)
@@ -410,8 +408,14 @@ mod tests {
 
     #[test]
     fn test_build_date_range_absolute() {
-        let range =
-            build_date_range(Some("2026-01-01"), Some("2026-01-31"), None, fixed_now(), &utc_tz()).unwrap();
+        let range = build_date_range(
+            Some("2026-01-01"),
+            Some("2026-01-31"),
+            None,
+            fixed_now(),
+            &utc_tz(),
+        )
+        .unwrap();
         assert_eq!(range.start.unwrap().day(), 1);
         assert_eq!(range.end.unwrap().day(), 31);
     }
@@ -428,30 +432,21 @@ mod tests {
     fn test_parse_duration_days() {
         // 3d from Jan 22 2026 noon → Jan 19 2026 00:00 UTC
         let result = parse_duration("3d", fixed_now(), &utc_tz()).unwrap();
-        assert_eq!(
-            result,
-            Utc.with_ymd_and_hms(2026, 1, 19, 0, 0, 0).unwrap()
-        );
+        assert_eq!(result, Utc.with_ymd_and_hms(2026, 1, 19, 0, 0, 0).unwrap());
     }
 
     #[test]
     fn test_parse_duration_weeks() {
         // 2w from Jan 22 2026 noon → Jan 8 2026 00:00 UTC
         let result = parse_duration("2w", fixed_now(), &utc_tz()).unwrap();
-        assert_eq!(
-            result,
-            Utc.with_ymd_and_hms(2026, 1, 8, 0, 0, 0).unwrap()
-        );
+        assert_eq!(result, Utc.with_ymd_and_hms(2026, 1, 8, 0, 0, 0).unwrap());
     }
 
     #[test]
     fn test_parse_duration_months() {
         // 1m from Jan 22 2026 noon → Dec 22 2025 00:00 UTC
         let result = parse_duration("1m", fixed_now(), &utc_tz()).unwrap();
-        assert_eq!(
-            result,
-            Utc.with_ymd_and_hms(2025, 12, 22, 0, 0, 0).unwrap()
-        );
+        assert_eq!(result, Utc.with_ymd_and_hms(2025, 12, 22, 0, 0, 0).unwrap());
     }
 
     #[test]
@@ -459,20 +454,14 @@ mod tests {
         // 1m from March 31 → Feb 28 (non-leap year 2026)
         let march_31 = Utc.with_ymd_and_hms(2026, 3, 31, 12, 0, 0).unwrap();
         let result = parse_duration("1m", march_31, &utc_tz()).unwrap();
-        assert_eq!(
-            result,
-            Utc.with_ymd_and_hms(2026, 2, 28, 0, 0, 0).unwrap()
-        );
+        assert_eq!(result, Utc.with_ymd_and_hms(2026, 2, 28, 0, 0, 0).unwrap());
     }
 
     #[test]
     fn test_parse_duration_months_multiple() {
         // 3m from Jan 22 2026 → Oct 22 2025
         let result = parse_duration("3m", fixed_now(), &utc_tz()).unwrap();
-        assert_eq!(
-            result,
-            Utc.with_ymd_and_hms(2025, 10, 22, 0, 0, 0).unwrap()
-        );
+        assert_eq!(result, Utc.with_ymd_and_hms(2025, 10, 22, 0, 0, 0).unwrap());
     }
 
     #[test]

--- a/src/query/evidence.rs
+++ b/src/query/evidence.rs
@@ -12,11 +12,11 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::models::Document;
-use crate::query::fts::{matches_all_tokens, FtsToken};
+use crate::query::fts::{FtsToken, matches_all_tokens};
 use crate::query::hybrid::BestChunk;
 use crate::query::shape::{
-    excerpt_around_match, title_matches, ContextUnit, EvidenceSource, MatchEvidence,
-    ShapedMeeting, Signals,
+    ContextUnit, EvidenceSource, MatchEvidence, ShapedMeeting, Signals, excerpt_around_match,
+    title_matches,
 };
 use crate::query::speaker::SpeakerFilter;
 use crate::query::text::{split_into_paragraphs, split_markdown_sections, strip_panel_footer};
@@ -40,7 +40,12 @@ pub struct EvidenceOptions {
 
 impl Default for EvidenceOptions {
     fn default() -> Self {
-        Self { max_matches: 1, max_chars: 160, speaker: None, context: 0 }
+        Self {
+            max_matches: 1,
+            max_chars: 160,
+            speaker: None,
+            context: 0,
+        }
     }
 }
 
@@ -102,7 +107,11 @@ pub fn collect_document_evidence(
 
     // Context expansion shows the matched unit whole; the window cap only
     // applies to the compact snippet view.
-    let width = if opts.context > 0 { usize::MAX } else { opts.max_chars };
+    let width = if opts.context > 0 {
+        usize::MAX
+    } else {
+        opts.max_chars
+    };
 
     let total = sites.len();
     let mut matches = Vec::new();
@@ -124,7 +133,11 @@ pub fn collect_document_evidence(
         }
     }
 
-    Ok(DocumentEvidence { matches, total, remaining_sources })
+    Ok(DocumentEvidence {
+        matches,
+        total,
+        remaining_sources,
+    })
 }
 
 /// Ranking facts about one document from the hybrid pipeline.
@@ -154,7 +167,11 @@ pub fn shape_meeting(
     let signals = Signals {
         keyword: facts.keyword,
         semantic: facts.best_chunk.is_some(),
-        title: doc.title.as_deref().map(|t| title_matches(t, tokens)).unwrap_or(false),
+        title: doc
+            .title
+            .as_deref()
+            .map(|t| title_matches(t, tokens))
+            .unwrap_or(false),
     };
 
     // Tier on whether lexical evidence exists, not on whether any was
@@ -330,7 +347,9 @@ fn collect_transcript_sites(
         if matches_all_tokens(text, tokens) {
             let (context_before, context_after) =
                 neighbors_of(&utterances, i, opts.context, |u| ContextUnit {
-                    text: crate::query::shape::normalize_whitespace(u.text.as_deref().unwrap_or_default()),
+                    text: crate::query::shape::normalize_whitespace(
+                        u.text.as_deref().unwrap_or_default(),
+                    ),
                     speaker: u.source.clone(),
                     speaker_name: u.detected_speaker_name.clone(),
                     timestamp: u.start_timestamp.clone(),
@@ -403,7 +422,10 @@ mod tests {
         query: &str,
         max_matches: usize,
     ) -> DocumentEvidence {
-        let limits = EvidenceOptions { max_matches, ..Default::default() };
+        let limits = EvidenceOptions {
+            max_matches,
+            ..Default::default()
+        };
         collect_document_evidence(conn, doc, &parse_query(query), &limits).unwrap()
     }
 
@@ -459,7 +481,10 @@ mod tests {
             .filter(|m| m.source == EvidenceSource::Transcript)
             .collect();
         assert_eq!(transcript[0].speaker.as_deref(), Some("microphone"));
-        assert_eq!(transcript[0].timestamp.as_deref(), Some("2026-01-20T10:01:00Z"));
+        assert_eq!(
+            transcript[0].timestamp.as_deref(),
+            Some("2026-01-20T10:01:00Z")
+        );
         assert_eq!(transcript[1].speaker.as_deref(), Some("system"));
     }
 
@@ -492,7 +517,10 @@ mod tests {
         let ev = collect(&conn, &doc, "kumquat question", 5);
         assert_eq!(ev.total, 1);
         assert_eq!(ev.matches[0].source, EvidenceSource::Transcript);
-        assert_eq!(ev.matches[0].timestamp.as_deref(), Some("2026-01-20T10:03:00Z"));
+        assert_eq!(
+            ev.matches[0].timestamp.as_deref(),
+            Some("2026-01-20T10:03:00Z")
+        );
     }
 
     #[test]
@@ -523,7 +551,14 @@ mod tests {
         query: &str,
         facts: &RankingFacts,
     ) -> ShapedMeeting {
-        shape_meeting(conn, doc, &parse_query(query), facts, &EvidenceOptions::default()).unwrap()
+        shape_meeting(
+            conn,
+            doc,
+            &parse_query(query),
+            facts,
+            &EvidenceOptions::default(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -531,8 +566,11 @@ mod tests {
         let conn = build_test_db(&evidence_state());
         let doc = load_doc(&conn, "doc-1");
         let chunk = best_chunk("some semantic chunk", "transcript_window", None);
-        let facts =
-            RankingFacts { keyword: true, best_chunk: Some(&chunk), score: Some(0.9) };
+        let facts = RankingFacts {
+            keyword: true,
+            best_chunk: Some(&chunk),
+            score: Some(0.9),
+        };
 
         let shaped = shape(&conn, &doc, "kumquat", &facts);
 
@@ -554,14 +592,21 @@ mod tests {
             "panel_section",
             Some("Decisions"),
         );
-        let facts = RankingFacts { keyword: false, best_chunk: Some(&chunk), score: Some(0.4) };
+        let facts = RankingFacts {
+            keyword: false,
+            best_chunk: Some(&chunk),
+            score: Some(0.4),
+        };
 
         let shaped = shape(&conn, &doc, "zyzzyva", &facts);
 
         assert_eq!(shaped.matches.len(), 1);
         assert_eq!(shaped.matches[0].source, EvidenceSource::Panel);
         assert_eq!(shaped.matches[0].section.as_deref(), Some("Decisions"));
-        assert_eq!(shaped.matches[0].excerpt.text, "discussion of adjacent topics");
+        assert_eq!(
+            shaped.matches[0].excerpt.text,
+            "discussion of adjacent topics"
+        );
         assert!(shaped.matches[0].excerpt.highlights.is_empty());
         assert_eq!(shaped.total_matches, 1);
         assert!(!shaped.signals.keyword);
@@ -576,7 +621,11 @@ mod tests {
             }
         }));
         let doc = load_doc(&conn, "doc-t");
-        let facts = RankingFacts { keyword: true, best_chunk: None, score: None };
+        let facts = RankingFacts {
+            keyword: true,
+            best_chunk: None,
+            score: None,
+        };
 
         let shaped = shape(&conn, &doc, "kumquat", &facts);
 
@@ -593,11 +642,17 @@ mod tests {
         let conn = build_test_db(&evidence_state());
         let doc = load_doc(&conn, "doc-1");
         let chunk = best_chunk("some semantic chunk", "transcript_window", None);
-        let facts = RankingFacts { keyword: true, best_chunk: Some(&chunk), score: None };
-        let limits = EvidenceOptions { max_matches: 0, ..Default::default() };
+        let facts = RankingFacts {
+            keyword: true,
+            best_chunk: Some(&chunk),
+            score: None,
+        };
+        let limits = EvidenceOptions {
+            max_matches: 0,
+            ..Default::default()
+        };
 
-        let shaped =
-            shape_meeting(&conn, &doc, &parse_query("kumquat"), &facts, &limits).unwrap();
+        let shaped = shape_meeting(&conn, &doc, &parse_query("kumquat"), &facts, &limits).unwrap();
 
         // Headers-only: no snippets, but the real lexical count and its
         // sources survive for the collapse line, and the semantic chunk
@@ -634,8 +689,11 @@ mod tests {
         query: &str,
         context: usize,
     ) -> DocumentEvidence {
-        let opts =
-            EvidenceOptions { max_matches: 10, context, ..Default::default() };
+        let opts = EvidenceOptions {
+            max_matches: 10,
+            context,
+            ..Default::default()
+        };
         collect_document_evidence(conn, doc, &parse_query(query), &opts).unwrap()
     }
 
@@ -644,8 +702,11 @@ mod tests {
         let conn = build_test_db(&evidence_state());
         let doc = load_doc(&conn, "doc-1");
         let ev = collect(&conn, &doc, "kumquat", 5);
-        assert!(ev.matches.iter().all(|m| m.context_before.is_empty()
-            && m.context_after.is_empty()));
+        assert!(
+            ev.matches
+                .iter()
+                .all(|m| m.context_before.is_empty() && m.context_after.is_empty())
+        );
     }
 
     #[test]
@@ -711,7 +772,14 @@ mod tests {
 
         let full = collect_with_context(&conn, &doc, "kumquat", 2);
         assert!(!full.matches[0].excerpt.text.contains('…'));
-        assert_eq!(full.matches[0].excerpt.text, long_para.trim().split_whitespace().collect::<Vec<_>>().join(" "));
+        assert_eq!(
+            full.matches[0].excerpt.text,
+            long_para
+                .trim()
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
     }
 
     #[test]
@@ -726,13 +794,15 @@ mod tests {
             speaker: Some(crate::query::speaker::SpeakerFilter::Me),
             ..Default::default()
         };
-        let ev =
-            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        let ev = collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
         // Only u1 (microphone) matches; its neighbor u2 is by the other
         // speaker and still appears as context.
         assert_eq!(ev.total, 1);
         assert_eq!(ev.matches[0].context_after.len(), 1);
-        assert_eq!(ev.matches[0].context_after[0].speaker.as_deref(), Some("system"));
+        assert_eq!(
+            ev.matches[0].context_after[0].speaker.as_deref(),
+            Some("system")
+        );
     }
 
     // --- speaker filter ---
@@ -747,8 +817,7 @@ mod tests {
             speaker: Some(crate::query::speaker::SpeakerFilter::Me),
             ..Default::default()
         };
-        let ev =
-            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        let ev = collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
         assert_eq!(ev.total, 1);
         assert_eq!(ev.matches[0].source, EvidenceSource::Transcript);
         assert_eq!(ev.matches[0].speaker.as_deref(), Some("microphone"));
@@ -763,8 +832,7 @@ mod tests {
             speaker: Some(SpeakerFilter::Names(vec!["Jane Doe".to_string()])),
             ..Default::default()
         };
-        let ev =
-            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        let ev = collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
         assert_eq!(ev.total, 1);
         assert_eq!(ev.matches[0].speaker_name.as_deref(), Some("Jane Doe"));
         assert!(ev.matches[0].excerpt.text.contains("rollout"));
@@ -781,8 +849,7 @@ mod tests {
             speaker: Some(SpeakerFilter::Names(vec!["Marcus Webb".to_string()])),
             ..Default::default()
         };
-        let ev =
-            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        let ev = collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
         assert_eq!(ev.total, 1);
         assert_eq!(ev.matches[0].speaker_name.as_deref(), Some("Marcus Webb"));
     }
@@ -834,8 +901,7 @@ mod tests {
             speaker: Some(crate::query::speaker::SpeakerFilter::Other),
             ..Default::default()
         };
-        let ev =
-            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        let ev = collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
         // Only u3 ("Back to the kumquat question.", system); the panel and
         // notes sites have no speaker to attribute and do not count.
         assert_eq!(ev.total, 1);
@@ -851,14 +917,17 @@ mod tests {
         // leaves no attributable evidence, and neither the semantic chunk
         // nor the title may stand in.
         let chunk = best_chunk("some semantic chunk", "transcript_window", None);
-        let facts = RankingFacts { keyword: true, best_chunk: Some(&chunk), score: None };
+        let facts = RankingFacts {
+            keyword: true,
+            best_chunk: Some(&chunk),
+            score: None,
+        };
         let opts = EvidenceOptions {
             speaker: Some(crate::query::speaker::SpeakerFilter::Other),
             ..Default::default()
         };
 
-        let shaped =
-            shape_meeting(&conn, &doc, &parse_query("rollout"), &facts, &opts).unwrap();
+        let shaped = shape_meeting(&conn, &doc, &parse_query("rollout"), &facts, &opts).unwrap();
 
         assert_eq!(shaped.total_matches, 0);
         assert!(shaped.matches.is_empty());
@@ -868,7 +937,11 @@ mod tests {
     fn shaped_meeting_carries_identity_fields() {
         let conn = build_test_db(&evidence_state());
         let doc = load_doc(&conn, "doc-1");
-        let facts = RankingFacts { keyword: true, best_chunk: None, score: Some(0.7) };
+        let facts = RankingFacts {
+            keyword: true,
+            best_chunk: None,
+            score: Some(0.7),
+        };
 
         let shaped = shape(&conn, &doc, "kumquat", &facts);
 

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -57,25 +57,40 @@ impl SearchTarget {
 /// Re-join parsed targets into an `--in` flag value, so a suggested command
 /// can echo the active filter as the user could re-type it.
 pub fn targets_to_flag_value(targets: &[SearchTarget]) -> String {
-    targets.iter().map(|t| t.as_str()).collect::<Vec<_>>().join(",")
+    targets
+        .iter()
+        .map(|t| t.as_str())
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 /// Compute a source type filter for semantic search from search targets.
 /// Returns `None` when all embeddable sources are included (= search everything).
 /// Returns `Some(empty vec)` if only non-embeddable targets (titles) are selected.
 pub fn semantic_source_filter(targets: &[SearchTarget]) -> Option<Vec<&'static str>> {
-    let all_embeddable = [SearchTarget::Transcripts, SearchTarget::Notes, SearchTarget::Panels];
+    let all_embeddable = [
+        SearchTarget::Transcripts,
+        SearchTarget::Notes,
+        SearchTarget::Panels,
+    ];
     if all_embeddable.iter().all(|t| targets.contains(t)) {
         return None; // default = no filter
     }
-    let types: Vec<&str> = targets.iter().filter_map(|t| t.to_chunk_source_type()).collect();
+    let types: Vec<&str> = targets
+        .iter()
+        .filter_map(|t| t.to_chunk_source_type())
+        .collect();
     Some(types)
 }
 
 /// True when the title or id contains the lowercased filter.
 pub fn meeting_filter_matches(filter_lower: &str, title: Option<&str>, id: Option<&str>) -> bool {
-    title.map(|t| t.to_lowercase().contains(filter_lower)).unwrap_or(false)
-        || id.map(|i| i.to_lowercase().contains(filter_lower)).unwrap_or(false)
+    title
+        .map(|t| t.to_lowercase().contains(filter_lower))
+        .unwrap_or(false)
+        || id
+            .map(|i| i.to_lowercase().contains(filter_lower))
+            .unwrap_or(false)
 }
 
 /// Keep only documents whose title or id contains `filter` (case-insensitive).
@@ -87,7 +102,9 @@ pub fn filter_by_meeting(results: Vec<Document>, meeting_filter: Option<&str>) -
     let filter_lower = filter.to_lowercase();
     results
         .into_iter()
-        .filter(|doc| meeting_filter_matches(&filter_lower, doc.title.as_deref(), doc.id.as_deref()))
+        .filter(|doc| {
+            meeting_filter_matches(&filter_lower, doc.title.as_deref(), doc.id.as_deref())
+        })
         .collect()
 }
 
@@ -99,7 +116,10 @@ mod tests {
     fn test_all_matches_the_default_target_string() {
         // `all()` and DEFAULT_SEARCH_TARGETS must stay in lockstep so the
         // clap default and the footer's "is this the default?" check agree.
-        assert_eq!(targets_to_flag_value(&SearchTarget::all()), DEFAULT_SEARCH_TARGETS);
+        assert_eq!(
+            targets_to_flag_value(&SearchTarget::all()),
+            DEFAULT_SEARCH_TARGETS
+        );
     }
 
     #[test]
@@ -120,28 +140,49 @@ mod tests {
     #[test]
     fn test_to_chunk_source_type() {
         assert_eq!(SearchTarget::Titles.to_chunk_source_type(), None);
-        assert_eq!(SearchTarget::Transcripts.to_chunk_source_type(), Some("transcript_window"));
-        assert_eq!(SearchTarget::Notes.to_chunk_source_type(), Some("notes_paragraph"));
-        assert_eq!(SearchTarget::Panels.to_chunk_source_type(), Some("panel_section"));
+        assert_eq!(
+            SearchTarget::Transcripts.to_chunk_source_type(),
+            Some("transcript_window")
+        );
+        assert_eq!(
+            SearchTarget::Notes.to_chunk_source_type(),
+            Some("notes_paragraph")
+        );
+        assert_eq!(
+            SearchTarget::Panels.to_chunk_source_type(),
+            Some("panel_section")
+        );
     }
 
     #[test]
     fn test_semantic_source_filter_all_embeddable() {
-        let targets = vec![SearchTarget::Transcripts, SearchTarget::Notes, SearchTarget::Panels];
+        let targets = vec![
+            SearchTarget::Transcripts,
+            SearchTarget::Notes,
+            SearchTarget::Panels,
+        ];
         assert_eq!(semantic_source_filter(&targets), None);
     }
 
     #[test]
     fn test_semantic_source_filter_all_with_titles() {
         // All embeddable + titles = still None (search everything)
-        let targets = vec![SearchTarget::Titles, SearchTarget::Transcripts, SearchTarget::Notes, SearchTarget::Panels];
+        let targets = vec![
+            SearchTarget::Titles,
+            SearchTarget::Transcripts,
+            SearchTarget::Notes,
+            SearchTarget::Panels,
+        ];
         assert_eq!(semantic_source_filter(&targets), None);
     }
 
     #[test]
     fn test_semantic_source_filter_subset() {
         let targets = vec![SearchTarget::Panels];
-        assert_eq!(semantic_source_filter(&targets), Some(vec!["panel_section"]));
+        assert_eq!(
+            semantic_source_filter(&targets),
+            Some(vec!["panel_section"])
+        );
     }
 
     #[test]

--- a/src/query/fts.rs
+++ b/src/query/fts.rs
@@ -157,10 +157,10 @@ mod tests {
 
     #[test]
     fn parse_empty_phrase_dropped() {
-        assert_eq!(parse_query("foo \"\" bar"), vec![
-            FtsToken::Term("foo".into()),
-            FtsToken::Term("bar".into())
-        ]);
+        assert_eq!(
+            parse_query("foo \"\" bar"),
+            vec![FtsToken::Term("foo".into()), FtsToken::Term("bar".into())]
+        );
     }
 
     #[test]
@@ -211,7 +211,10 @@ mod tests {
 
     #[test]
     fn sanitize_neutralizes_fts_operators() {
-        assert_eq!(sanitize_fts_query("cats OR dogs"), "\"cats\" \"OR\" \"dogs\"");
+        assert_eq!(
+            sanitize_fts_query("cats OR dogs"),
+            "\"cats\" \"OR\" \"dogs\""
+        );
         assert_eq!(sanitize_fts_query("foo NOT bar"), "\"foo\" \"NOT\" \"bar\"");
         assert_eq!(sanitize_fts_query("col:value"), "\"col:value\"");
         assert_eq!(sanitize_fts_query("wild*"), "\"wild*\"");

--- a/src/query/hybrid.rs
+++ b/src/query/hybrid.rs
@@ -10,11 +10,11 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::embed::model::Embedder;
 use crate::embed::EmbeddingIndex;
+use crate::embed::model::Embedder;
 use crate::query::dates::DateRange;
-use crate::query::filter::{meeting_filter_matches, semantic_source_filter, SearchTarget};
-use crate::query::fusion::{reciprocal_rank_fusion, FusedDoc, RRF_K};
+use crate::query::filter::{SearchTarget, meeting_filter_matches, semantic_source_filter};
+use crate::query::fusion::{FusedDoc, RRF_K, reciprocal_rank_fusion};
 
 /// How many top documents each retriever contributes to fusion.
 pub const CANDIDATE_POOL: usize = 100;
@@ -63,7 +63,9 @@ pub fn hybrid_ranked(
     date_range: Option<&DateRange>,
     include_deleted: bool,
 ) -> Result<HybridRanking> {
-    let allowed = meeting_filter.map(|f| allowed_meeting_ids(conn, f)).transpose()?;
+    let allowed = meeting_filter
+        .map(|f| allowed_meeting_ids(conn, f))
+        .transpose()?;
     let is_allowed = |id: &str| allowed.as_ref().is_none_or(|set| set.contains(id));
 
     let fts_docs = crate::db::meetings::search_meetings(
@@ -76,8 +78,11 @@ pub fn hybrid_ranked(
         date_range,
         include_deleted,
     )?;
-    let fts_ids: Vec<String> =
-        fts_docs.into_iter().filter_map(|d| d.id).filter(|id| is_allowed(id)).collect();
+    let fts_ids: Vec<String> = fts_docs
+        .into_iter()
+        .filter_map(|d| d.id)
+        .filter(|id| is_allowed(id))
+        .collect();
 
     // No limit: the per-document best chunks must cover every candidate,
     // including FTS-only documents outside the semantic top of the pool.
@@ -215,10 +220,18 @@ mod tests {
         let conn = build_test_db(&hybrid_state());
         let index = hybrid_index();
 
-        let fused =
-            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, None, false)
-                .unwrap()
-                .fused;
+        let fused = hybrid_ranked(
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &all_targets(),
+            None,
+            None,
+            false,
+        )
+        .unwrap()
+        .fused;
 
         // FTS title tier orders by recency: [doc-fts, doc-both].
         // Semantic orders by cosine: [doc-both, doc-sem].
@@ -240,10 +253,18 @@ mod tests {
         let index = hybrid_index();
         let targets = vec![SearchTarget::Titles];
 
-        let fused =
-            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &targets, None, None, false)
-                .unwrap()
-                .fused;
+        let fused = hybrid_ranked(
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &targets,
+            None,
+            None,
+            false,
+        )
+        .unwrap()
+        .fused;
 
         // Semantic search is filtered to no embeddable source types, so
         // only the FTS title matches remain, in FTS order.
@@ -264,9 +285,17 @@ mod tests {
             stats: None,
         };
 
-        let ranking =
-            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, None, false)
-                .unwrap();
+        let ranking = hybrid_ranked(
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &all_targets(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(
             ranking.best_chunks.get("doc-both").map(|c| c.text.as_str()),
@@ -277,7 +306,10 @@ mod tests {
             Some("strong chunk")
         );
         assert_eq!(
-            ranking.best_chunks.get("doc-sem").map(|c| c.source_type.as_str()),
+            ranking
+                .best_chunks
+                .get("doc-sem")
+                .map(|c| c.source_type.as_str()),
             Some("transcript_window")
         );
         // doc-fts has no chunks, so it has no passage entry.
@@ -289,9 +321,17 @@ mod tests {
         let conn = build_test_db(&hybrid_state());
         let index = hybrid_index();
 
-        let ranking =
-            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, None, false)
-                .unwrap();
+        let ranking = hybrid_ranked(
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &all_targets(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
 
         // Both kumquat-titled docs come from FTS; the semantic-only doc
         // does not.
@@ -318,11 +358,22 @@ mod tests {
             );
         }
         let conn = build_test_db(&json!({ "documents": docs }));
-        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
+        let index = EmbeddingIndex {
+            vectors: Vec::new(),
+            stats: None,
+        };
 
-        let ranking =
-            hybrid_ranked(&conn, &FixedEmbedder, &index, "kumquat", &all_targets(), None, None, false)
-                .unwrap();
+        let ranking = hybrid_ranked(
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &all_targets(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
 
         assert_eq!(ranking.keyword_total, 120);
         assert_eq!(ranking.fused.len(), CANDIDATE_POOL);
@@ -361,7 +412,10 @@ mod tests {
         // pool. The beta doc ranks 121st in FTS (past CANDIDATE_POOL), so
         // only a pushdown before truncation can surface it.
         let conn = build_test_db(&pooled_state_with_beta_target());
-        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
+        let index = EmbeddingIndex {
+            vectors: Vec::new(),
+            stats: None,
+        };
 
         let ranking = hybrid_ranked(
             &conn,
@@ -375,7 +429,11 @@ mod tests {
         )
         .unwrap();
 
-        let ids: Vec<&str> = ranking.fused.iter().map(|d| d.document_id.as_str()).collect();
+        let ids: Vec<&str> = ranking
+            .fused
+            .iter()
+            .map(|d| d.document_id.as_str())
+            .collect();
         assert_eq!(ids, vec!["doc-beta-target"]);
         assert_eq!(ranking.keyword_total, 1);
 
@@ -391,10 +449,12 @@ mod tests {
             false,
         )
         .unwrap();
-        assert!(!unfiltered
-            .fused
-            .iter()
-            .any(|d| d.document_id == "doc-beta-target"));
+        assert!(
+            !unfiltered
+                .fused
+                .iter()
+                .any(|d| d.document_id == "doc-beta-target")
+        );
     }
 
     #[test]
@@ -416,7 +476,11 @@ mod tests {
         )
         .unwrap();
 
-        let ids: Vec<&str> = ranking.fused.iter().map(|d| d.document_id.as_str()).collect();
+        let ids: Vec<&str> = ranking
+            .fused
+            .iter()
+            .map(|d| d.document_id.as_str())
+            .collect();
         assert_eq!(ids, vec!["doc-sem"]);
         // Nothing FTS-matched survives the filter.
         assert_eq!(ranking.keyword_total, 0);
@@ -431,15 +495,33 @@ mod tests {
 
         // Title substring, different case.
         let by_title = hybrid_ranked(
-            &conn, &FixedEmbedder, &index, "kumquat", &all_targets(), Some("SYNC A"), None, false,
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &all_targets(),
+            Some("SYNC A"),
+            None,
+            false,
         )
         .unwrap();
-        let ids: Vec<&str> = by_title.fused.iter().map(|d| d.document_id.as_str()).collect();
+        let ids: Vec<&str> = by_title
+            .fused
+            .iter()
+            .map(|d| d.document_id.as_str())
+            .collect();
         assert_eq!(ids, vec!["doc-both"]);
 
         // Id substring.
         let by_id = hybrid_ranked(
-            &conn, &FixedEmbedder, &index, "kumquat", &all_targets(), Some("doc-fts"), None, false,
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "kumquat",
+            &all_targets(),
+            Some("doc-fts"),
+            None,
+            false,
         )
         .unwrap();
         let ids: Vec<&str> = by_id.fused.iter().map(|d| d.document_id.as_str()).collect();
@@ -481,11 +563,22 @@ mod tests {
     #[test]
     fn no_matches_fuse_to_empty() {
         let conn = build_test_db(&hybrid_state());
-        let index = EmbeddingIndex { vectors: Vec::new(), stats: None };
+        let index = EmbeddingIndex {
+            vectors: Vec::new(),
+            stats: None,
+        };
 
-        let ranking =
-            hybrid_ranked(&conn, &FixedEmbedder, &index, "zyzzyva", &all_targets(), None, None, false)
-                .unwrap();
+        let ranking = hybrid_ranked(
+            &conn,
+            &FixedEmbedder,
+            &index,
+            "zyzzyva",
+            &all_targets(),
+            None,
+            None,
+            false,
+        )
+        .unwrap();
 
         assert!(ranking.fused.is_empty());
         assert!(ranking.best_chunks.is_empty());

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -91,7 +91,10 @@ pub fn rerank_hybrid_detailed(
                 fused_score: fused.score,
                 passage: build_passage(
                     title.as_deref(),
-                    ranking.best_chunks.get(&fused.document_id).map(|c| c.text.as_str()),
+                    ranking
+                        .best_chunks
+                        .get(&fused.document_id)
+                        .map(|c| c.text.as_str()),
                 ),
                 title: title.clone(),
                 created_at: created_at.clone(),
@@ -118,10 +121,15 @@ pub fn rerank_hybrid(
     ctx: &RankingContext,
     cfg: &RankingConfig,
 ) -> Result<Vec<RerankedDoc>> {
-    Ok(rerank_hybrid_detailed(conn, reranker, query, ranking, ctx, cfg)?
-        .into_iter()
-        .map(|c| RerankedDoc { document_id: c.document_id, score: c.rerank_score })
-        .collect())
+    Ok(
+        rerank_hybrid_detailed(conn, reranker, query, ranking, ctx, cfg)?
+            .into_iter()
+            .map(|c| RerankedDoc {
+                document_id: c.document_id,
+                score: c.rerank_score,
+            })
+            .collect(),
+    )
 }
 
 #[cfg(test)]
@@ -137,12 +145,18 @@ mod tests {
     /// Explicitly boost-free config: these tests pin the fusion-blend
     /// behavior on its own, independent of the adopted default weights.
     fn no_boost() -> RankingConfig {
-        RankingConfig { title_boost_weight: 0.0, ..Default::default() }
+        RankingConfig {
+            title_boost_weight: 0.0,
+            ..Default::default()
+        }
     }
 
     #[test]
     fn passage_combines_title_and_chunk() {
-        assert_eq!(build_passage(Some("Title"), Some("chunk text")), "Title\n\nchunk text");
+        assert_eq!(
+            build_passage(Some("Title"), Some("chunk text")),
+            "Title\n\nchunk text"
+        );
         assert_eq!(build_passage(Some("Title"), None), "Title");
         assert_eq!(build_passage(None, Some("chunk text")), "chunk text");
         assert_eq!(build_passage(None, None), "");
@@ -150,7 +164,10 @@ mod tests {
 
     fn fused(ids: &[&str]) -> Vec<FusedDoc> {
         ids.iter()
-            .map(|id| FusedDoc { document_id: id.to_string(), score: 0.0 })
+            .map(|id| FusedDoc {
+                document_id: id.to_string(),
+                score: 0.0,
+            })
             .collect()
     }
 
@@ -162,7 +179,10 @@ mod tests {
         }
     }
 
-    fn make_ranking(fused: Vec<FusedDoc>, best_chunks: HashMap<String, BestChunk>) -> HybridRanking {
+    fn make_ranking(
+        fused: Vec<FusedDoc>,
+        best_chunks: HashMap<String, BestChunk>,
+    ) -> HybridRanking {
         HybridRanking {
             fused,
             best_chunks,
@@ -188,7 +208,15 @@ mod tests {
             HashMap::from([("doc-chunk".to_string(), chunk("kumquat kumquat"))]),
         );
 
-        let reranked = rerank_hybrid(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let reranked = rerank_hybrid(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         let ids: Vec<&str> = reranked.iter().map(|d| d.document_id.as_str()).collect();
         assert_eq!(ids, vec!["doc-chunk", "doc-title", "doc-none"]);
@@ -208,15 +236,31 @@ mod tests {
         }));
         let ranking = make_ranking(
             vec![
-                FusedDoc { document_id: "doc-none".to_string(), score: 0.03 },
-                FusedDoc { document_id: "doc-title".to_string(), score: 0.02 },
-                FusedDoc { document_id: "doc-chunk".to_string(), score: 0.01 },
+                FusedDoc {
+                    document_id: "doc-none".to_string(),
+                    score: 0.03,
+                },
+                FusedDoc {
+                    document_id: "doc-title".to_string(),
+                    score: 0.02,
+                },
+                FusedDoc {
+                    document_id: "doc-chunk".to_string(),
+                    score: 0.01,
+                },
             ],
             HashMap::from([("doc-chunk".to_string(), chunk("kumquat kumquat"))]),
         );
 
-        let detailed =
-            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let detailed = rerank_hybrid_detailed(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert_eq!(detailed.len(), 3);
         assert_eq!(detailed[0].document_id, "doc-chunk");
@@ -246,14 +290,27 @@ mod tests {
         }));
         let ranking = make_ranking(
             vec![
-                FusedDoc { document_id: "doc-fused".to_string(), score: 0.1 },
-                FusedDoc { document_id: "doc-deep".to_string(), score: 0.0 },
+                FusedDoc {
+                    document_id: "doc-fused".to_string(),
+                    score: 0.1,
+                },
+                FusedDoc {
+                    document_id: "doc-deep".to_string(),
+                    score: 0.0,
+                },
             ],
             HashMap::from([("doc-deep".to_string(), chunk("kumquat kumquat"))]),
         );
 
-        let detailed =
-            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let detailed = rerank_hybrid_detailed(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         // Blends: doc-fused 1 + 30 * 0.1 = 4, doc-deep 2 + 30 * 0 = 2.
         assert_eq!(detailed[0].document_id, "doc-fused");
@@ -273,11 +330,21 @@ mod tests {
         }));
         let ranking = make_ranking(fused(&["doc-1"]), HashMap::new());
 
-        let detailed =
-            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let detailed = rerank_hybrid_detailed(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert_eq!(detailed[0].title.as_deref(), Some("Kumquat sync"));
-        assert_eq!(detailed[0].created_at.as_deref(), Some("2026-01-02T10:00:00Z"));
+        assert_eq!(
+            detailed[0].created_at.as_deref(),
+            Some("2026-01-02T10:00:00Z")
+        );
     }
 
     #[test]
@@ -296,8 +363,14 @@ mod tests {
         }));
         let ranking = make_ranking(
             vec![
-                FusedDoc { document_id: "doc-plain".to_string(), score: 0.05 },
-                FusedDoc { document_id: "doc-titled".to_string(), score: 0.01 },
+                FusedDoc {
+                    document_id: "doc-plain".to_string(),
+                    score: 0.05,
+                },
+                FusedDoc {
+                    document_id: "doc-titled".to_string(),
+                    score: 0.01,
+                },
             ],
             HashMap::from([
                 ("doc-plain".to_string(), chunk("kumquat")),
@@ -306,17 +379,18 @@ mod tests {
         );
         let ctx = RankingContext::default();
 
-        let without = rerank_hybrid_detailed(
-            &conn, &MockReranker, "kumquat", &ranking, &ctx, &no_boost(),
-        )
-        .unwrap();
+        let without =
+            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &ctx, &no_boost())
+                .unwrap();
         assert_eq!(without[0].document_id, "doc-plain");
 
-        let boosted = RankingConfig { title_boost_weight: 0.25, ..Default::default() };
-        let with = rerank_hybrid_detailed(
-            &conn, &MockReranker, "kumquat", &ranking, &ctx, &boosted,
-        )
-        .unwrap();
+        let boosted = RankingConfig {
+            title_boost_weight: 0.25,
+            ..Default::default()
+        };
+        let with =
+            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &ctx, &boosted)
+                .unwrap();
         assert_eq!(with[0].document_id, "doc-titled");
         assert_eq!(with[0].rerank_score, 2.0);
         assert_eq!(with[1].rerank_score, 1.0);
@@ -334,8 +408,15 @@ mod tests {
         }));
         let ranking = make_ranking(fused(&["doc-first", "doc-second"]), HashMap::new());
 
-        let detailed =
-            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let detailed = rerank_hybrid_detailed(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         let ids: Vec<&str> = detailed.iter().map(|d| d.document_id.as_str()).collect();
         assert_eq!(ids, vec!["doc-first", "doc-second"]);
@@ -348,8 +429,15 @@ mod tests {
         let conn = build_test_db(&json!({ "documents": {} }));
         let ranking = make_ranking(Vec::new(), HashMap::new());
 
-        let detailed =
-            rerank_hybrid_detailed(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let detailed = rerank_hybrid_detailed(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert!(detailed.is_empty());
     }
@@ -375,7 +463,15 @@ mod tests {
             HashMap::from([("doc-59".to_string(), chunk("kumquat"))]),
         );
 
-        let reranked = rerank_hybrid(&conn, &MockReranker, "kumquat", &ranking, &RankingContext::default(), &no_boost()).unwrap();
+        let reranked = rerank_hybrid(
+            &conn,
+            &MockReranker,
+            "kumquat",
+            &ranking,
+            &RankingContext::default(),
+            &no_boost(),
+        )
+        .unwrap();
 
         assert_eq!(reranked.len(), RERANK_POOL);
         assert!(reranked.iter().all(|d| d.document_id != "doc-59"));

--- a/src/query/shape.rs
+++ b/src/query/shape.rs
@@ -315,7 +315,11 @@ mod tests {
 
     #[test]
     fn phrase_token_highlights_as_one_span() {
-        let e = excerpt("the database migration ran fine", "\"database migration\"", 80);
+        let e = excerpt(
+            "the database migration ran fine",
+            "\"database migration\"",
+            80,
+        );
         assert_eq!(highlighted(&e), vec!["database migration"]);
     }
 

--- a/src/query/speaker.rs
+++ b/src/query/speaker.rs
@@ -12,7 +12,7 @@
 //! lets a typo be an error instead of an empty result set that reads as
 //! "nobody said that".
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use rusqlite::Connection;
 
 /// How many known speakers an error message lists before it truncates.
@@ -63,8 +63,9 @@ impl SpeakerFilter {
         match self {
             SpeakerFilter::Me => source == Some("microphone"),
             SpeakerFilter::Other => source == Some("system"),
-            SpeakerFilter::Names(names) => speaker_name
-                .is_some_and(|name| names.iter().any(|n| n.eq_ignore_ascii_case(name))),
+            SpeakerFilter::Names(names) => {
+                speaker_name.is_some_and(|name| names.iter().any(|n| n.eq_ignore_ascii_case(name)))
+            }
         }
     }
 }
@@ -216,8 +217,14 @@ mod tests {
     fn parse_reserves_me_and_other_case_insensitively() {
         assert_eq!(SpeakerSelector::parse("me"), Some(SpeakerSelector::Me));
         assert_eq!(SpeakerSelector::parse("ME"), Some(SpeakerSelector::Me));
-        assert_eq!(SpeakerSelector::parse("other"), Some(SpeakerSelector::Other));
-        assert_eq!(SpeakerSelector::parse("OTHER"), Some(SpeakerSelector::Other));
+        assert_eq!(
+            SpeakerSelector::parse("other"),
+            Some(SpeakerSelector::Other)
+        );
+        assert_eq!(
+            SpeakerSelector::parse("OTHER"),
+            Some(SpeakerSelector::Other)
+        );
     }
 
     #[test]
@@ -369,7 +376,10 @@ mod tests {
     #[test]
     fn no_match_message_distinguishes_a_corpus_with_no_attribution() {
         let msg = no_match_message("jane", &[]);
-        assert!(msg.contains("no utterances have speaker attribution"), "got: {msg}");
+        assert!(
+            msg.contains("no utterances have speaker attribution"),
+            "got: {msg}"
+        );
         assert!(msg.contains("2026-07-21"), "got: {msg}");
     }
 

--- a/src/query/text.rs
+++ b/src/query/text.rs
@@ -73,7 +73,10 @@ pub fn split_markdown_sections(content: &str) -> Vec<(Option<&str>, &str)> {
         let heading = after_marker[..line_end].trim();
 
         let body_start = start + marker_len + line_end;
-        let body_end = heading_starts.get(idx + 1).copied().unwrap_or(content.len());
+        let body_end = heading_starts
+            .get(idx + 1)
+            .copied()
+            .unwrap_or(content.len());
 
         if body_start <= body_end {
             let body = content[body_start..body_end].trim();
@@ -112,9 +115,7 @@ fn detect_section_header_level(content: &str) -> Option<usize> {
     }
 
     // Among levels with max count, pick the deepest (highest number)
-    (1..=6)
-        .rev()
-        .find(|&level| counts[level] == max_count)
+    (1..=6).rev().find(|&level| counts[level] == max_count)
 }
 
 /// Split text into paragraphs (on `\n\n`), trimming whitespace and filtering empties.
@@ -260,7 +261,8 @@ mod tests {
 
     #[test]
     fn test_split_markdown_sections_multiple() {
-        let content = "### Action Items\n\n- Do thing 1\n\n### Key Decisions\n\nWe decided to ship.";
+        let content =
+            "### Action Items\n\n- Do thing 1\n\n### Key Decisions\n\nWe decided to ship.";
         let sections = split_markdown_sections(content);
         assert_eq!(sections.len(), 2);
         assert_eq!(sections[0].0, Some("Action Items"));
@@ -323,7 +325,8 @@ mod tests {
     #[test]
     fn test_split_markdown_sections_h1_title_h3_sections() {
         // h1 title + h3 sections → should split on h3 (more frequent)
-        let content = "# Meeting Title\n\n### Action Items\n\n- Do thing\n\n### Decisions\n\nWe decided.";
+        let content =
+            "# Meeting Title\n\n### Action Items\n\n- Do thing\n\n### Decisions\n\nWe decided.";
         let sections = split_markdown_sections(content);
         assert_eq!(sections.len(), 3);
         assert_eq!(sections[0].0, None); // "# Meeting Title" is preamble

--- a/src/sync/config.rs
+++ b/src/sync/config.rs
@@ -52,8 +52,8 @@ impl SyncConfig {
             fs::create_dir_all(parent)?;
         }
 
-        let content =
-            toml::to_string_pretty(self).map_err(|e| SyncError::Config(format!("serialize: {}", e)))?;
+        let content = toml::to_string_pretty(self)
+            .map_err(|e| SyncError::Config(format!("serialize: {}", e)))?;
 
         // Write to temp file first for atomic operation
         let temp_path = path.with_extension("toml.tmp");

--- a/src/sync/content_hash.rs
+++ b/src/sync/content_hash.rs
@@ -145,7 +145,8 @@ mod tests {
     const ONE_FULL_BLOCK: &str = "907a506cf5e706bda5c7a29b43c9c65d8344bd2fa2f22339b359c214812af5a1";
     const ONE_BLOCK_PLUS_ONE: &str =
         "c53f160bb0f52f97d686989961c455b5bba18dbca70d2cdc402eb63cdddf7b4d";
-    const TWO_FULL_BLOCKS: &str = "caa2b7a097746dcd56cbddd09bb9e5b5ab1c3a9a518a63453f07fb799e7839ec";
+    const TWO_FULL_BLOCKS: &str =
+        "caa2b7a097746dcd56cbddd09bb9e5b5ab1c3a9a518a63453f07fb799e7839ec";
 
     fn hash_all(data: &[u8]) -> String {
         let mut hasher = ContentHasher::new();

--- a/src/sync/dropbox.rs
+++ b/src/sync/dropbox.rs
@@ -105,10 +105,16 @@ impl DropboxClient {
         let start = Instant::now();
 
         let uploaded = if file_size <= UPLOAD_SINGLE_LIMIT {
-            debug!("upload {} ({} bytes, single request)", dropbox_path, file_size);
+            debug!(
+                "upload {} ({} bytes, single request)",
+                dropbox_path, file_size
+            );
             self.upload_single(local_path, dropbox_path, file_size, on_progress)
         } else {
-            debug!("upload {} ({} bytes, chunked session)", dropbox_path, file_size);
+            debug!(
+                "upload {} ({} bytes, chunked session)",
+                dropbox_path, file_size
+            );
             self.upload_chunked(local_path, dropbox_path, file_size, on_progress)
         }?;
 
@@ -154,7 +160,8 @@ impl DropboxClient {
         // 150 MB out of memory and lets reqwest's pull of the body drive the
         // progress report.
         let file = std::fs::File::open(local_path)?;
-        let body = reqwest::blocking::Body::sized(ProgressReader::new(file, on_progress), file_size);
+        let body =
+            reqwest::blocking::Body::sized(ProgressReader::new(file, on_progress), file_size);
 
         let response = self
             .http
@@ -247,12 +254,7 @@ impl DropboxClient {
     }
 
     /// Append data to an upload session.
-    fn upload_session_append(
-        &self,
-        session_id: &str,
-        offset: u64,
-        data: &[u8],
-    ) -> SyncResult<()> {
+    fn upload_session_append(&self, session_id: &str, offset: u64, data: &[u8]) -> SyncResult<()> {
         #[derive(Serialize)]
         struct AppendArg {
             cursor: SessionCursor,
@@ -512,7 +514,9 @@ pub fn format_timestamp(ts: u64) -> String {
     use chrono::{DateTime, Local};
     let dt = DateTime::from_timestamp(ts as i64, 0)
         .unwrap_or_else(|| DateTime::from_timestamp(0, 0).unwrap());
-    dt.with_timezone(&Local).format("%Y-%m-%d %H:%M:%S").to_string()
+    dt.with_timezone(&Local)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
 }
 
 #[cfg(test)]

--- a/src/sync/metadata.rs
+++ b/src/sync/metadata.rs
@@ -71,7 +71,6 @@ impl SyncMetadata {
             embeddings_db: None, // No longer using separate embeddings.db
         })
     }
-
 }
 
 impl IndexDbStats {

--- a/src/sync/oauth.rs
+++ b/src/sync/oauth.rs
@@ -66,9 +66,7 @@ pub fn exchange_code(code: &str, verifier: &str) -> SyncResult<TokenResponse> {
     if !status.is_success() {
         // Try to parse error response
         if let Ok(err) = serde_json::from_str::<TokenError>(&body) {
-            let msg = err
-                .error_description
-                .unwrap_or_else(|| err.error.clone());
+            let msg = err.error_description.unwrap_or_else(|| err.error.clone());
             return Err(SyncError::OAuth(msg));
         }
         return Err(SyncError::OAuth(format!("HTTP {}: {}", status, body)));
@@ -100,9 +98,7 @@ pub fn refresh_access_token(refresh_token: &str) -> SyncResult<TokenResponse> {
 
     if !status.is_success() {
         if let Ok(err) = serde_json::from_str::<TokenError>(&body) {
-            let msg = err
-                .error_description
-                .unwrap_or_else(|| err.error.clone());
+            let msg = err.error_description.unwrap_or_else(|| err.error.clone());
             return Err(SyncError::OAuth(msg));
         }
         return Err(SyncError::OAuth(format!("HTTP {}: {}", status, body)));

--- a/src/sync/reconcile.rs
+++ b/src/sync/reconcile.rs
@@ -90,7 +90,10 @@ mod tests {
         let after_push = A;
 
         // Local and remote both hold what the first push stored.
-        assert_eq!(decide(after_push, Some(after_push), Some(after_push)), UpToDate);
+        assert_eq!(
+            decide(after_push, Some(after_push), Some(after_push)),
+            UpToDate
+        );
     }
 
     /// The same in the other direction: pulling twice must not claim the local
@@ -99,7 +102,10 @@ mod tests {
     fn pulling_twice_with_no_remote_change_is_up_to_date() {
         let after_pull = A;
 
-        assert_eq!(decide(after_pull, Some(after_pull), Some(after_pull)), UpToDate);
+        assert_eq!(
+            decide(after_pull, Some(after_pull), Some(after_pull)),
+            UpToDate
+        );
     }
 
     /// A machine that pushed, then synced new data locally, may push again.
@@ -108,7 +114,10 @@ mod tests {
         let synced = A;
         let local_after_new_data = B;
 
-        assert_eq!(decide(local_after_new_data, Some(synced), Some(synced)), Proceed);
+        assert_eq!(
+            decide(local_after_new_data, Some(synced), Some(synced)),
+            Proceed
+        );
     }
 
     /// A second machine pushed since we last synced, so our push would discard

--- a/src/sync/transfer.rs
+++ b/src/sync/transfer.rs
@@ -583,6 +583,10 @@ mod tests {
         let msg = err.to_string();
 
         assert!(msg.contains("512"), "message should report actual: {}", msg);
-        assert!(msg.contains("1024"), "message should report expected: {}", msg);
+        assert!(
+            msg.contains("1024"),
+            "message should report expected: {}",
+            msg
+        );
     }
 }

--- a/src/tiptap.rs
+++ b/src/tiptap.rs
@@ -375,10 +375,7 @@ mod tests {
                 ]}
             ]
         });
-        assert_eq!(
-            tiptap_to_markdown(&doc),
-            "[**link**](https://example.com)"
-        );
+        assert_eq!(tiptap_to_markdown(&doc), "[**link**](https://example.com)");
     }
 
     #[test]

--- a/src/update/download.rs
+++ b/src/update/download.rs
@@ -119,8 +119,7 @@ pub fn replace_binary(content: &[u8]) -> UpdateResult<()> {
     }
 
     // Replace the binary
-    self_replace::self_replace(&temp_path)
-        .map_err(|e| UpdateError::Replace(e.to_string()))?;
+    self_replace::self_replace(&temp_path).map_err(|e| UpdateError::Replace(e.to_string()))?;
 
     // Clean up temp file (may fail on Windows, that's okay)
     let _ = std::fs::remove_file(&temp_path);

--- a/src/update/github.rs
+++ b/src/update/github.rs
@@ -55,9 +55,7 @@ pub struct Asset {
 impl Asset {
     /// Extract SHA256 hash from digest field.
     pub fn sha256(&self) -> Option<&str> {
-        self.digest
-            .as_ref()
-            .and_then(|d| d.strip_prefix("sha256:"))
+        self.digest.as_ref().and_then(|d| d.strip_prefix("sha256:"))
     }
 }
 
@@ -360,9 +358,6 @@ mod tests {
         };
 
         let run2 = run1.clone();
-        assert_eq!(
-            BuildStatus::Completed(run1),
-            BuildStatus::Completed(run2)
-        );
+        assert_eq!(BuildStatus::Completed(run1), BuildStatus::Completed(run2));
     }
 }

--- a/src/update/wait.rs
+++ b/src/update/wait.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 
-use super::github::{check_build_status, BuildStatus, WorkflowRun};
+use super::github::{BuildStatus, WorkflowRun, check_build_status};
 use super::{UpdateError, UpdateResult};
 
 /// Configuration for waiting on a build.
@@ -37,14 +37,8 @@ impl WaitConfig {
 /// Display information about an in-progress build.
 pub fn display_build_info(run: &WorkflowRun) {
     println!();
-    println!(
-        "{}: A release build is in progress",
-        "Note".yellow().bold()
-    );
-    println!(
-        "  Workflow: {}",
-        run.name.as_deref().unwrap_or("Unknown")
-    );
+    println!("{}: A release build is in progress", "Note".yellow().bold());
+    println!("  Workflow: {}", run.name.as_deref().unwrap_or("Unknown"));
     println!("  Started:  {}", format_timestamp(&run.created_at));
     println!("  URL:      {}", run.html_url);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -393,7 +393,8 @@ fn insert_test_data(conn: &Connection, state: &serde_json::Value) {
                     person.get("company_name").and_then(|v| v.as_str()),
                     person.get("job_title").and_then(|v| v.as_str()),
                 ],
-            ).unwrap();
+            )
+            .unwrap();
         }
     }
 
@@ -437,7 +438,8 @@ fn insert_test_data(conn: &Connection, state: &serde_json::Value) {
                     end_time,
                     event.get("calendarId").and_then(|v| v.as_str()),
                 ],
-            ).unwrap();
+            )
+            .unwrap();
         }
     }
 
@@ -528,7 +530,8 @@ fn insert_test_data(conn: &Connection, state: &serde_json::Value) {
     // notes_fts still needs the explicit rebuild, because nothing populates it
     // anywhere -- that is the bug in #85, and until it is fixed this is what
     // makes `--in notes` return anything in tests.
-    conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')", []).unwrap();
+    conn.execute("INSERT INTO notes_fts(notes_fts) VALUES('rebuild')", [])
+        .unwrap();
 }
 
 /// Build a fixture state with known, deterministic data.

--- a/tests/date_filter.rs
+++ b/tests/date_filter.rs
@@ -18,10 +18,7 @@ fn meetings_list_from_date_filters_correctly() {
     let docs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(docs.len(), 2);
 
-    let titles: Vec<&str> = docs
-        .iter()
-        .map(|d| d["title"].as_str().unwrap())
-        .collect();
+    let titles: Vec<&str> = docs.iter().map(|d| d["title"].as_str().unwrap()).collect();
     assert!(!titles.contains(&"Project Alpha Kickoff"));
     assert!(titles.contains(&"Beta Feature Review"));
     assert!(titles.contains(&"Gamma Sprint Planning"));
@@ -49,9 +46,7 @@ fn meetings_list_from_and_to_range() {
     // --from 2025-07-01 --to 2025-08-01 should only include doc-beta
     let output = env
         .cmd_json()
-        .args([
-            "list", "--from", "2025-07-01", "--to", "2025-08-01",
-        ])
+        .args(["list", "--from", "2025-07-01", "--to", "2025-08-01"])
         .output()
         .unwrap();
 
@@ -98,9 +93,7 @@ fn meetings_search_with_date_filter() {
     // Only doc-gamma (2025-08-10) should match
     let output = env
         .cmd_json()
-        .args([
-            "grep", "Sprint", "--in", "titles", "--from", "2025-08-01",
-        ])
+        .args(["grep", "Sprint", "--in", "titles", "--from", "2025-08-01"])
         .output()
         .unwrap();
 
@@ -119,9 +112,7 @@ fn transcripts_search_with_date_filter() {
     // Using search with --context to search transcripts
     let output = env
         .cmd_json()
-        .args([
-            "grep", "kickoff", "--context", "2", "--from", "2025-07-01",
-        ])
+        .args(["grep", "kickoff", "--context", "2", "--from", "2025-07-01"])
         .output()
         .unwrap();
 
@@ -136,7 +127,13 @@ fn calendars_events_with_date_filter() {
     // Filter events to only July
     env.cmd()
         .args([
-            "browse", "calendars", "events", "--from", "2025-07-01", "--to", "2025-08-01",
+            "browse",
+            "calendars",
+            "events",
+            "--from",
+            "2025-07-01",
+            "--to",
+            "2025-08-01",
         ])
         .assert()
         .success()

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -20,11 +20,7 @@ fn meetings_list_shows_all_meetings() {
 #[test]
 fn meetings_list_json_returns_array() {
     let env = TestEnv::with_fixture();
-    let output = env
-        .cmd_json()
-        .args(["list"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["list"]).output().unwrap();
 
     assert!(output.status.success());
     let docs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
@@ -56,11 +52,7 @@ fn meetings_show_by_id() {
 #[test]
 fn meetings_show_json_has_fields() {
     let env = TestEnv::with_fixture();
-    let output = env
-        .cmd_json()
-        .args(["show", "doc-alpha"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["show", "doc-alpha"]).output().unwrap();
 
     assert!(output.status.success());
     let doc: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
@@ -145,14 +137,18 @@ fn meetings_show_notes_json() {
     assert!(output.status.success());
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     // Should have both notes formats
-    assert!(json["notes_plain"]
-        .as_str()
-        .unwrap()
-        .contains("Discussed the project timeline"));
-    assert!(json["notes_markdown"]
-        .as_str()
-        .unwrap()
-        .contains("**project timeline**"));
+    assert!(
+        json["notes_plain"]
+            .as_str()
+            .unwrap()
+            .contains("Discussed the project timeline")
+    );
+    assert!(
+        json["notes_markdown"]
+            .as_str()
+            .unwrap()
+            .contains("**project timeline**")
+    );
     // Should NOT have transcript
     assert!(json.get("transcript").is_none());
 }
@@ -467,11 +463,7 @@ fn recipes_show_json_has_config() {
 #[test]
 fn meetings_show_displays_chat_url() {
     let env = TestEnv::with_fixture();
-    let output = env
-        .cmd()
-        .args(["show", "Alpha"])
-        .output()
-        .unwrap();
+    let output = env.cmd().args(["show", "Alpha"]).output().unwrap();
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -484,11 +476,7 @@ fn meetings_show_displays_chat_url() {
 #[test]
 fn meetings_show_json_includes_chat_url() {
     let env = TestEnv::with_fixture();
-    let output = env
-        .cmd_json()
-        .args(["show", "doc-alpha"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["show", "doc-alpha"]).output().unwrap();
 
     assert!(output.status.success());
     let doc: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
@@ -503,11 +491,7 @@ fn meetings_show_json_includes_chat_url() {
 #[test]
 fn meetings_show_json_chat_url_null_when_absent() {
     let env = TestEnv::with_fixture();
-    let output = env
-        .cmd_json()
-        .args(["show", "doc-beta"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["show", "doc-beta"]).output().unwrap();
 
     assert!(output.status.success());
     let doc: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();

--- a/tests/people_junction.rs
+++ b/tests/people_junction.rs
@@ -7,20 +7,13 @@ use predicates::prelude::*;
 fn people_meetings_alice_has_alpha_and_gamma() {
     let env = TestEnv::with_fixture();
     // Alice is creator/attendee of doc-alpha and doc-gamma
-    let output = env
-        .cmd_json()
-        .args(["with", "Alice"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["with", "Alice"]).output().unwrap();
 
     assert!(output.status.success());
     let docs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(docs.len(), 2);
 
-    let titles: Vec<&str> = docs
-        .iter()
-        .map(|d| d["title"].as_str().unwrap())
-        .collect();
+    let titles: Vec<&str> = docs.iter().map(|d| d["title"].as_str().unwrap()).collect();
     assert!(titles.contains(&"Project Alpha Kickoff"));
     assert!(titles.contains(&"Gamma Sprint Planning"));
     assert!(!titles.contains(&"Beta Feature Review"));
@@ -30,20 +23,13 @@ fn people_meetings_alice_has_alpha_and_gamma() {
 fn people_meetings_bob_has_alpha_and_beta() {
     let env = TestEnv::with_fixture();
     // Bob is attendee of doc-alpha and creator of doc-beta
-    let output = env
-        .cmd_json()
-        .args(["with", "Bob"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["with", "Bob"]).output().unwrap();
 
     assert!(output.status.success());
     let docs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(docs.len(), 2);
 
-    let titles: Vec<&str> = docs
-        .iter()
-        .map(|d| d["title"].as_str().unwrap())
-        .collect();
+    let titles: Vec<&str> = docs.iter().map(|d| d["title"].as_str().unwrap()).collect();
     assert!(titles.contains(&"Project Alpha Kickoff"));
     assert!(titles.contains(&"Beta Feature Review"));
     assert!(!titles.contains(&"Gamma Sprint Planning"));
@@ -53,20 +39,13 @@ fn people_meetings_bob_has_alpha_and_beta() {
 fn people_meetings_carol_has_beta_and_gamma() {
     let env = TestEnv::with_fixture();
     // Carol is attendee of doc-beta and doc-gamma
-    let output = env
-        .cmd_json()
-        .args(["with", "Carol"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["with", "Carol"]).output().unwrap();
 
     assert!(output.status.success());
     let docs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(docs.len(), 2);
 
-    let titles: Vec<&str> = docs
-        .iter()
-        .map(|d| d["title"].as_str().unwrap())
-        .collect();
+    let titles: Vec<&str> = docs.iter().map(|d| d["title"].as_str().unwrap()).collect();
     assert!(titles.contains(&"Beta Feature Review"));
     assert!(titles.contains(&"Gamma Sprint Planning"));
     assert!(!titles.contains(&"Project Alpha Kickoff"));
@@ -97,11 +76,7 @@ fn people_meetings_nonexistent_person_errors() {
 #[test]
 fn people_meetings_json_structure() {
     let env = TestEnv::with_fixture();
-    let output = env
-        .cmd_json()
-        .args(["with", "Alice"])
-        .output()
-        .unwrap();
+    let output = env.cmd_json().args(["with", "Alice"]).output().unwrap();
 
     assert!(output.status.success());
     let docs: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -28,7 +28,14 @@ fn context_search_phrase() {
     let env = TestEnv::with_fixture();
     let output = env
         .cmd_json()
-        .args(["grep", "resource allocation", "--context", "2", "--in", "transcripts"])
+        .args([
+            "grep",
+            "resource allocation",
+            "--context",
+            "2",
+            "--in",
+            "transcripts",
+        ])
         .output()
         .unwrap();
 
@@ -162,8 +169,12 @@ fn grep_json_is_shaped_with_evidence() {
     let m = &meetings[0];
     assert_eq!(m["id"], "doc-alpha");
     assert!(m["score"].is_null(), "grep results carry no rerank score");
-    let signals: Vec<&str> =
-        m["signals"].as_array().unwrap().iter().map(|s| s.as_str().unwrap()).collect();
+    let signals: Vec<&str> = m["signals"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s.as_str().unwrap())
+        .collect();
     assert!(signals.contains(&"keyword"));
     assert!(!signals.contains(&"semantic"));
 
@@ -264,7 +275,9 @@ fn grep_tty_header_reports_complete_count_when_limited() {
         .stdout(predicate::str::contains(
             "Found 2 meeting(s) matching \"prototype\" (showing 1):",
         ))
-        .stdout(predicate::str::contains("Use --limit 0 to show all 2 meetings."));
+        .stdout(predicate::str::contains(
+            "Use --limit 0 to show all 2 meetings.",
+        ));
 }
 
 #[test]
@@ -274,7 +287,9 @@ fn grep_tty_header_without_truncation_omits_showing() {
         .args(["grep", "prototype", "--in", "transcripts"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Found 2 meeting(s) matching \"prototype\":"))
+        .stdout(predicate::str::contains(
+            "Found 2 meeting(s) matching \"prototype\":",
+        ))
         .stdout(predicate::str::contains("(showing").not());
 }
 
@@ -366,7 +381,11 @@ fn speaker_name_filter_matches_a_partial_name() {
 
     assert!(output.status.success());
     let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(result["meetings"].as_array().unwrap().len(), 1, "got: {result}");
+    assert_eq!(
+        result["meetings"].as_array().unwrap().len(),
+        1,
+        "got: {result}"
+    );
 }
 
 #[test]
@@ -381,13 +400,19 @@ fn speaker_name_matching_several_speakers_notes_them_and_takes_the_union() {
 
     assert!(output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("matched 2 speakers"), "got stderr: {stderr}");
+    assert!(
+        stderr.contains("matched 2 speakers"),
+        "got stderr: {stderr}"
+    );
     assert!(stderr.contains("Priya Nair"), "got stderr: {stderr}");
     assert!(stderr.contains("Priya Raman"), "got stderr: {stderr}");
 
     // The note goes to stderr so JSON on stdout stays parseable.
     let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(result["meetings"].as_array().unwrap().len() >= 1, "got: {result}");
+    assert!(
+        result["meetings"].as_array().unwrap().len() >= 1,
+        "got: {result}"
+    );
 }
 
 #[test]
@@ -398,7 +423,9 @@ fn unknown_speaker_name_errors_and_lists_known_speakers() {
         .args(["grep", "prototype", "--speaker", "Marcys Webb"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("no speaker matches \"Marcys Webb\""))
+        .stderr(predicate::str::contains(
+            "no speaker matches \"Marcys Webb\"",
+        ))
         .stderr(predicate::str::contains("Marcus Webb"));
 }
 
@@ -417,7 +444,13 @@ fn show_transcript_names_the_detected_speaker() {
 fn show_transcript_filtered_to_a_speaker_keeps_only_their_utterances() {
     let env = TestEnv::with_fixture();
     env.cmd()
-        .args(["show", "doc-beta", "--transcript", "--speaker", "Marcus Webb"])
+        .args([
+            "show",
+            "doc-beta",
+            "--transcript",
+            "--speaker",
+            "Marcus Webb",
+        ])
         .assert()
         .success()
         .stdout(predicate::str::contains("Marcus Webb:"))


### PR DESCRIPTION
> **Merge this last.** It touches 84 files, so it conflicts with anything else outstanding. If it does conflict, do not resolve it by hand: `git checkout main -- . && cargo fmt --all` regenerates the first commit exactly, and the second commit needs only its SHA updated in `.git-blame-ignore-revs`. The other three PRs in this batch (#115, #116, #118) are not format-clean and will fail the new gate if this lands first.

## Decision 1: edition-2024 style, no `rustfmt.toml`

The issue flagged this as needing a deliberate choice, since rustfmt's 2024 style reorders imports (`use anyhow::{bail, Result}` becomes `use anyhow::{Result, bail}`) and the tree is written the old way throughout. Measured both:

| Style edition | Diff |
|---|---|
| 2024 (default for this crate) | 84 files, +2673/-1353 |
| 2021 (pinned via `rustfmt.toml`) | 77 files, +2485/-1247 |

The import reordering is ~7% of the churn, not the bulk of it. Pinning would buy a marginally smaller one-time diff in exchange for a config file that permanently diverges from what a default toolchain produces for the crate's own edition. So: take the 2024 style, add no config file.

## Decision 2: no git hook

Rust convention is editor format-on-save (`rust-analyzer`'s `editor.formatOnSave`) plus a CI check, and each hook option costs something the gate does not:

- `cargo-husky` / `rusty-hook` write to `.git/hooks` as a build side effect
- the `pre-commit` framework pulls Python into a Rust repo
- a committed `.githooks/` needs `git config core.hooksPath` run in every clone

The reasoning is recorded in a comment on the `fmt` job, so it is next to the thing it explains rather than only in this PR.

## The gate

`cargo fmt --all --check` needs no build of the project's own code, so it runs beside the test matrix rather than behind it.

It feeds `CI Status`, which is the one check branch protection requires. Without that, a formatting failure would be an advisory red X that does not hold the merge, which is most of the way back to having no gate at all. `CI Status` now treats `skipped` as a pass for either job (a non-Rust PR) and anything else as a failure, cancelled included, and reports which job failed:

```
test=success fmt=success   -> exit=0
test=success fmt=failure   -> exit=1  "Formatting failure"
test=skipped fmt=skipped   -> exit=0
test=success fmt=cancelled -> exit=1  "Formatting cancelled"
test=failure fmt=success   -> exit=1  "Tests failure"
```

## One thing fixed along the way

`'tests/**'` joins the paths filter that both `fmt` and `test` gate on. It was not there, so a PR touching only `tests/*.rs` matched nothing and skipped CI entirely: no tests, and under this change no formatting check either. `platform-tests.yml` has always listed it. That is a pre-existing coverage gap, but it is directly in the way of this gate being meaningful.

## Out of scope

`cargo clippy -- -D warnings` is left for its own change. There are two pre-existing dead-code warnings (`credential_store::file`, `SourceTypeBreakdown::total`) that would have to be resolved first, and whether to delete them or use them is a judgement about dead code, not about formatting.

## Verification

The reformat commit is `cargo fmt --all` and nothing else, so it can be checked by rerunning the command. 84 files modified, none added or deleted. Full suite from PowerShell, `cargo test --no-fail-fast`: 945 tests, all six binaries, exit 0, unchanged from before.

Closes #103

https://claude.ai/code/session_014akTv9Sj4UZ7bQPDhXe5hn