### PR TITLE
#106: Surface Granola's native per-utterance speaker attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,10 @@ grans grep "budget"
 grans g "budget"     # short alias
 
 # Complete and speaker-attributed: only that speaker's utterances count
-grans grep "action items" --speaker me      # things you said
-grans grep "deadline" --speaker other       # things others said
+grans grep "action items" --speaker me            # things you said
+grans grep "deadline" --speaker other             # things anyone else said
+grans grep "deadline" --speaker "Jane Doe"        # things Jane said
+grans grep "deadline" --speaker jane              # partial names work
 
 # Search specific targets (both verbs)
 grans search "AI" --in titles
@@ -281,9 +283,11 @@ grans search "budget" --include-deleted
 
 Ranked search runs keyword and semantic retrieval together and fuses the two rankings with reciprocal rank fusion, so a meeting ranked well by either retriever surfaces, and one ranked well by both rises to the top. The top 50 fused candidates are then scored by a cross-encoder reranker (`jina-reranker-v1-turbo-en`) for how well each meeting actually answers the query, and the final order blends that judgment with the fusion ranking and a small boost for meetings whose title matches the query (damped when many meetings share the title, as recurring series do). Reranking takes roughly 2.2 seconds per query on CPU, most of it model inference; `--fast` skips the stage and returns fusion-order results (no relevance scores) in about 75 milliseconds.
 
-Grep matches every word in the query, in any order (`grans grep "budget review"` finds meetings that mention both words; quote a phrase inside the query, e.g. `grans grep '"budget review"'`, to require it verbatim). Results are ranked by relevance: meetings whose title contains the query come first, then content matches ranked by BM25, with newer meetings breaking ties. Use grep when completeness is the point, e.g. auditing every mention of a term, or when you need matches attributed to a speaker: `--speaker me|other` keeps only meetings where that speaker's transcript utterances match the query, and the cards show exactly those utterances. Notes and AI notes carry no speaker, so combining `--speaker` with an `--in` list that excludes transcripts is an error. Speaker filtering is grep-only because semantic retrieval has no per-utterance attribution, so search could not honor the filter without capping the answer.
+Grep matches every word in the query, in any order (`grans grep "budget review"` finds meetings that mention both words; quote a phrase inside the query, e.g. `grans grep '"budget review"'`, to require it verbatim). Results are ranked by relevance: meetings whose title contains the query come first, then content matches ranked by BM25, with newer meetings breaking ties. Use grep when completeness is the point, e.g. auditing every mention of a term, or when you need matches attributed to a speaker: `--speaker` keeps only meetings where that speaker's transcript utterances match the query, and the cards show exactly those utterances. Notes and AI notes carry no speaker, so combining `--speaker` with an `--in` list that excludes transcripts is an error. Speaker filtering is grep-only because semantic retrieval has no per-utterance attribution, so search could not honor the filter without capping the answer.
 
-Both verbs render the same cards. Each card shows why the meeting matched: the source of the best match (`AI notes` with its section heading, `your notes`, or `transcript` with time and speaker), a snippet with the query terms highlighted, and a `+N more matches` line when the meeting matched in more places. `--matches N` shows up to N snippets per meeting (default 1), and `--context N` renders N neighboring units around each shown match inside the card (the utterances around a transcript hit, the sections around an AI-notes hit, the paragraphs around a notes hit), with the matched unit shown whole. In search results, a meeting that matched semantically but contains none of the query's literal words shows its best-matching passage without highlights, and a meeting that matched only by its title says `title match`. The relevance score is not shown in the card view; `--json` carries it (`score`), along with which retrievers surfaced each meeting (`signals`), the full match list, and snippet highlight offsets. `--min-score` drops search results below a relevance threshold; it conflicts with `--fast`, since only the rerank stage produces that score. Both verbs support `--in`, `--meeting`, date filters, and `--limit` (which counts meetings everywhere).
+`--speaker` takes `me`, `other`, or a speaker's name. `me` and `other` split on the audio channel and work on every meeting: `me` is your microphone, `other` is everyone else. A name matches Granola's own per-utterance attribution, which it began providing on 2026-07-21 and only on the remote side of the call, so meetings recorded before then have no names to match. Names are matched case-insensitively as substrings, so `--speaker jane` finds Jane Doe; quoting the full name (`--speaker "Jane Doe"`) pins it exactly when several names share a fragment. A name that matches several speakers searches all of them and says which on stderr; one that matches nobody is an error listing the speakers you do have, so a typo never looks like a genuine absence of results. In `--json`, each match carries `speaker` (the channel, `me` or `other`) and, when attributed, `speaker_name`.
+
+Both verbs render the same cards. Each card shows why the meeting matched: the source of the best match (`AI notes` with its section heading, `your notes`, or `transcript` with time and speaker, named when Granola attributed the utterance and `You`/`Other` otherwise), a snippet with the query terms highlighted, and a `+N more matches` line when the meeting matched in more places. `--matches N` shows up to N snippets per meeting (default 1), and `--context N` renders N neighboring units around each shown match inside the card (the utterances around a transcript hit, the sections around an AI-notes hit, the paragraphs around a notes hit), with the matched unit shown whole. In search results, a meeting that matched semantically but contains none of the query's literal words shows its best-matching passage without highlights, and a meeting that matched only by its title says `title match`. The relevance score is not shown in the card view; `--json` carries it (`score`), along with which retrievers surfaced each meeting (`signals`), the full match list, and snippet highlight offsets. `--min-score` drops search results below a relevance threshold; it conflicts with `--fast`, since only the rerank stage produces that score. Both verbs support `--in`, `--meeting`, date filters, and `--limit` (which counts meetings everywhere).
 
 The JSON envelopes differ where the contracts do: grep JSON reports `total_meetings` (the complete count), while search JSON reports `keyword_total` (the uncapped count of meetings containing the query's words, backing the footer) and no total, because its meeting list is a pooled best-k.
 
@@ -368,16 +372,19 @@ grans show "Weekly Standup" --notes > notes.md
 grans show "Weekly Standup" --notes --transcript
 
 # Filter transcript by speaker
-grans show "Weekly Standup" --transcript --speaker me      # only your utterances
-grans show "Weekly Standup" --transcript --speaker other   # only others' utterances
+grans show "Weekly Standup" --transcript --speaker me           # only your utterances
+grans show "Weekly Standup" --transcript --speaker other        # everyone else
+grans show "Weekly Standup" --transcript --speaker "Jane Doe"   # only Jane's
 
 # AI-generated panels are shown automatically under "AI Notes"
 # when present for a meeting
 
-# JSON format (includes source field for speaker identification)
+# JSON format (includes source and detected_speaker_name per utterance)
 grans show "Weekly Standup" --transcript --json
 grans show "Weekly Standup" --notes --json
 ```
+
+Transcript lines are labelled with the speaker: `You` for your microphone, the speaker's name when Granola attributed the utterance, and `Other` when it did not. `--speaker` accepts the same values here as on `grep`, described above.
 
 ### Meetings with a Person
 

--- a/src/cli/args/mod.rs
+++ b/src/cli/args/mod.rs
@@ -1,10 +1,11 @@
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::models::SpeakerFilter;
 use crate::query::filter::SearchTarget;
+use crate::query::speaker::SpeakerSelector;
 
-fn parse_speaker_filter(s: &str) -> Result<SpeakerFilter, String> {
-    SpeakerFilter::parse(s).ok_or_else(|| format!("invalid speaker filter '{}': expected 'me' or 'other'", s))
+fn parse_speaker_selector(s: &str) -> Result<SpeakerSelector, String> {
+    SpeakerSelector::parse(s)
+        .ok_or_else(|| "empty speaker filter: expected 'me', 'other', or a speaker's name".to_string())
 }
 
 #[derive(Parser, Debug)]
@@ -151,9 +152,9 @@ pub enum Commands {
         #[arg(long)]
         date: Option<String>,
 
-        /// Filter matches by speaker: "me" (your utterances) or "other" (others' utterances); only meetings where that speaker's utterances match survive. Requires transcripts in --in
-        #[arg(long, value_parser = parse_speaker_filter)]
-        speaker: Option<SpeakerFilter>,
+        /// Filter matches by speaker: "me" (your utterances), "other" (everyone else), or a name to match Granola's detected speaker (partial names are fine); only meetings where that speaker's utterances match survive. Requires transcripts in --in
+        #[arg(long, value_parser = parse_speaker_selector)]
+        speaker: Option<SpeakerSelector>,
 
         /// Maximum number of meetings to show (0 = no limit)
         #[arg(long, default_value = "10")]
@@ -201,9 +202,9 @@ pub enum Commands {
         #[arg(long)]
         notes: bool,
 
-        /// Filter transcript by speaker: "me" (your utterances) or "other" (others' utterances)
-        #[arg(long, value_parser = parse_speaker_filter)]
-        speaker: Option<SpeakerFilter>,
+        /// Filter transcript by speaker: "me" (your utterances), "other" (everyone else), or a name to match Granola's detected speaker (partial names are fine)
+        #[arg(long, value_parser = parse_speaker_selector)]
+        speaker: Option<SpeakerSelector>,
     },
 
     /// Show meetings with a person

--- a/src/cli/args/tests.rs
+++ b/src/cli/args/tests.rs
@@ -105,7 +105,7 @@ fn grep_parses_with_lookup_flags() {
         panic!("expected grep subcommand");
     };
     assert_eq!(query, "kumquat");
-    assert_eq!(*speaker, Some(SpeakerFilter::Me));
+    assert_eq!(*speaker, Some(SpeakerSelector::Me));
     assert_eq!(r#in, &vec![SearchTarget::Titles, SearchTarget::Transcripts]);
     assert_eq!(meeting.as_deref(), Some("standup"));
     assert_eq!(*context, 2);

--- a/src/commands/grep.rs
+++ b/src/commands/grep.rs
@@ -9,7 +9,8 @@ use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
 use crate::commands::search_common::{print_shaped_cards, shape_and_page};
-use crate::models::{Document, SpeakerFilter};
+use crate::models::Document;
+use crate::query::speaker::SpeakerFilter;
 use crate::output::format::OutputMode;
 use crate::query::dates::DateRange;
 use crate::query::filter::{filter_by_meeting, SearchTarget};

--- a/src/commands/meetings.rs
+++ b/src/commands/meetings.rs
@@ -3,7 +3,7 @@ use chrono::Utc;
 use rusqlite::Connection;
 
 use crate::cli::context::RunContext;
-use crate::models::SpeakerFilter;
+use crate::query::speaker::SpeakerFilter;
 use crate::output::format::OutputMode;
 use crate::query::dates::build_date_range;
 
@@ -71,12 +71,11 @@ pub fn show(
 
                 // Transcript second (if requested)
                 if transcript_only {
-                    let transcript = filter_by_speaker(
-                        crate::db::meetings::get_transcript(conn, doc_id)?,
-                        speaker,
-                    );
+                    let all = crate::db::meetings::get_transcript(conn, doc_id)?;
+                    let had_utterances = !all.is_empty();
+                    let transcript = filter_by_speaker(all, speaker);
                     if transcript.is_empty() && !notes_only {
-                        bail!("No transcript available for this meeting");
+                        bail!("{}", empty_transcript_message(had_utterances));
                     }
                     if !transcript.is_empty() {
                         let text: String = transcript
@@ -181,9 +180,20 @@ fn filter_by_speaker(
     match speaker {
         Some(filter) => utterances
             .into_iter()
-            .filter(|u| filter.matches(u.source.as_deref()))
+            .filter(|u| filter.matches(u.source.as_deref(), u.detected_speaker_name.as_deref()))
             .collect(),
         None => utterances,
+    }
+}
+
+/// Why `--transcript` produced nothing. A meeting with utterances that the
+/// speaker filter emptied is a different situation from one that was never
+/// transcribed, and saying so saves the reader from re-checking the sync.
+fn empty_transcript_message(had_utterances: bool) -> &'static str {
+    if had_utterances {
+        "No utterances by that speaker in this meeting"
+    } else {
+        "No transcript available for this meeting"
     }
 }
 

--- a/src/commands/search_common.rs
+++ b/src/commands/search_common.rs
@@ -63,7 +63,7 @@ pub fn print_shaped_cards(shaped: &[crate::query::shape::ShapedMeeting], ctx: &R
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::SpeakerFilter;
+    use crate::query::speaker::SpeakerFilter;
 
     /// Documents in a fixed order with scores, as a ranked pipeline would
     /// hand them to shaping.

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -67,7 +67,7 @@ mod tests {
         let conn = migrations::open_and_migrate(&db_path).unwrap();
         let version = migrations::get_schema_version(&conn).unwrap();
 
-        // After applying all migrations, version should be 13
-        assert_eq!(version, 13);
+        // After applying all migrations, version should be 14
+        assert_eq!(version, 14);
     }
 }

--- a/src/db/meetings.rs
+++ b/src/db/meetings.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use super::common::{DocumentRow, row_to_document};
-use super::transcripts::{TranscriptUtteranceRow, row_to_utterance};
+
 use crate::models::{Document, TranscriptUtterance};
 use crate::query::dates::DateRange;
 use crate::query::fts::sanitize_fts_query;
@@ -204,23 +204,7 @@ pub fn resolve_document_id(
 }
 
 pub fn get_transcript(conn: &Connection, document_id: &str) -> Result<Vec<TranscriptUtterance>> {
-    let mut stmt = conn.prepare(
-        "SELECT id, document_id, start_timestamp, end_timestamp, text, source, is_final FROM transcript_utterances WHERE document_id = ?1 ORDER BY start_timestamp",
-    )?;
-
-    let rows = stmt.query_map([document_id], |row| {
-        Ok(TranscriptUtteranceRow {
-            id: row.get(0)?,
-            document_id: row.get(1)?,
-            start_timestamp: row.get(2)?,
-            end_timestamp: row.get(3)?,
-            text: row.get(4)?,
-            source: row.get(5)?,
-            is_final: row.get(6)?,
-        })
-    })?;
-
-    Ok(rows.filter_map(|r| r.ok()).map(row_to_utterance).collect())
+    super::transcripts::load_transcript(conn, document_id)
 }
 
 pub fn search_meetings(

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -28,6 +28,7 @@ fn migrations() -> Migrations<'static> {
         M::up(include_str!("v011_raw_json_templates_recipes_events.sql")),
         M::up(include_str!("v012_rename_is_primary_to_primary.sql")),
         M::up(include_str!("v013_api_snapshot.sql")),
+        M::up(include_str!("v014_utterance_speaker_name.sql")),
     ])
 }
 
@@ -51,7 +52,7 @@ pub fn open_and_migrate(db_path: &Path) -> Result<Connection> {
         rusqlite_migration::SchemaVersion::Inside(v) => {
             // Check if current version is less than the number of migrations
             let current = v.get();
-            let total = 13; // We have 13 migrations (v001-v013)
+            let total = 14; // We have 14 migrations (v001-v014)
             current < total
         }
         rusqlite_migration::SchemaVersion::Outside(_) => false,
@@ -163,8 +164,8 @@ mod tests {
         let conn = open_and_migrate(&db_path).unwrap();
         let version = get_schema_version(&conn).unwrap();
 
-        // Should be version 13 after all migrations
-        assert_eq!(version, 13);
+        // Should be version 14 after all migrations
+        assert_eq!(version, 14);
     }
 
     #[test]
@@ -676,6 +677,116 @@ mod tests {
             )
             .unwrap();
         assert!(snapshot.is_none());
+    }
+
+    #[test]
+    fn test_speaker_name_column_backfills_from_api_snapshot() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        let conn = open_and_migrate(&db_path).unwrap();
+
+        conn.execute(
+            "INSERT INTO documents (id, title) VALUES ('doc1', 'Test Doc')",
+            [],
+        )
+        .unwrap();
+
+        // A row inserted after the migration still writes the column directly.
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text, source, speaker_name)
+             VALUES ('utt1', 'doc1', 'Hello', 'system', 'Jane Doe')",
+            [],
+        )
+        .unwrap();
+
+        let name: Option<String> = conn
+            .query_row(
+                "SELECT speaker_name FROM transcript_utterances WHERE id = 'utt1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(name, Some("Jane Doe".to_string()));
+
+        // NULL is allowed: the microphone channel is never attributed.
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text, source)
+             VALUES ('utt2', 'doc1', 'Mine', 'microphone')",
+            [],
+        )
+        .unwrap();
+
+        let name: Option<String> = conn
+            .query_row(
+                "SELECT speaker_name FROM transcript_utterances WHERE id = 'utt2'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(name.is_none());
+
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_transcript_utterances_speaker_name'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx_count, 1);
+    }
+
+    #[test]
+    fn test_speaker_name_backfill_lifts_names_out_of_existing_snapshots() {
+        // Attribution arrived in the API on 2026-07-21 and has been riding
+        // into api_snapshot ever since. Rows already on disk when v014 runs
+        // must come out attributed without a re-sync.
+        let mut conn = Connection::open_in_memory().unwrap();
+        let m = migrations();
+
+        // Stop at v013: the snapshot column exists, speaker_name does not.
+        m.to_version(&mut conn, 13).unwrap();
+
+        conn.execute(
+            "INSERT INTO documents (id, title) VALUES ('doc1', 'Test Doc')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            r#"INSERT INTO transcript_utterances (id, document_id, text, source, api_snapshot)
+               VALUES ('attributed', 'doc1', 'Hello', 'system',
+                       '{"id":"attributed","text":"[stored]","detected_speaker_name":"Jane Doe"}')"#,
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            r#"INSERT INTO transcript_utterances (id, document_id, text, source, api_snapshot)
+               VALUES ('pre-cutover', 'doc1', 'Older', 'system',
+                       '{"id":"pre-cutover","text":"[stored]"}')"#,
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, text, source)
+             VALUES ('no-snapshot', 'doc1', 'Oldest', 'system')",
+            [],
+        )
+        .unwrap();
+
+        m.to_latest(&mut conn).unwrap();
+
+        let name_of = |id: &str| -> Option<String> {
+            conn.query_row(
+                "SELECT speaker_name FROM transcript_utterances WHERE id = ?1",
+                [id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        assert_eq!(name_of("attributed"), Some("Jane Doe".to_string()));
+        assert!(name_of("pre-cutover").is_none());
+        assert!(name_of("no-snapshot").is_none());
     }
 
     #[test]

--- a/src/db/migrations/v014_utterance_speaker_name.sql
+++ b/src/db/migrations/v014_utterance_speaker_name.sql
@@ -1,0 +1,23 @@
+-- Migration v014: Surface Granola's per-utterance speaker attribution.
+--
+-- Granola began returning a detected speaker per utterance on 2026-07-21.
+-- Those fields were never modeled, so they landed in the flattened `extra`
+-- map and rode into `api_snapshot` (added in v013) unchanged. The data is
+-- already on disk; this lifts the name into a column we can query.
+--
+-- A dedicated column rather than reading `api_snapshot` at query time:
+-- json_extract cannot use an index, and the filter and the DISTINCT lookup
+-- that resolves `--speaker <name>` both run over every utterance.
+--
+-- The column is nullable and mostly NULL. Only the system channel is ever
+-- attributed (the microphone channel is the local user), and only meetings
+-- recorded after the cutover carry attribution at all.
+
+ALTER TABLE transcript_utterances ADD COLUMN speaker_name TEXT;
+
+UPDATE transcript_utterances
+   SET speaker_name = json_extract(api_snapshot, '$.detected_speaker_name')
+ WHERE api_snapshot IS NOT NULL;
+
+CREATE INDEX idx_transcript_utterances_speaker_name
+    ON transcript_utterances(speaker_name);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -31,5 +31,6 @@ pub fn create_tables(conn: &Connection) -> Result<()> {
     conn.execute_batch(include_str!("migrations/v011_raw_json_templates_recipes_events.sql"))?;
     conn.execute_batch(include_str!("migrations/v012_rename_is_primary_to_primary.sql"))?;
     conn.execute_batch(include_str!("migrations/v013_api_snapshot.sql"))?;
+    conn.execute_batch(include_str!("migrations/v014_utterance_speaker_name.sql"))?;
     Ok(())
 }

--- a/src/db/test_fixtures.rs
+++ b/src/db/test_fixtures.rs
@@ -271,8 +271,8 @@ pub fn build_test_db(state: &Value) -> Connection {
             if let Some(arr) = utts.as_array() {
                 for utt in arr {
                     conn.execute(
-                        "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, source, is_final)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, source, is_final, speaker_name)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                         rusqlite::params![
                             utt.get("id").and_then(|v| v.as_str()),
                             utt.get("document_id").and_then(|v| v.as_str()),
@@ -281,6 +281,7 @@ pub fn build_test_db(state: &Value) -> Connection {
                             utt.get("text").and_then(|v| v.as_str()),
                             utt.get("source").and_then(|v| v.as_str()),
                             utt.get("is_final").and_then(|v| v.as_bool()),
+                            utt.get("speaker_name").and_then(|v| v.as_str()),
                         ],
                     ).unwrap();
                 }

--- a/src/db/transcripts.rs
+++ b/src/db/transcripts.rs
@@ -13,6 +13,26 @@ pub(crate) struct TranscriptUtteranceRow {
     pub text: Option<String>,
     pub source: Option<String>,
     pub is_final: Option<bool>,
+    pub speaker_name: Option<String>,
+}
+
+/// The columns every utterance read selects, in the order the row mapper
+/// expects. Kept in one place so the two read paths cannot drift apart.
+pub(crate) const UTTERANCE_COLUMNS: &str =
+    "id, document_id, start_timestamp, end_timestamp, text, source, is_final, speaker_name";
+
+/// Map a row selected with [`UTTERANCE_COLUMNS`].
+pub(crate) fn map_utterance_row(row: &rusqlite::Row) -> rusqlite::Result<TranscriptUtteranceRow> {
+    Ok(TranscriptUtteranceRow {
+        id: row.get(0)?,
+        document_id: row.get(1)?,
+        start_timestamp: row.get(2)?,
+        end_timestamp: row.get(3)?,
+        text: row.get(4)?,
+        source: row.get(5)?,
+        is_final: row.get(6)?,
+        speaker_name: row.get(7)?,
+    })
 }
 
 /// Convert a raw database row into a domain `TranscriptUtterance`.
@@ -28,6 +48,7 @@ pub(crate) fn row_to_utterance(row: TranscriptUtteranceRow) -> TranscriptUtteran
         text: row.text,
         source: row.source,
         is_final: row.is_final,
+        detected_speaker_name: row.speaker_name,
         extra: Default::default(),
     }
 }
@@ -38,23 +59,30 @@ pub(crate) fn row_to_utterance(row: TranscriptUtteranceRow) -> TranscriptUtteran
 /// migration v003. These fields are only populated for transcripts fetched after that
 /// migration was applied. See v003_utterance_metadata.sql for details.
 pub fn load_transcript(conn: &Connection, document_id: &str) -> Result<Vec<TranscriptUtterance>> {
-    let mut stmt = conn.prepare(
-        "SELECT id, document_id, start_timestamp, end_timestamp, text, source, is_final FROM transcript_utterances WHERE document_id = ?1 ORDER BY start_timestamp",
-    )?;
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {UTTERANCE_COLUMNS} FROM transcript_utterances WHERE document_id = ?1 ORDER BY start_timestamp"
+    ))?;
 
-    let rows = stmt.query_map([document_id], |row| {
-        Ok(TranscriptUtteranceRow {
-            id: row.get(0)?,
-            document_id: row.get(1)?,
-            start_timestamp: row.get(2)?,
-            end_timestamp: row.get(3)?,
-            text: row.get(4)?,
-            source: row.get(5)?,
-            is_final: row.get(6)?,
-        })
-    })?;
+    let rows = stmt.query_map([document_id], map_utterance_row)?;
 
     Ok(rows.filter_map(|r| r.ok()).map(row_to_utterance).collect())
+}
+
+/// Every distinct detected speaker name in the database, alphabetically.
+///
+/// Backs `--speaker <name>` resolution: the pattern is matched against this
+/// list so that a name matching nobody can be reported rather than silently
+/// returning no results.
+pub fn distinct_speaker_names(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT speaker_name FROM transcript_utterances
+         WHERE speaker_name IS NOT NULL AND speaker_name <> ''
+         ORDER BY speaker_name",
+    )?;
+    let names = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(names)
 }
 
 /// Document info for transcript sync
@@ -244,8 +272,8 @@ pub fn insert_transcript_from_api(
 
     // Insert new utterances with 'api' source
     let mut stmt = conn.prepare(
-        "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, transcript_source, source, is_final, api_snapshot)
-         VALUES (?1, ?2, ?3, ?4, ?5, 'api', ?6, ?7, ?8)",
+        "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, transcript_source, source, is_final, api_snapshot, speaker_name)
+         VALUES (?1, ?2, ?3, ?4, ?5, 'api', ?6, ?7, ?8, ?9)",
     )?;
 
     let mut inserted = 0;
@@ -266,6 +294,7 @@ pub fn insert_transcript_from_api(
             utt.source.as_deref(),
             utt.is_final,
             &api_snapshot,
+            utt.detected_speaker_name.as_deref(),
         ])?;
         inserted += 1;
     }
@@ -357,6 +386,7 @@ mod tests {
                 text: Some("Hello from API".to_string()),
                 source: None,
                 is_final: None,
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
             crate::models::TranscriptUtterance {
@@ -367,6 +397,7 @@ mod tests {
                 text: Some("Second utterance".to_string()),
                 source: None,
                 is_final: None,
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
         ];
@@ -412,6 +443,7 @@ mod tests {
                 text: Some("Replaced transcript".to_string()),
                 source: None,
                 is_final: None,
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
         ];
@@ -454,6 +486,7 @@ mod tests {
                 text: Some("quantum computing breakthroughs".to_string()),
                 source: None,
                 is_final: None,
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
         ];
@@ -484,6 +517,7 @@ mod tests {
                 text: Some("test".to_string()),
                 source: None,
                 is_final: None,
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
         ];
@@ -511,6 +545,7 @@ mod tests {
                 text: Some("Hello from me".to_string()),
                 source: Some("microphone".to_string()),
                 is_final: Some(true),
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
             crate::models::TranscriptUtterance {
@@ -521,6 +556,7 @@ mod tests {
                 text: Some("Response from others".to_string()),
                 source: Some("system".to_string()),
                 is_final: Some(false),
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
         ];
@@ -784,6 +820,7 @@ mod tests {
             text: Some("Hello everyone, welcome to the meeting.".to_string()),
             source: Some("microphone".to_string()),
             is_final: Some(true),
+            detected_speaker_name: None,
             extra: Default::default(),
         };
 
@@ -807,6 +844,7 @@ mod tests {
             text: None,
             source: None,
             is_final: None,
+            detected_speaker_name: None,
             extra: Default::default(),
         };
 
@@ -838,6 +876,7 @@ mod tests {
                 text: Some("Hello from snapshot test".to_string()),
                 source: Some("microphone".to_string()),
                 is_final: Some(true),
+                detected_speaker_name: None,
                 extra: Default::default(),
             },
         ];
@@ -881,6 +920,128 @@ mod tests {
         assert!(docs.is_empty());
     }
 
+    // --- speaker attribution ---
+
+    #[test]
+    fn test_load_transcript_includes_detected_speaker_name() {
+        let conn = build_test_db(&transcripts_state());
+
+        conn.execute(
+            "INSERT INTO documents (id, title, created_at) VALUES ('doc-attr', 'Attributed', '2026-07-22T10:00:00Z')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, start_timestamp, text, source, speaker_name, transcript_source)
+             VALUES ('attr-u1', 'doc-attr', '2026-07-22T10:00:00Z', 'Hers', 'system', 'Jane Doe', 'api')",
+            [],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO transcript_utterances (id, document_id, start_timestamp, text, source, transcript_source)
+             VALUES ('attr-u2', 'doc-attr', '2026-07-22T10:00:30Z', 'Mine', 'microphone', 'api')",
+            [],
+        ).unwrap();
+
+        let utterances = load_transcript(&conn, "doc-attr").unwrap();
+        assert_eq!(utterances[0].detected_speaker_name.as_deref(), Some("Jane Doe"));
+        // The microphone channel is the local user and is never attributed.
+        assert!(utterances[1].detected_speaker_name.is_none());
+    }
+
+    #[test]
+    fn test_insert_transcript_from_api_stores_detected_speaker_name() {
+        let conn = build_test_db(&transcripts_state());
+
+        conn.execute(
+            "INSERT INTO documents (id, title, created_at) VALUES ('doc-attr', 'Attributed', '2026-07-22T10:00:00Z')",
+            [],
+        ).unwrap();
+
+        let utterances = vec![crate::models::TranscriptUtterance {
+            id: Some("attr-u1".to_string()),
+            document_id: Some("doc-attr".to_string()),
+            text: Some("Hers".to_string()),
+            source: Some("system".to_string()),
+            detected_speaker_name: Some("Jane Doe".to_string()),
+            ..Default::default()
+        }];
+
+        insert_transcript_from_api(&conn, "doc-attr", &utterances).unwrap();
+
+        let name: Option<String> = conn.query_row(
+            "SELECT speaker_name FROM transcript_utterances WHERE id = 'attr-u1'",
+            [],
+            |r| r.get(0),
+        ).unwrap();
+        assert_eq!(name, Some("Jane Doe".to_string()));
+    }
+
+    #[test]
+    fn test_redact_utterance_snapshot_keeps_the_detected_speaker_name() {
+        // The name must stay in the snapshot at its API key, since that is
+        // what the v014 backfill reads and what a future re-derivation needs.
+        let utt = crate::models::TranscriptUtterance {
+            id: Some("u1".to_string()),
+            text: Some("Hers".to_string()),
+            source: Some("system".to_string()),
+            detected_speaker_name: Some("Jane Doe".to_string()),
+            ..Default::default()
+        };
+
+        let snapshot = redact_utterance_snapshot(&utt).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&snapshot).unwrap();
+        assert_eq!(parsed["detected_speaker_name"], "Jane Doe");
+    }
+
+    #[test]
+    fn test_transcript_utterance_deserializes_the_api_speaker_field() {
+        // Granola sends `detected_speaker_name` alongside a `detectedSpeaker`
+        // object; the modeled field must claim the former rather than letting
+        // it fall through into `extra`.
+        let utt: crate::models::TranscriptUtterance = serde_json::from_str(
+            r#"{"id":"u1","source":"system","text":"Hers",
+                "detected_speaker_name":"Jane Doe",
+                "detectedSpeaker":{"participantId":"Jane Doe","participantName":"Jane Doe"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(utt.detected_speaker_name.as_deref(), Some("Jane Doe"));
+        assert!(!utt.extra.contains_key("detected_speaker_name"));
+        // The object form is still unmodeled and rides along in `extra`.
+        assert!(utt.extra.contains_key("detectedSpeaker"));
+    }
+
+    #[test]
+    fn test_distinct_speaker_names_are_deduped_and_sorted() {
+        let conn = build_test_db(&transcripts_state());
+
+        conn.execute(
+            "INSERT INTO documents (id, title, created_at) VALUES ('doc-attr', 'Attributed', '2026-07-22T10:00:00Z')",
+            [],
+        ).unwrap();
+        for (id, name) in [
+            ("s1", Some("Marcus Webb")),
+            ("s2", Some("Jane Doe")),
+            ("s3", Some("Jane Doe")),
+            ("s4", None),
+            ("s5", Some("")),
+        ] {
+            conn.execute(
+                "INSERT INTO transcript_utterances (id, document_id, text, source, speaker_name)
+                 VALUES (?1, 'doc-attr', 'x', 'system', ?2)",
+                rusqlite::params![id, name],
+            ).unwrap();
+        }
+
+        let names = distinct_speaker_names(&conn).unwrap();
+        assert_eq!(names, vec!["Jane Doe".to_string(), "Marcus Webb".to_string()]);
+    }
+
+    #[test]
+    fn test_distinct_speaker_names_is_empty_without_attribution() {
+        let conn = build_test_db(&transcripts_state());
+        assert!(distinct_speaker_names(&conn).unwrap().is_empty());
+    }
+
     #[test]
     fn test_row_to_utterance_all_fields() {
         let row = TranscriptUtteranceRow {
@@ -889,16 +1050,18 @@ mod tests {
             start_timestamp: Some("2026-01-20T10:00:00Z".to_string()),
             end_timestamp: Some("2026-01-20T10:01:00Z".to_string()),
             text: Some("Hello world".to_string()),
-            source: Some("microphone".to_string()),
+            source: Some("system".to_string()),
             is_final: Some(true),
+            speaker_name: Some("Jane Doe".to_string()),
         };
         let utt = row_to_utterance(row);
+        assert_eq!(utt.detected_speaker_name.as_deref(), Some("Jane Doe"));
         assert_eq!(utt.id.as_deref(), Some("u1"));
         assert_eq!(utt.document_id.as_deref(), Some("doc-1"));
         assert_eq!(utt.start_timestamp.as_deref(), Some("2026-01-20T10:00:00Z"));
         assert_eq!(utt.end_timestamp.as_deref(), Some("2026-01-20T10:01:00Z"));
         assert_eq!(utt.text.as_deref(), Some("Hello world"));
-        assert_eq!(utt.source.as_deref(), Some("microphone"));
+        assert_eq!(utt.source.as_deref(), Some("system"));
         assert_eq!(utt.is_final, Some(true));
         assert!(utt.extra.is_empty());
     }
@@ -913,6 +1076,7 @@ mod tests {
             text: None,
             source: None,
             is_final: None,
+            speaker_name: None,
         };
         let utt = row_to_utterance(row);
         assert!(utt.id.is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ fn main() -> Result<()> {
                 meeting_filter: meeting.clone(),
                 limit: *limit,
                 matches: *matches,
-                speaker: speaker.clone(),
+                speaker: query::speaker::resolve_opt(&conn, speaker.as_ref())?,
                 context: *context,
             };
             let date_range = query::dates::build_date_range(
@@ -214,6 +214,7 @@ fn main() -> Result<()> {
             notes,
             speaker,
         } => {
+            let speaker = query::speaker::resolve_opt(&conn, speaker.as_ref())?;
             commands::meetings::show(&conn, meeting, *transcript, *notes, speaker.as_ref(), &ctx)?;
         }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -141,31 +141,6 @@ pub struct PersonName {
 // Transcript Types
 // ============================================================================
 
-/// Filter transcript utterances by speaker
-#[derive(Debug, Clone, PartialEq)]
-pub enum SpeakerFilter {
-    Me,
-    Other,
-}
-
-impl SpeakerFilter {
-    pub fn parse(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "me" => Some(SpeakerFilter::Me),
-            "other" => Some(SpeakerFilter::Other),
-            _ => None,
-        }
-    }
-
-    pub fn matches(&self, source: Option<&str>) -> bool {
-        match (self, source) {
-            (SpeakerFilter::Me, Some("microphone")) => true,
-            (SpeakerFilter::Other, Some("system")) => true,
-            _ => false,
-        }
-    }
-}
-
 /// A transcript utterance
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TranscriptUtterance {
@@ -183,6 +158,14 @@ pub struct TranscriptUtterance {
     pub source: Option<String>,
     #[serde(default)]
     pub is_final: Option<bool>,
+    /// The speaker Granola detected, on the system channel only and only for
+    /// meetings recorded after 2026-07-21. A display name, not an identifier.
+    ///
+    /// The field name matches the API's JSON key, so it round-trips through
+    /// `api_snapshot` in the same position it occupied when it was landing in
+    /// `extra`.
+    #[serde(default)]
+    pub detected_speaker_name: Option<String>,
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
@@ -508,42 +491,3 @@ pub struct RecipeConfig {
     pub extra: HashMap<String, Value>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn speaker_filter_parse_me() {
-        assert_eq!(SpeakerFilter::parse("me"), Some(SpeakerFilter::Me));
-        assert_eq!(SpeakerFilter::parse("ME"), Some(SpeakerFilter::Me));
-        assert_eq!(SpeakerFilter::parse("Me"), Some(SpeakerFilter::Me));
-    }
-
-    #[test]
-    fn speaker_filter_parse_other() {
-        assert_eq!(SpeakerFilter::parse("other"), Some(SpeakerFilter::Other));
-        assert_eq!(SpeakerFilter::parse("OTHER"), Some(SpeakerFilter::Other));
-    }
-
-    #[test]
-    fn speaker_filter_parse_invalid() {
-        assert_eq!(SpeakerFilter::parse("unknown"), None);
-        assert_eq!(SpeakerFilter::parse(""), None);
-    }
-
-    #[test]
-    fn speaker_filter_matches_me() {
-        let filter = SpeakerFilter::Me;
-        assert!(filter.matches(Some("microphone")));
-        assert!(!filter.matches(Some("system")));
-        assert!(!filter.matches(None));
-    }
-
-    #[test]
-    fn speaker_filter_matches_other() {
-        let filter = SpeakerFilter::Other;
-        assert!(filter.matches(Some("system")));
-        assert!(!filter.matches(Some("microphone")));
-        assert!(!filter.matches(None));
-    }
-}

--- a/src/output/card.rs
+++ b/src/output/card.rs
@@ -9,6 +9,7 @@ use chrono::FixedOffset;
 use colored::Colorize;
 
 use crate::query::shape::{ContextUnit, EvidenceSource, Excerpt, MatchEvidence, ShapedMeeting};
+use crate::query::speaker::{label as speaker_label, SpeakerLabel};
 
 /// Card body indent, sized to clear the rank gutter.
 const INDENT: &str = "    ";
@@ -77,10 +78,12 @@ fn source_line(evidence: &MatchEvidence, tz: &FixedOffset) -> String {
     if let Some(ts) = evidence.timestamp.as_deref() {
         details.push(super::table::format_time_only(ts, tz).dimmed().to_string());
     }
-    match evidence.speaker.as_deref() {
-        Some("microphone") => details.push("You".cyan().to_string()),
-        Some("system") => details.push("Other".dimmed().to_string()),
-        _ => {}
+    if let Some(label) = speaker_label(evidence.speaker.as_deref(), evidence.speaker_name.as_deref())
+    {
+        details.push(match label {
+            SpeakerLabel::You => label.as_str().cyan().to_string(),
+            _ => label.as_str().dimmed().to_string(),
+        });
     }
     if let Some(section) = evidence.section.as_deref() {
         details.push(section.dimmed().to_string());
@@ -120,10 +123,9 @@ fn context_block(unit: &ContextUnit, tz: &FixedOffset) -> String {
         head.push_str(&super::table::format_time_only(ts, tz));
         head.push(' ');
     }
-    match unit.speaker.as_deref() {
-        Some("microphone") => head.push_str("You  "),
-        Some("system") => head.push_str("Other  "),
-        _ => {}
+    if let Some(label) = speaker_label(unit.speaker.as_deref(), unit.speaker_name.as_deref()) {
+        head.push_str(label.as_str());
+        head.push_str("  ");
     }
     if let Some(section) = unit.section.as_deref() {
         head.push_str(section);
@@ -237,6 +239,7 @@ mod tests {
                     highlights: vec![(8, 16), (38, 47)],
                 },
                 speaker: None,
+                speaker_name: None,
                 timestamp: None,
                 section: Some("Migration Plan".to_string()),
                 context_before: Vec::new(),
@@ -292,6 +295,7 @@ mod tests {
             source: EvidenceSource::Transcript,
             excerpt: Excerpt { text: "say the migration runs".to_string(), highlights: vec![] },
             speaker: Some("microphone".to_string()),
+            speaker_name: None,
             timestamp: Some("2026-05-12T14:31:07Z".to_string()),
             section: None,
             context_before: Vec::new(),
@@ -299,6 +303,68 @@ mod tests {
         }];
         let out = strip(&format_shaped_meeting(&m, 1, &utc()));
         assert!(out.contains("    transcript › 14:31:07 You"), "got:\n{out}");
+    }
+
+    #[test]
+    fn transcript_evidence_names_the_detected_speaker() {
+        let mut m = base_meeting();
+        m.matches = vec![MatchEvidence {
+            source: EvidenceSource::Transcript,
+            excerpt: Excerpt { text: "the migration runs tonight".to_string(), highlights: vec![] },
+            speaker: Some("system".to_string()),
+            speaker_name: Some("Jane Doe".to_string()),
+            timestamp: Some("2026-07-22T14:31:07Z".to_string()),
+            section: None,
+            context_before: Vec::new(),
+            context_after: Vec::new(),
+        }];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains("    transcript › 14:31:07 Jane Doe"), "got:\n{out}");
+        assert!(!out.contains("Other"), "name should replace the channel label:\n{out}");
+    }
+
+    #[test]
+    fn unattributed_transcript_evidence_still_says_other() {
+        // Most of the corpus predates attribution and must keep rendering.
+        let mut m = base_meeting();
+        m.matches = vec![MatchEvidence {
+            source: EvidenceSource::Transcript,
+            excerpt: Excerpt { text: "the migration runs tonight".to_string(), highlights: vec![] },
+            speaker: Some("system".to_string()),
+            speaker_name: None,
+            timestamp: Some("2026-05-12T14:31:07Z".to_string()),
+            section: None,
+            context_before: Vec::new(),
+            context_after: Vec::new(),
+        }];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(out.contains("    transcript › 14:31:07 Other"), "got:\n{out}");
+    }
+
+    #[test]
+    fn context_units_name_their_detected_speaker() {
+        let mut m = base_meeting();
+        m.matches = vec![MatchEvidence {
+            source: EvidenceSource::Transcript,
+            excerpt: Excerpt { text: "run it tonight".to_string(), highlights: vec![] },
+            speaker: Some("microphone".to_string()),
+            speaker_name: None,
+            timestamp: Some("2026-07-22T14:31:07Z".to_string()),
+            section: None,
+            context_before: vec![ContextUnit {
+                text: "are we ready for it".to_string(),
+                speaker: Some("system".to_string()),
+                speaker_name: Some("Jane Doe".to_string()),
+                timestamp: Some("2026-07-22T14:30:50Z".to_string()),
+                section: None,
+            }],
+            context_after: Vec::new(),
+        }];
+        let out = strip(&format_shaped_meeting(&m, 1, &utc()));
+        assert!(
+            out.contains("      14:30:50 Jane Doe  are we ready for it"),
+            "got:\n{out}"
+        );
     }
 
     #[test]
@@ -369,17 +435,20 @@ mod tests {
                 highlights: vec![(8, 17)],
             },
             speaker: Some("microphone".to_string()),
+            speaker_name: None,
             timestamp: Some("2026-05-12T14:31:07Z".to_string()),
             section: None,
             context_before: vec![ContextUnit {
                 text: "are we ready for it".to_string(),
                 speaker: Some("system".to_string()),
+                speaker_name: None,
                 timestamp: Some("2026-05-12T14:30:50Z".to_string()),
                 section: None,
             }],
             context_after: vec![ContextUnit {
                 text: "ok, scheduling it now".to_string(),
                 speaker: Some("system".to_string()),
+                speaker_name: None,
                 timestamp: Some("2026-05-12T14:31:20Z".to_string()),
                 section: None,
             }],
@@ -398,6 +467,7 @@ mod tests {
         m.matches[0].context_after = vec![ContextUnit {
             text: "follow up next week".to_string(),
             speaker: None,
+            speaker_name: None,
             timestamp: None,
             section: Some("Action Items".to_string()),
         }];

--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -24,8 +24,13 @@ pub fn format_meeting_detail(doc: &Document) -> String {
 pub struct ShapedMatchJson {
     /// `transcript`, `panel`, or `notes`.
     pub source: &'static str,
+    /// The audio channel: `me` or `other`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub speaker: Option<String>,
+    /// Granola's detected speaker name, present only on attributed
+    /// utterances. Separate from `speaker`, which keeps naming the channel.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,6 +52,8 @@ pub struct ContextUnitJson {
     pub text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub speaker: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,6 +123,7 @@ impl ContextUnitJson {
         ContextUnitJson {
             text: unit.text.clone(),
             speaker: shaped_speaker_label(unit.speaker.as_deref()),
+            speaker_name: unit.speaker_name.clone(),
             timestamp: unit.timestamp.clone(),
             section: unit.section.clone(),
         }
@@ -147,6 +155,7 @@ impl ShapedMeetingJson {
                 .map(|ev| ShapedMatchJson {
                     source: shaped_source_label(ev.source),
                     speaker: shaped_speaker_label(ev.speaker.as_deref()),
+                    speaker_name: ev.speaker_name.clone(),
                     timestamp: ev.timestamp.clone(),
                     section: ev.section.clone(),
                     snippet: ev.excerpt.text.clone(),
@@ -244,6 +253,7 @@ mod tests {
                     highlights: vec![(8, 17)],
                 },
                 speaker: Some("microphone".to_string()),
+                speaker_name: None,
                 timestamp: Some("2026-05-12T14:31:07Z".to_string()),
                 section: None,
                 context_before: Vec::new(),
@@ -270,6 +280,21 @@ mod tests {
         assert_eq!(mt["snippet"], "run the migration tonight");
         assert_eq!(mt["highlights"], serde_json::json!([[8, 17]]));
         assert!(mt.get("section").is_none());
+        // Unattributed evidence omits the field rather than emitting null.
+        assert!(mt.get("speaker_name").is_none());
+    }
+
+    #[test]
+    fn shaped_json_reports_the_speaker_name_beside_the_channel() {
+        let mut m = shaped();
+        m.matches[0].speaker = Some("system".to_string());
+        m.matches[0].speaker_name = Some("Jane Doe".to_string());
+        let out = format_grep_meetings(&[m], "migration", 1, 10);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let mt = &v["meetings"][0]["matches"][0];
+        // `speaker` keeps naming the channel so the existing contract holds.
+        assert_eq!(mt["speaker"], "other");
+        assert_eq!(mt["speaker_name"], "Jane Doe");
     }
 
     #[test]

--- a/src/output/table.rs
+++ b/src/output/table.rs
@@ -4,6 +4,7 @@ use colored::Colorize;
 use crate::models::{
     Calendar, CalendarEvent, Document, PanelTemplate, Person, Recipe, TranscriptUtterance,
 };
+use crate::query::speaker::{label as speaker_label, SpeakerLabel};
 
 /// Format a meeting list entry for TTY display.
 pub fn format_meeting_row(doc: &Document, tz: &FixedOffset) -> String {
@@ -92,11 +93,12 @@ pub fn format_utterance(utt: &TranscriptUtterance, highlight: bool, tz: &FixedOf
         .unwrap_or_default();
     let text = utt.text.as_deref().unwrap_or("");
 
-    let speaker_prefix = match utt.source.as_deref() {
-        Some("microphone") => format!("{} ", "You:".cyan()),
-        Some("system") => format!("{} ", "Other:".dimmed()),
-        _ => String::new(),
-    };
+    let speaker_prefix =
+        match speaker_label(utt.source.as_deref(), utt.detected_speaker_name.as_deref()) {
+            Some(SpeakerLabel::You) => format!("{} ", "You:".cyan()),
+            Some(label) => format!("{} ", format!("{}:", label.as_str()).dimmed()),
+            None => String::new(),
+        };
 
     if highlight {
         format!("  {} {} {}{}", "▶".green(), timestamp.dimmed(), speaker_prefix, text.bold())
@@ -294,6 +296,19 @@ mod tests {
         };
         let output = strip(&format_utterance(&utt, false, &utc()));
         assert!(output.contains("Other:"), "Expected 'Other:' label, got: {}", output);
+    }
+
+    #[test]
+    fn format_utterance_prefers_the_detected_speaker_name() {
+        let utt = TranscriptUtterance {
+            source: Some("system".to_string()),
+            text: Some("Hello from Jane".to_string()),
+            detected_speaker_name: Some("Jane Doe".to_string()),
+            ..Default::default()
+        };
+        let output = strip(&format_utterance(&utt, false, &utc()));
+        assert!(output.contains("Jane Doe:"), "Expected the name, got: {}", output);
+        assert!(!output.contains("Other:"), "Name should replace 'Other:', got: {}", output);
     }
 
     #[test]

--- a/src/query/evidence.rs
+++ b/src/query/evidence.rs
@@ -11,7 +11,8 @@
 use anyhow::Result;
 use rusqlite::Connection;
 
-use crate::models::{Document, SpeakerFilter};
+use crate::models::Document;
+use crate::query::speaker::SpeakerFilter;
 use crate::query::fts::{matches_all_tokens, FtsToken};
 use crate::query::hybrid::BestChunk;
 use crate::query::shape::{
@@ -60,6 +61,7 @@ struct Site {
     source: EvidenceSource,
     text: String,
     speaker: Option<String>,
+    speaker_name: Option<String>,
     timestamp: Option<String>,
     section: Option<String>,
     context_before: Vec<ContextUnit>,
@@ -111,6 +113,7 @@ pub fn collect_document_evidence(
                 source: site.source,
                 excerpt: excerpt_around_match(&site.text, tokens, width),
                 speaker: site.speaker,
+                speaker_name: site.speaker_name,
                 timestamp: site.timestamp,
                 section: site.section,
                 context_before: site.context_before,
@@ -198,6 +201,7 @@ fn chunk_evidence(
         source,
         excerpt: excerpt_around_match(&chunk.text, tokens, opts.max_chars),
         speaker: None,
+        speaker_name: None,
         timestamp: None,
         section: chunk.section_heading.clone(),
         // A chunk has no site location, so it cannot expand with context.
@@ -244,6 +248,7 @@ fn collect_panel_sites(
                     neighbors_of(&sections, i, context_size, |(h, b)| ContextUnit {
                         text: crate::query::shape::normalize_whitespace(b),
                         speaker: None,
+                        speaker_name: None,
                         timestamp: None,
                         section: h.map(String::from),
                     });
@@ -251,6 +256,7 @@ fn collect_panel_sites(
                     source: EvidenceSource::Panel,
                     text: body.to_string(),
                     speaker: None,
+                    speaker_name: None,
                     timestamp: None,
                     section: heading.map(String::from),
                     context_before,
@@ -279,6 +285,7 @@ fn collect_notes_sites(
                 neighbors_of(&paras, i, context_size, |p| ContextUnit {
                     text: crate::query::shape::normalize_whitespace(p),
                     speaker: None,
+                    speaker_name: None,
                     timestamp: None,
                     section: None,
                 });
@@ -286,6 +293,7 @@ fn collect_notes_sites(
                 source: EvidenceSource::Notes,
                 text: para.to_string(),
                 speaker: None,
+                speaker_name: None,
                 timestamp: None,
                 section: None,
                 context_before,
@@ -314,7 +322,7 @@ fn collect_transcript_sites(
 
     for (i, utt) in utterances.iter().enumerate() {
         if let Some(filter) = &opts.speaker {
-            if !filter.matches(utt.source.as_deref()) {
+            if !filter.matches(utt.source.as_deref(), utt.detected_speaker_name.as_deref()) {
                 continue;
             }
         }
@@ -324,6 +332,7 @@ fn collect_transcript_sites(
                 neighbors_of(&utterances, i, opts.context, |u| ContextUnit {
                     text: crate::query::shape::normalize_whitespace(u.text.as_deref().unwrap_or_default()),
                     speaker: u.source.clone(),
+                    speaker_name: u.detected_speaker_name.clone(),
                     timestamp: u.start_timestamp.clone(),
                     section: None,
                 });
@@ -331,6 +340,7 @@ fn collect_transcript_sites(
                 source: EvidenceSource::Transcript,
                 text: text.to_string(),
                 speaker: utt.source.clone(),
+                speaker_name: utt.detected_speaker_name.clone(),
                 timestamp: utt.start_timestamp.clone(),
                 section: None,
                 context_before,
@@ -713,7 +723,7 @@ mod tests {
         let opts = EvidenceOptions {
             max_matches: 10,
             context: 1,
-            speaker: Some(crate::models::SpeakerFilter::Me),
+            speaker: Some(crate::query::speaker::SpeakerFilter::Me),
             ..Default::default()
         };
         let ev =
@@ -734,7 +744,7 @@ mod tests {
         // "kumquat" sites: 1 panel, 2 notes, u1 (microphone), u3 (system).
         // With a speaker filter only transcript sites by that speaker count.
         let opts = EvidenceOptions {
-            speaker: Some(crate::models::SpeakerFilter::Me),
+            speaker: Some(crate::query::speaker::SpeakerFilter::Me),
             ..Default::default()
         };
         let ev =
@@ -745,11 +755,83 @@ mod tests {
     }
 
     #[test]
+    fn named_speaker_filter_keeps_only_that_speakers_utterances() {
+        let conn = build_test_db(&attributed_state());
+        let doc = load_doc(&conn, "doc-1");
+        let opts = EvidenceOptions {
+            max_matches: 10,
+            speaker: Some(SpeakerFilter::Names(vec!["Jane Doe".to_string()])),
+            ..Default::default()
+        };
+        let ev =
+            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        assert_eq!(ev.total, 1);
+        assert_eq!(ev.matches[0].speaker_name.as_deref(), Some("Jane Doe"));
+        assert!(ev.matches[0].excerpt.text.contains("rollout"));
+    }
+
+    #[test]
+    fn named_speaker_filter_excludes_unattributed_utterances() {
+        // u4 mentions kumquat on the system channel with no detected name;
+        // a name filter must not sweep it in.
+        let conn = build_test_db(&attributed_state());
+        let doc = load_doc(&conn, "doc-1");
+        let opts = EvidenceOptions {
+            max_matches: 10,
+            speaker: Some(SpeakerFilter::Names(vec!["Marcus Webb".to_string()])),
+            ..Default::default()
+        };
+        let ev =
+            collect_document_evidence(&conn, &doc, &parse_query("kumquat"), &opts).unwrap();
+        assert_eq!(ev.total, 1);
+        assert_eq!(ev.matches[0].speaker_name.as_deref(), Some("Marcus Webb"));
+    }
+
+    #[test]
+    fn transcript_evidence_carries_the_detected_speaker_name() {
+        let conn = build_test_db(&attributed_state());
+        let doc = load_doc(&conn, "doc-1");
+        let ev = collect(&conn, &doc, "kumquat", 10);
+        let named: Vec<Option<&str>> = ev
+            .matches
+            .iter()
+            .filter(|m| m.source == EvidenceSource::Transcript)
+            .map(|m| m.speaker_name.as_deref())
+            .collect();
+        assert_eq!(named, vec![Some("Jane Doe"), Some("Marcus Webb"), None]);
+    }
+
+    /// One meeting on the far side of the attribution cutover: two named
+    /// system speakers and one system utterance Granola left unattributed.
+    fn attributed_state() -> serde_json::Value {
+        json!({
+            "documents": {
+                "doc-1": { "id": "doc-1", "title": "Infra Sync", "created_at": "2026-07-22T10:00:00Z" }
+            },
+            "transcripts": {
+                "doc-1": [
+                    {"id": "u1", "document_id": "doc-1", "text": "Ship the kumquat rollout.",
+                     "start_timestamp": "2026-07-22T10:01:00Z", "source": "system",
+                     "speaker_name": "Jane Doe"},
+                    {"id": "u2", "document_id": "doc-1", "text": "Nothing relevant here.",
+                     "start_timestamp": "2026-07-22T10:02:00Z", "source": "system",
+                     "speaker_name": "Marcus Webb"},
+                    {"id": "u3", "document_id": "doc-1", "text": "The kumquat timeline works.",
+                     "start_timestamp": "2026-07-22T10:03:00Z", "source": "system",
+                     "speaker_name": "Marcus Webb"},
+                    {"id": "u4", "document_id": "doc-1", "text": "Kumquat, agreed.",
+                     "start_timestamp": "2026-07-22T10:04:00Z", "source": "system"}
+                ]
+            }
+        })
+    }
+
+    #[test]
     fn speaker_filter_excludes_unattributable_sources() {
         let conn = build_test_db(&evidence_state());
         let doc = load_doc(&conn, "doc-1");
         let opts = EvidenceOptions {
-            speaker: Some(crate::models::SpeakerFilter::Other),
+            speaker: Some(crate::query::speaker::SpeakerFilter::Other),
             ..Default::default()
         };
         let ev =
@@ -771,7 +853,7 @@ mod tests {
         let chunk = best_chunk("some semantic chunk", "transcript_window", None);
         let facts = RankingFacts { keyword: true, best_chunk: Some(&chunk), score: None };
         let opts = EvidenceOptions {
-            speaker: Some(crate::models::SpeakerFilter::Other),
+            speaker: Some(crate::query::speaker::SpeakerFilter::Other),
             ..Default::default()
         };
 

--- a/src/query/evidence.rs
+++ b/src/query/evidence.rs
@@ -12,13 +12,13 @@ use anyhow::Result;
 use rusqlite::Connection;
 
 use crate::models::Document;
-use crate::query::speaker::SpeakerFilter;
 use crate::query::fts::{matches_all_tokens, FtsToken};
 use crate::query::hybrid::BestChunk;
 use crate::query::shape::{
     excerpt_around_match, title_matches, ContextUnit, EvidenceSource, MatchEvidence,
     ShapedMeeting, Signals,
 };
+use crate::query::speaker::SpeakerFilter;
 use crate::query::text::{split_into_paragraphs, split_markdown_sections, strip_panel_footer};
 
 /// How evidence is selected and excerpted per document.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -7,4 +7,5 @@ pub mod fusion;
 pub mod hybrid;
 pub mod rerank;
 pub mod shape;
+pub mod speaker;
 pub mod text;

--- a/src/query/shape.rs
+++ b/src/query/shape.rs
@@ -34,6 +34,9 @@ pub struct MatchEvidence {
     pub excerpt: Excerpt,
     /// Raw utterance source for transcripts (`"microphone"`/`"system"`).
     pub speaker: Option<String>,
+    /// Granola's detected speaker name, when the utterance carries one.
+    /// Independent of `speaker`, which stays the audio channel.
+    pub speaker_name: Option<String>,
     /// ISO start timestamp for transcript evidence.
     pub timestamp: Option<String>,
     /// Section heading for panel evidence.
@@ -52,6 +55,8 @@ pub struct ContextUnit {
     pub text: String,
     /// Raw utterance source for transcript neighbors.
     pub speaker: Option<String>,
+    /// Granola's detected speaker name for transcript neighbors, if any.
+    pub speaker_name: Option<String>,
     /// ISO start timestamp for transcript neighbors.
     pub timestamp: Option<String>,
     /// Section heading for panel neighbors.

--- a/src/query/speaker.rs
+++ b/src/query/speaker.rs
@@ -1,0 +1,437 @@
+//! Filtering transcript utterances by who spoke.
+//!
+//! Granola gives two attribution signals, and they are not the same kind of
+//! thing. The audio channel (`microphone`/`system`) is on every utterance and
+//! only ever says "you" or "not you". A detected speaker name is on the system
+//! channel, only for meetings recorded after 2026-07-21, and is a display name
+//! with no stable identifier behind it.
+//!
+//! That second signal is why `--speaker` takes two passes. What the user types
+//! is a [`SpeakerSelector`]; resolving it against the names actually present
+//! produces a [`SpeakerFilter`] over concrete names. Resolving up front is what
+//! lets a typo be an error instead of an empty result set that reads as
+//! "nobody said that".
+
+use anyhow::{bail, Result};
+use rusqlite::Connection;
+
+/// How many known speakers an error message lists before it truncates.
+const MAX_LISTED_SPEAKERS: usize = 10;
+
+/// What the user asked for on `--speaker`, before it is resolved against the
+/// names present in the database.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpeakerSelector {
+    /// The local user: the microphone channel.
+    Me,
+    /// Everyone else: the system channel, named or not.
+    Other,
+    /// A case-insensitive name pattern.
+    Name(String),
+}
+
+impl SpeakerSelector {
+    /// Parse the `--speaker` value. `me` and `other` are reserved words;
+    /// anything else is a name pattern. Only an empty pattern is rejected,
+    /// since any other string could be somebody's name.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_lowercase().as_str() {
+            "" => None,
+            "me" => Some(SpeakerSelector::Me),
+            "other" => Some(SpeakerSelector::Other),
+            _ => Some(SpeakerSelector::Name(s.trim().to_string())),
+        }
+    }
+}
+
+/// A resolved speaker filter: what an utterance is actually tested against.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpeakerFilter {
+    Me,
+    Other,
+    /// The concrete attributed names the pattern resolved to.
+    Names(Vec<String>),
+}
+
+impl SpeakerFilter {
+    /// Whether an utterance belongs to the filtered speaker.
+    ///
+    /// `Me` and `Other` test the audio channel alone, so they keep working on
+    /// the ~500k utterances that predate attribution. `Names` tests the
+    /// detected name, which never matches the microphone channel.
+    pub fn matches(&self, source: Option<&str>, speaker_name: Option<&str>) -> bool {
+        match self {
+            SpeakerFilter::Me => source == Some("microphone"),
+            SpeakerFilter::Other => source == Some("system"),
+            SpeakerFilter::Names(names) => speaker_name
+                .is_some_and(|name| names.iter().any(|n| n.eq_ignore_ascii_case(name))),
+        }
+    }
+}
+
+/// The names a pattern selects out of those present.
+///
+/// An exact case-insensitive hit wins outright, so `--speaker "Jane Doe"`
+/// selects only her even when "Jane Doe Jr" is also in the corpus. Otherwise
+/// every name containing the pattern is selected, because a first name is what
+/// people actually type.
+pub fn resolve_names(pattern: &str, available: &[String]) -> Vec<String> {
+    let needle = pattern.trim().to_lowercase();
+
+    let exact: Vec<String> = available
+        .iter()
+        .filter(|n| n.to_lowercase() == needle)
+        .cloned()
+        .collect();
+    if !exact.is_empty() {
+        return exact;
+    }
+
+    available
+        .iter()
+        .filter(|n| n.to_lowercase().contains(&needle))
+        .cloned()
+        .collect()
+}
+
+/// How to name a speaker in output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpeakerLabel<'a> {
+    /// The local user.
+    You,
+    /// Granola's detected name for the speaker.
+    Named(&'a str),
+    /// An unattributed remote speaker: everything before the cutover, and the
+    /// 9% of system-channel utterances Granola declines to attribute.
+    Other,
+}
+
+impl SpeakerLabel<'_> {
+    pub fn as_str(&self) -> &str {
+        match self {
+            SpeakerLabel::You => "You",
+            SpeakerLabel::Named(name) => name,
+            SpeakerLabel::Other => "Other",
+        }
+    }
+}
+
+/// How to name the speaker of an utterance, or `None` when the audio channel
+/// is unknown and there is nothing truthful to say.
+///
+/// A detected name always wins over the channel label. The microphone channel
+/// is the local user, so `You` holds even in the impossible case of a name on
+/// it.
+pub fn label<'a>(source: Option<&str>, speaker_name: Option<&'a str>) -> Option<SpeakerLabel<'a>> {
+    match source {
+        Some("microphone") => Some(SpeakerLabel::You),
+        Some("system") => Some(match speaker_name.filter(|n| !n.trim().is_empty()) {
+            Some(name) => SpeakerLabel::Named(name),
+            None => SpeakerLabel::Other,
+        }),
+        _ => None,
+    }
+}
+
+/// Resolve a selector against the database, reporting what the pattern hit.
+///
+/// `Me` and `Other` need no lookup. A name pattern that matches nothing is an
+/// error rather than an empty result; one that matches several speakers takes
+/// all of them and says so on stderr, since the union is usually what was
+/// wanted and the note names the string needed to narrow.
+pub fn resolve(conn: &Connection, selector: &SpeakerSelector) -> Result<SpeakerFilter> {
+    let pattern = match selector {
+        SpeakerSelector::Me => return Ok(SpeakerFilter::Me),
+        SpeakerSelector::Other => return Ok(SpeakerFilter::Other),
+        SpeakerSelector::Name(p) => p,
+    };
+
+    let available = crate::db::transcripts::distinct_speaker_names(conn)?;
+    let matched = resolve_names(pattern, &available);
+
+    match matched.len() {
+        0 => bail!("{}", no_match_message(pattern, &available)),
+        1 => Ok(SpeakerFilter::Names(matched)),
+        n => {
+            eprintln!(
+                "[grans] --speaker \"{}\" matched {} speakers: {}",
+                pattern,
+                n,
+                matched.join(", ")
+            );
+            Ok(SpeakerFilter::Names(matched))
+        }
+    }
+}
+
+/// [`resolve`] over an optional selector, for the `--speaker` flag.
+pub fn resolve_opt(
+    conn: &Connection,
+    selector: Option<&SpeakerSelector>,
+) -> Result<Option<SpeakerFilter>> {
+    selector.map(|s| resolve(conn, s)).transpose()
+}
+
+/// The error for a pattern that matches nobody. A corpus with no attribution
+/// at all is a different problem from a misspelled name, so it says so.
+fn no_match_message(pattern: &str, available: &[String]) -> String {
+    if available.is_empty() {
+        return format!(
+            "no utterances have speaker attribution, so --speaker \"{pattern}\" cannot match; \
+             Granola began attributing speakers on 2026-07-21, and only on meetings \
+             recorded after that (run `grans sync` to pull recent ones)"
+        );
+    }
+
+    let shown: Vec<&str> = available
+        .iter()
+        .take(MAX_LISTED_SPEAKERS)
+        .map(String::as_str)
+        .collect();
+    let more = available.len().saturating_sub(shown.len());
+    let suffix = if more > 0 {
+        format!(" (+{more} more)")
+    } else {
+        String::new()
+    };
+    format!(
+        "no speaker matches \"{}\"; known speakers: {}{}",
+        pattern,
+        shown.join(", "),
+        suffix
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    // --- SpeakerSelector::parse ---
+
+    #[test]
+    fn parse_reserves_me_and_other_case_insensitively() {
+        assert_eq!(SpeakerSelector::parse("me"), Some(SpeakerSelector::Me));
+        assert_eq!(SpeakerSelector::parse("ME"), Some(SpeakerSelector::Me));
+        assert_eq!(SpeakerSelector::parse("other"), Some(SpeakerSelector::Other));
+        assert_eq!(SpeakerSelector::parse("OTHER"), Some(SpeakerSelector::Other));
+    }
+
+    #[test]
+    fn parse_treats_anything_else_as_a_name_pattern() {
+        assert_eq!(
+            SpeakerSelector::parse("Jane Doe"),
+            Some(SpeakerSelector::Name("Jane Doe".to_string()))
+        );
+        // Case is preserved for display; matching lowercases later.
+        assert_eq!(
+            SpeakerSelector::parse("  jane  "),
+            Some(SpeakerSelector::Name("jane".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_rejects_an_empty_pattern() {
+        assert_eq!(SpeakerSelector::parse(""), None);
+        assert_eq!(SpeakerSelector::parse("   "), None);
+    }
+
+    // --- resolve_names ---
+
+    #[test]
+    fn resolve_names_matches_a_substring_case_insensitively() {
+        let available = names(&["Jane Doe", "Marcus Webb"]);
+        assert_eq!(resolve_names("jane", &available), names(&["Jane Doe"]));
+        assert_eq!(resolve_names("WEBB", &available), names(&["Marcus Webb"]));
+    }
+
+    #[test]
+    fn resolve_names_returns_every_substring_hit() {
+        let available = names(&["Jane Doe", "Jane Smith", "Marcus Webb"]);
+        assert_eq!(
+            resolve_names("jane", &available),
+            names(&["Jane Doe", "Jane Smith"])
+        );
+    }
+
+    #[test]
+    fn resolve_names_exact_hit_beats_substring_hits() {
+        // "Jane Doe" is a substring of "Jane Doe Jr", so a naive substring
+        // match would union the two and there would be no way to name just her.
+        let available = names(&["Jane Doe", "Jane Doe Jr"]);
+        assert_eq!(resolve_names("jane doe", &available), names(&["Jane Doe"]));
+    }
+
+    #[test]
+    fn resolve_names_returns_empty_when_nothing_matches() {
+        let available = names(&["Jane Doe"]);
+        assert!(resolve_names("jayne", &available).is_empty());
+    }
+
+    // --- SpeakerFilter::matches ---
+
+    #[test]
+    fn me_and_other_test_the_audio_channel_only() {
+        assert!(SpeakerFilter::Me.matches(Some("microphone"), None));
+        assert!(!SpeakerFilter::Me.matches(Some("system"), None));
+        assert!(!SpeakerFilter::Me.matches(None, None));
+
+        assert!(SpeakerFilter::Other.matches(Some("system"), None));
+        assert!(!SpeakerFilter::Other.matches(Some("microphone"), None));
+        assert!(!SpeakerFilter::Other.matches(None, None));
+    }
+
+    #[test]
+    fn other_keeps_meaning_not_me_when_a_name_is_present() {
+        // Attribution must not silently narrow `other` to attributed rows.
+        assert!(SpeakerFilter::Other.matches(Some("system"), Some("Jane Doe")));
+    }
+
+    #[test]
+    fn names_test_the_detected_name_case_insensitively() {
+        let filter = SpeakerFilter::Names(names(&["Jane Doe"]));
+        assert!(filter.matches(Some("system"), Some("Jane Doe")));
+        assert!(filter.matches(Some("system"), Some("jane doe")));
+        assert!(!filter.matches(Some("system"), Some("Marcus Webb")));
+    }
+
+    #[test]
+    fn names_never_match_an_unattributed_utterance() {
+        // The microphone channel is never attributed, and neither is anything
+        // recorded before the cutover.
+        let filter = SpeakerFilter::Names(names(&["Jane Doe"]));
+        assert!(!filter.matches(Some("microphone"), None));
+        assert!(!filter.matches(Some("system"), None));
+    }
+
+    #[test]
+    fn names_match_any_of_a_multi_speaker_resolution() {
+        let filter = SpeakerFilter::Names(names(&["Jane Doe", "Jane Smith"]));
+        assert!(filter.matches(Some("system"), Some("Jane Doe")));
+        assert!(filter.matches(Some("system"), Some("Jane Smith")));
+        assert!(!filter.matches(Some("system"), Some("Marcus Webb")));
+    }
+
+    // --- label ---
+
+    #[test]
+    fn label_names_the_detected_speaker_when_there_is_one() {
+        assert_eq!(
+            label(Some("system"), Some("Jane Doe")),
+            Some(SpeakerLabel::Named("Jane Doe"))
+        );
+    }
+
+    #[test]
+    fn label_falls_back_to_other_for_an_unattributed_remote_speaker() {
+        assert_eq!(label(Some("system"), None), Some(SpeakerLabel::Other));
+        // A blank name is not a name.
+        assert_eq!(label(Some("system"), Some("  ")), Some(SpeakerLabel::Other));
+    }
+
+    #[test]
+    fn label_calls_the_microphone_channel_you() {
+        assert_eq!(label(Some("microphone"), None), Some(SpeakerLabel::You));
+        assert_eq!(
+            label(Some("microphone"), Some("Jane Doe")),
+            Some(SpeakerLabel::You)
+        );
+    }
+
+    #[test]
+    fn label_says_nothing_when_the_channel_is_unknown() {
+        // Transcripts synced before v003 have no source at all.
+        assert_eq!(label(None, None), None);
+        assert_eq!(label(Some("weird"), None), None);
+    }
+
+    // --- no_match_message ---
+
+    #[test]
+    fn no_match_message_lists_known_speakers() {
+        let msg = no_match_message("jayne", &names(&["Jane Doe", "Marcus Webb"]));
+        assert!(msg.contains("no speaker matches \"jayne\""), "got: {msg}");
+        assert!(msg.contains("Jane Doe, Marcus Webb"), "got: {msg}");
+    }
+
+    #[test]
+    fn no_match_message_truncates_a_long_speaker_list() {
+        let all: Vec<String> = (0..15).map(|i| format!("Speaker {i}")).collect();
+        let msg = no_match_message("nobody", &all);
+        assert!(msg.contains("Speaker 9"), "got: {msg}");
+        assert!(!msg.contains("Speaker 10"), "got: {msg}");
+        assert!(msg.contains("(+5 more)"), "got: {msg}");
+    }
+
+    #[test]
+    fn no_match_message_distinguishes_a_corpus_with_no_attribution() {
+        let msg = no_match_message("jane", &[]);
+        assert!(msg.contains("no utterances have speaker attribution"), "got: {msg}");
+        assert!(msg.contains("2026-07-21"), "got: {msg}");
+    }
+
+    // --- resolve ---
+
+    #[test]
+    fn resolve_passes_me_and_other_through_without_a_lookup() {
+        let conn = crate::db::test_fixtures::build_test_db(&serde_json::json!({}));
+        assert_eq!(
+            resolve(&conn, &SpeakerSelector::Me).unwrap(),
+            SpeakerFilter::Me
+        );
+        assert_eq!(
+            resolve(&conn, &SpeakerSelector::Other).unwrap(),
+            SpeakerFilter::Other
+        );
+    }
+
+    #[test]
+    fn resolve_selects_the_matching_names() {
+        let conn = crate::db::test_fixtures::build_test_db(&attributed_state());
+        let filter = resolve(&conn, &SpeakerSelector::Name("jane".to_string())).unwrap();
+        assert_eq!(filter, SpeakerFilter::Names(names(&["Jane Doe"])));
+    }
+
+    #[test]
+    fn resolve_errors_when_the_pattern_matches_nobody() {
+        let conn = crate::db::test_fixtures::build_test_db(&attributed_state());
+        let err = resolve(&conn, &SpeakerSelector::Name("jayne".to_string()))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no speaker matches \"jayne\""), "got: {err}");
+        assert!(err.contains("Jane Doe"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_takes_the_union_when_several_speakers_match() {
+        let conn = crate::db::test_fixtures::build_test_db(&attributed_state());
+        let filter = resolve(&conn, &SpeakerSelector::Name("a".to_string())).unwrap();
+        let SpeakerFilter::Names(matched) = filter else {
+            panic!("expected resolved names");
+        };
+        assert_eq!(matched, names(&["Jane Doe", "Marcus Webb"]));
+    }
+
+    /// One meeting whose system channel carries two attributed speakers and
+    /// one utterance from before the cutover.
+    fn attributed_state() -> serde_json::Value {
+        serde_json::json!({
+            "documents": {
+                "doc-1": { "id": "doc-1", "title": "Sync", "created_at": "2026-07-22T10:00:00Z" }
+            },
+            "transcripts": {
+                "doc-1": [
+                    {"id": "u1", "document_id": "doc-1", "text": "Mine", "source": "microphone"},
+                    {"id": "u2", "document_id": "doc-1", "text": "Hers", "source": "system",
+                     "speaker_name": "Jane Doe"},
+                    {"id": "u3", "document_id": "doc-1", "text": "Theirs", "source": "system",
+                     "speaker_name": "Marcus Webb"},
+                    {"id": "u4", "document_id": "doc-1", "text": "Unknown", "source": "system"}
+                ]
+            }
+        })
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -686,7 +686,8 @@ pub fn fixture_state() -> String {
                     "end_timestamp": "2025-07-20T14:01:30.000Z",
                     "text": "Let us review the performance benchmarks.",
                     "source": "system",
-                    "is_final": true
+                    "is_final": true,
+                    "speaker_name": "Priya Raman"
                 },
                 {
                     "id": "utt-b2",
@@ -695,7 +696,8 @@ pub fn fixture_state() -> String {
                     "end_timestamp": "2025-07-20T14:02:00.000Z",
                     "text": "The latency improved by forty percent after optimization.",
                     "source": "system",
-                    "is_final": true
+                    "is_final": true,
+                    "speaker_name": "Priya Nair"
                 },
                 {
                     "id": "utt-b3",
@@ -704,7 +706,8 @@ pub fn fixture_state() -> String {
                     "end_timestamp": "2025-07-20T14:02:30.000Z",
                     "text": "We should deploy the prototype to staging next sprint.",
                     "source": "system",
-                    "is_final": true
+                    "is_final": true,
+                    "speaker_name": "Marcus Webb"
                 }
             ]
         },

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -80,6 +80,7 @@ fn create_test_tables(conn: &Connection) {
             source TEXT,
             is_final INTEGER,
             api_snapshot TEXT,
+            speaker_name TEXT,
             FOREIGN KEY (document_id) REFERENCES documents(id)
         );
 
@@ -211,6 +212,8 @@ fn create_test_tables(conn: &Connection) {
 
         CREATE INDEX idx_transcript_utterances_document ON transcript_utterances(document_id);
 
+        CREATE INDEX idx_transcript_utterances_speaker_name ON transcript_utterances(speaker_name);
+
         CREATE INDEX idx_panels_document_id ON panels(document_id);
 
         CREATE TABLE panel_sync_log (
@@ -243,7 +246,7 @@ fn create_test_tables(conn: &Connection) {
         );
 
         -- Set schema version via user_version pragma (used by rusqlite_migration)
-        PRAGMA user_version = 13;
+        PRAGMA user_version = 14;
         "#,
     )
     .unwrap();
@@ -314,8 +317,8 @@ fn insert_test_data(conn: &Connection, state: &serde_json::Value) {
             if let Some(arr) = utts.as_array() {
                 for utt in arr {
                     conn.execute(
-                        "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, source, is_final)
-                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                        "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, source, is_final, speaker_name)
+                         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                         rusqlite::params![
                             utt.get("id").and_then(|v| v.as_str()),
                             utt.get("document_id").and_then(|v| v.as_str()),
@@ -324,6 +327,7 @@ fn insert_test_data(conn: &Connection, state: &serde_json::Value) {
                             utt.get("text").and_then(|v| v.as_str()),
                             utt.get("source").and_then(|v| v.as_str()),
                             utt.get("is_final").and_then(|v| v.as_bool()),
+                            utt.get("speaker_name").and_then(|v| v.as_str()),
                         ],
                     ).unwrap();
                 }

--- a/tests/search.rs
+++ b/tests/search.rs
@@ -332,6 +332,110 @@ fn speaker_filter_me_matches_nothing_in_all_system_fixture() {
     assert_eq!(result["total_meetings"], 0, "got: {result}");
 }
 
+// --- Named speakers: Granola's own attribution, post-2026-07-21 ---
+
+#[test]
+fn speaker_name_filter_keeps_only_that_speakers_meetings() {
+    let env = TestEnv::with_fixture();
+    // "prototype" appears in doc-alpha (unattributed) and doc-beta (Marcus
+    // Webb). Naming Marcus drops doc-alpha.
+    let output = env
+        .cmd_json()
+        .args(["grep", "prototype", "--speaker", "Marcus Webb"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let meetings = result["meetings"].as_array().unwrap();
+    assert_eq!(meetings.len(), 1, "got: {result}");
+    assert_eq!(meetings[0]["id"], "doc-beta");
+    assert_eq!(meetings[0]["matches"][0]["speaker_name"], "Marcus Webb");
+    // The channel label survives alongside the name.
+    assert_eq!(meetings[0]["matches"][0]["speaker"], "other");
+}
+
+#[test]
+fn speaker_name_filter_matches_a_partial_name() {
+    let env = TestEnv::with_fixture();
+    let output = env
+        .cmd_json()
+        .args(["grep", "prototype", "--speaker", "marcus"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["meetings"].as_array().unwrap().len(), 1, "got: {result}");
+}
+
+#[test]
+fn speaker_name_matching_several_speakers_notes_them_and_takes_the_union() {
+    let env = TestEnv::with_fixture();
+    // Two Priyas in the fixture: the run proceeds over both and says so.
+    let output = env
+        .cmd_json()
+        .args(["grep", "the", "--speaker", "priya"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("matched 2 speakers"), "got stderr: {stderr}");
+    assert!(stderr.contains("Priya Nair"), "got stderr: {stderr}");
+    assert!(stderr.contains("Priya Raman"), "got stderr: {stderr}");
+
+    // The note goes to stderr so JSON on stdout stays parseable.
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(result["meetings"].as_array().unwrap().len() >= 1, "got: {result}");
+}
+
+#[test]
+fn unknown_speaker_name_errors_and_lists_known_speakers() {
+    let env = TestEnv::with_fixture();
+    // A typo must not read as "nobody said that".
+    env.cmd()
+        .args(["grep", "prototype", "--speaker", "Marcys Webb"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no speaker matches \"Marcys Webb\""))
+        .stderr(predicate::str::contains("Marcus Webb"));
+}
+
+#[test]
+fn show_transcript_names_the_detected_speaker() {
+    let env = TestEnv::with_fixture();
+    env.cmd()
+        .args(["show", "doc-beta", "--transcript"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Marcus Webb:"))
+        .stdout(predicate::str::contains("Priya Raman:"));
+}
+
+#[test]
+fn show_transcript_filtered_to_a_speaker_keeps_only_their_utterances() {
+    let env = TestEnv::with_fixture();
+    env.cmd()
+        .args(["show", "doc-beta", "--transcript", "--speaker", "Marcus Webb"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Marcus Webb:"))
+        .stdout(predicate::str::contains("Priya Raman:").not());
+}
+
+#[test]
+fn show_transcript_says_so_when_the_speaker_filter_empties_it() {
+    let env = TestEnv::with_fixture();
+    // doc-beta has a transcript; it just has nothing by this speaker. Saying
+    // "no transcript available" would send the reader to check their sync.
+    env.cmd()
+        .args(["show", "doc-beta", "--transcript", "--speaker", "me"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No utterances by that speaker"));
+}
+
 #[test]
 fn grep_speaker_with_in_excluding_transcripts_errors() {
     let env = TestEnv::with_fixture();


### PR DESCRIPTION
Closes #106.

Granola began emitting per-utterance speaker names on 2026-07-21 (`detected_speaker_name`; characterized in #66). grans was already persisting them inside the `api_snapshot` column but nothing could read them. This surfaces the field end to end:

- **Migration v014** adds `transcript_utterances.speaker_name` and backfills it from `api_snapshot` in the same migration. Pure SQL; no API round-trip and no re-sync needed.
- `TranscriptUtterance` models `detected_speaker_name` as a first-class field instead of letting it land in `extra`.
- Write and read paths carry the column.
- Output shows the speaker's name where one exists, falling back to the existing `Other` label. Pre-cutover utterances (all ~500k of them) and the 8.8% of post-cutover system utterances without attribution keep the old behavior.
- `--speaker` accepts a name in addition to `me`/`other`: `grans grep "budget" --speaker "Jane Doe"`. Matching is case-insensitive; `me` and `other` keep their existing meanings (`other` means "not me", not "named speakers only").
- README documents the new filter.

## Migration numbering note for reviewers

This migration must land as **v014**. It has already been applied to the production database during end-to-end verification (`user_version` = 14 with `speaker_name` present), so the number is burned in. #118's FTS trigger migration, currently also numbered v014 on its branch, renumbers to v015 and lands after this (see merge-order discussion on #118).

## Testing

- Migration tests cover fresh-create with backfill and lifting names out of snapshots already stored by earlier versions.
- `--speaker <name>` has unit tests through the parse/filter path and an integration test in `tests/search.rs`.
- Verified end to end against the live database: backfill populated 13,518 rows and named-speaker filtering returns the expected utterances.
