### PR TITLE
#110: Attach speaker set to transcript chunk metadata (no re-embed)

### DIFF
--- a/src/embed/chunker.rs
+++ b/src/embed/chunker.rs
@@ -105,6 +105,12 @@ struct Utterance {
 /// sentinel entry either; the `[You]` label in the chunk text and the
 /// window indices already identify them, and an invented name would sit
 /// in the same namespace speaker filtering matches display names against.
+///
+/// Overlap carryover text duplicated from the previous chunk sits outside
+/// the window, so its speakers are deliberately not listed here, matching
+/// how `window_start_idx`/`window_end_idx` already exclude carryover. The
+/// chunk that owns those utterances attributes them; listing them twice
+/// would double-attribute every speaker near a chunk boundary.
 fn window_speakers(utterances: &[Utterance], start: usize, end: usize) -> Vec<String> {
     let mut speakers: Vec<String> = Vec::new();
     for utt in utterances.get(start..=end).unwrap_or(&[]) {
@@ -1897,6 +1903,55 @@ mod tests {
         let meta1 = chunks[1].metadata.as_ref().unwrap();
         assert_eq!(meta0["speakers"], serde_json::json!(["Jane Doe"]));
         assert_eq!(meta1["speakers"], serde_json::json!(["John Smith"]));
+    }
+
+    #[test]
+    fn test_adaptive_speakers_exclude_overlap_carryover() {
+        // Chars-mode overlap copies the tail of the previous chunk into
+        // the next one, so a prior speaker's words can appear in a chunk
+        // whose window doesn't include them. The speakers array follows
+        // the window, exactly like window_start_idx/window_end_idx: the
+        // chunk that owns the utterance attributes it, and adjacent
+        // chunks don't double-attribute shared overlap text.
+        let utt_a = "Jane spends a while walking through the quarterly budget figures";
+        let utt_b = "John follows up with a question about the deployment schedule now";
+        let utts = vec![
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                utt_a,
+                Some("system"),
+                Some("Jane Doe"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                utt_b,
+                Some("system"),
+                Some("John Smith"),
+            ),
+        ];
+        let conn = setup_test_db_with_speakers(&utts);
+        let config = ChunkingConfig {
+            target_tokens: 25,
+            max_tokens: 100,
+            overlap_tokens: 15,
+            min_chars: 10,
+            chars_per_token: 4.0,
+            overlap_mode: OverlapMode::Chars,
+        };
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
+
+        assert_eq!(chunks.len(), 2);
+        // The second chunk really does carry Jane's words via overlap...
+        assert!(chunks[1].text.contains("budget figures"));
+        // ...but its window is utterance 1 only, and speakers match it.
+        let meta = chunks[1].metadata.as_ref().unwrap();
+        assert_eq!(meta["window_start_idx"], 1);
+        assert_eq!(meta["speakers"], serde_json::json!(["John Smith"]));
+        // Jane is attributed by the chunk that owns her utterance.
+        let meta0 = chunks[0].metadata.as_ref().unwrap();
+        assert_eq!(meta0["speakers"], serde_json::json!(["Jane Doe"]));
     }
 
     #[test]

--- a/src/embed/chunker.rs
+++ b/src/embed/chunker.rs
@@ -87,6 +87,56 @@ impl ChunkingConfig {
     }
 }
 
+/// A transcript utterance as read by the transcript window chunker.
+struct Utterance {
+    document_id: String,
+    text: String,
+    start_timestamp: Option<String>,
+    end_timestamp: Option<String>,
+    source: Option<String>,
+    speaker_name: Option<String>,
+}
+
+/// Distinct speaker names for the utterance window `start..=end`, in
+/// first-appearance order. Empty-text utterances contributed nothing to
+/// the chunk and are skipped. An empty array is the common case: the
+/// pre-cutover corpus has no names at all, and the local user
+/// (microphone channel) never carries one. The local user gets no
+/// sentinel entry either; the `[You]` label in the chunk text and the
+/// window indices already identify them, and an invented name would sit
+/// in the same namespace speaker filtering matches display names against.
+fn window_speakers(utterances: &[Utterance], start: usize, end: usize) -> Vec<String> {
+    let mut speakers: Vec<String> = Vec::new();
+    for utt in utterances.get(start..=end).unwrap_or(&[]) {
+        if utt.text.trim().is_empty() {
+            continue;
+        }
+        if let Some(name) = &utt.speaker_name {
+            if !speakers.iter().any(|s| s == name) {
+                speakers.push(name.clone());
+            }
+        }
+    }
+    speakers
+}
+
+/// Metadata for a transcript window chunk covering `start_idx..=end_idx`.
+fn transcript_chunk_metadata(
+    utterances: &[Utterance],
+    start_idx: usize,
+    end_idx: usize,
+    start_ts: Option<&str>,
+    end_ts: Option<&str>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "window_start_idx": start_idx,
+        "window_end_idx": end_idx,
+        "start_timestamp": start_ts,
+        "end_timestamp": end_ts,
+        "speakers": window_speakers(utterances, start_idx, end_idx),
+    })
+}
+
 /// Generate transcript window chunks using adaptive token-based chunking.
 /// This normalizes chunk sizes to be within the model's token limits.
 /// When `headers` is provided, each document's contextual header is
@@ -99,18 +149,10 @@ pub fn transcript_window_chunker_adaptive(
     headers: Option<&HashMap<String, String>>,
 ) -> Result<Vec<Chunk>> {
     let mut stmt = index_conn.prepare(
-        "SELECT document_id, id, text, start_timestamp, end_timestamp, source
+        "SELECT document_id, id, text, start_timestamp, end_timestamp, source, speaker_name
          FROM transcript_utterances
          ORDER BY document_id, start_timestamp, rowid",
     )?;
-
-    struct Utterance {
-        document_id: String,
-        text: String,
-        start_timestamp: Option<String>,
-        end_timestamp: Option<String>,
-        source: Option<String>,
-    }
 
     let rows = stmt.query_map([], |row| {
         Ok(Utterance {
@@ -119,6 +161,7 @@ pub fn transcript_window_chunker_adaptive(
             start_timestamp: row.get(3)?,
             end_timestamp: row.get(4)?,
             source: row.get(5)?,
+            speaker_name: row.get(6)?,
         })
     })?;
 
@@ -191,12 +234,13 @@ pub fn transcript_window_chunker_adaptive(
                         text: buffer.clone(),
                         content_hash: hash_embed_input(header.map(String::as_str), &buffer),
                         header: header.cloned(),
-                        metadata: Some(serde_json::json!({
-                            "window_start_idx": buffer_start_idx,
-                            "window_end_idx": buffer_end_idx,
-                            "start_timestamp": buffer_start_ts,
-                            "end_timestamp": buffer_end_ts,
-                        })),
+                        metadata: Some(transcript_chunk_metadata(
+                            utterances,
+                            buffer_start_idx,
+                            buffer_end_idx,
+                            buffer_start_ts,
+                            buffer_end_ts,
+                        )),
                     });
                     chunk_idx += 1;
                 }
@@ -237,12 +281,13 @@ pub fn transcript_window_chunker_adaptive(
                         text: buffer.clone(),
                         content_hash: hash_embed_input(header.map(String::as_str), &buffer),
                         header: header.cloned(),
-                        metadata: Some(serde_json::json!({
-                            "window_start_idx": buffer_start_idx,
-                            "window_end_idx": buffer_end_idx,
-                            "start_timestamp": buffer_start_ts,
-                            "end_timestamp": buffer_end_ts,
-                        })),
+                        metadata: Some(transcript_chunk_metadata(
+                            utterances,
+                            buffer_start_idx,
+                            buffer_end_idx,
+                            buffer_start_ts,
+                            buffer_end_ts,
+                        )),
                     });
                     chunk_idx += 1;
                 }
@@ -280,12 +325,13 @@ pub fn transcript_window_chunker_adaptive(
                             text: buffer.clone(),
                             content_hash: hash_embed_input(header.map(String::as_str), &buffer),
                             header: header.cloned(),
-                            metadata: Some(serde_json::json!({
-                                "window_start_idx": buffer_start_idx,
-                                "window_end_idx": buffer_end_idx,
-                                "start_timestamp": buffer_start_ts,
-                                "end_timestamp": buffer_end_ts,
-                            })),
+                            metadata: Some(transcript_chunk_metadata(
+                                utterances,
+                                buffer_start_idx,
+                                buffer_end_idx,
+                                buffer_start_ts,
+                                buffer_end_ts,
+                            )),
                         });
                         chunk_idx += 1;
                     }
@@ -332,12 +378,13 @@ pub fn transcript_window_chunker_adaptive(
                 text: buffer.clone(),
                 content_hash: hash_embed_input(header.map(String::as_str), &buffer),
                 header: header.cloned(),
-                metadata: Some(serde_json::json!({
-                    "window_start_idx": buffer_start_idx,
-                    "window_end_idx": buffer_end_idx,
-                    "start_timestamp": buffer_start_ts,
-                    "end_timestamp": buffer_end_ts,
-                })),
+                metadata: Some(transcript_chunk_metadata(
+                    utterances,
+                    buffer_start_idx,
+                    buffer_end_idx,
+                    buffer_start_ts,
+                    buffer_end_ts,
+                )),
             });
         }
     }
@@ -708,6 +755,16 @@ mod tests {
     }
 
     fn setup_test_db(utterances: &[(&str, &str, &str, Option<&str>)]) -> Connection {
+        let with_speakers: Vec<_> = utterances
+            .iter()
+            .map(|&(doc_id, ts, text, source)| (doc_id, ts, text, source, None))
+            .collect();
+        setup_test_db_with_speakers(&with_speakers)
+    }
+
+    fn setup_test_db_with_speakers(
+        utterances: &[(&str, &str, &str, Option<&str>, Option<&str>)],
+    ) -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE transcript_utterances (
@@ -716,15 +773,16 @@ mod tests {
                 start_timestamp TEXT,
                 end_timestamp TEXT,
                 text TEXT,
-                source TEXT
+                source TEXT,
+                speaker_name TEXT
             );",
         )
         .unwrap();
 
-        for (i, (doc_id, timestamp, text, source)) in utterances.iter().enumerate() {
+        for (i, (doc_id, timestamp, text, source, speaker_name)) in utterances.iter().enumerate() {
             conn.execute(
-                "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, source)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                "INSERT INTO transcript_utterances (id, document_id, start_timestamp, end_timestamp, text, source, speaker_name)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
                 rusqlite::params![
                     format!("u-{}", i),
                     doc_id,
@@ -732,6 +790,7 @@ mod tests {
                     timestamp,
                     text,
                     source,
+                    speaker_name,
                 ],
             )
             .unwrap();
@@ -1680,6 +1739,198 @@ mod tests {
                 .text
                 .contains("[Other] Labeled utterance from other person.")
         );
+    }
+
+    // Tests for the speakers array in chunk metadata (#110)
+    #[test]
+    fn test_adaptive_speakers_in_metadata() {
+        // Distinct names, first-appearance order, duplicates collapsed.
+        let utts = vec![
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "Jane opens the meeting with the agenda for today.",
+                Some("system"),
+                Some("Jane Doe"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "John responds with an update on the deployment.",
+                Some("system"),
+                Some("John Smith"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:02:00Z",
+                "Jane wraps up with the action items for everyone.",
+                Some("system"),
+                Some("Jane Doe"),
+            ),
+        ];
+        let conn = setup_test_db_with_speakers(&utts);
+        let config = ChunkingConfig {
+            target_tokens: 500,
+            max_tokens: 1000,
+            overlap_tokens: 100,
+            min_chars: 10,
+            chars_per_token: 4.0,
+            overlap_mode: OverlapMode::Chars,
+        };
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        let meta = chunks[0].metadata.as_ref().unwrap();
+        assert_eq!(
+            meta["speakers"],
+            serde_json::json!(["Jane Doe", "John Smith"])
+        );
+    }
+
+    #[test]
+    fn test_adaptive_speakers_empty_when_unattributed() {
+        // Pre-cutover data: no names anywhere. The array is present and
+        // empty, not absent and not an error.
+        let utts = vec![
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "An old utterance from before speaker attribution existed.",
+                Some("system"),
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "Another unattributed utterance with plenty of content.",
+                Some("system"),
+                None,
+            ),
+        ];
+        let conn = setup_test_db_with_speakers(&utts);
+        let config = ChunkingConfig {
+            target_tokens: 500,
+            max_tokens: 1000,
+            overlap_tokens: 100,
+            min_chars: 10,
+            chars_per_token: 4.0,
+            overlap_mode: OverlapMode::Chars,
+        };
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        let meta = chunks[0].metadata.as_ref().unwrap();
+        assert_eq!(meta["speakers"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn test_adaptive_speakers_exclude_local_user() {
+        // Microphone utterances are the local user: no name, no sentinel.
+        // Only named speakers from the system channel appear.
+        let utts = vec![
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                "I think we should go ahead with the migration plan.",
+                Some("microphone"),
+                None,
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                "Agreed, let me pull up the timeline for that work.",
+                Some("system"),
+                Some("Jane Doe"),
+            ),
+        ];
+        let conn = setup_test_db_with_speakers(&utts);
+        let config = ChunkingConfig {
+            target_tokens: 500,
+            max_tokens: 1000,
+            overlap_tokens: 100,
+            min_chars: 10,
+            chars_per_token: 4.0,
+            overlap_mode: OverlapMode::Chars,
+        };
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
+
+        assert_eq!(chunks.len(), 1);
+        let meta = chunks[0].metadata.as_ref().unwrap();
+        assert_eq!(meta["speakers"], serde_json::json!(["Jane Doe"]));
+    }
+
+    #[test]
+    fn test_adaptive_speakers_follow_chunk_windows() {
+        // When a document splits into multiple chunks, each chunk carries
+        // only the speakers of its own window.
+        let utt_a = "Utterance alpha talks about the quarterly budget plan.";
+        let utt_b = "Utterance bravo covers the deployment timeline today.";
+        let utts = vec![
+            (
+                "doc1",
+                "2025-01-01T10:00:00Z",
+                utt_a,
+                Some("system"),
+                Some("Jane Doe"),
+            ),
+            (
+                "doc1",
+                "2025-01-01T10:01:00Z",
+                utt_b,
+                Some("system"),
+                Some("John Smith"),
+            ),
+        ];
+        let conn = setup_test_db_with_speakers(&utts);
+        let config = ChunkingConfig {
+            target_tokens: 20,
+            max_tokens: 100,
+            overlap_tokens: 1,
+            min_chars: 10,
+            chars_per_token: 4.0,
+            overlap_mode: OverlapMode::Utterances,
+        };
+        let chunks = transcript_window_chunker_adaptive(&conn, &config, None).unwrap();
+
+        assert_eq!(chunks.len(), 2);
+        let meta0 = chunks[0].metadata.as_ref().unwrap();
+        let meta1 = chunks[1].metadata.as_ref().unwrap();
+        assert_eq!(meta0["speakers"], serde_json::json!(["Jane Doe"]));
+        assert_eq!(meta1["speakers"], serde_json::json!(["John Smith"]));
+    }
+
+    #[test]
+    fn test_speaker_name_does_not_change_content_hash() {
+        // The core #110 invariant: attaching speaker names is metadata
+        // only. Identical text with and without names must hash the same,
+        // or the whole corpus re-embeds.
+        let text = "This utterance has enough content to form a chunk on its own for the test.";
+        let config = ChunkingConfig::default();
+
+        let conn_named = setup_test_db_with_speakers(&[(
+            "doc1",
+            "2025-01-01T10:00:00Z",
+            text,
+            Some("system"),
+            Some("Jane Doe"),
+        )]);
+        let named = transcript_window_chunker_adaptive(&conn_named, &config, None).unwrap();
+
+        let conn_unnamed = setup_test_db_with_speakers(&[(
+            "doc1",
+            "2025-01-01T10:00:00Z",
+            text,
+            Some("system"),
+            None,
+        )]);
+        let unnamed = transcript_window_chunker_adaptive(&conn_unnamed, &config, None).unwrap();
+
+        assert_eq!(named[0].text, unnamed[0].text);
+        assert_eq!(named[0].content_hash, unnamed[0].content_hash);
+        // Only the metadata differs.
+        let named_meta = named[0].metadata.as_ref().unwrap();
+        let unnamed_meta = unnamed[0].metadata.as_ref().unwrap();
+        assert_ne!(named_meta["speakers"], unnamed_meta["speakers"]);
     }
 
     #[test]

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -303,6 +303,18 @@ fn desired_chunks_for_spec(conn: &Connection, spec: &config::EmbedSpec) -> Resul
     Ok(chunks)
 }
 
+/// True when a chunk's desired metadata no longer matches what is stored.
+/// Compared as parsed JSON so key order and formatting don't count;
+/// unparseable stored metadata counts as drifted so a refresh repairs it.
+fn chunk_metadata_differs(stored: Option<&str>, desired: Option<&serde_json::Value>) -> bool {
+    let stored_value = stored.and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok());
+    match (&stored_value, desired) {
+        (None, None) => false,
+        (Some(s), Some(d)) => s != d,
+        _ => true,
+    }
+}
+
 /// Wipe all embeddings from the database.
 /// Used by `grans embed --force` to force re-embedding.
 pub fn wipe_all_embeddings(conn: &Connection) -> Result<()> {
@@ -390,8 +402,9 @@ pub fn ensure_embeddings(
         .map(|s| ((s.source_type.as_str(), s.source_id.as_str()), s))
         .collect();
 
-    // Diff: find new/changed chunks and orphaned chunks
+    // Diff: find new/changed chunks, metadata drift, and orphaned chunks
     let mut to_embed: Vec<&Chunk> = Vec::new();
+    let mut to_refresh: Vec<(i64, Option<String>)> = Vec::new();
     let mut desired_keys: HashSet<(String, String)> = HashSet::new();
 
     for chunk in &desired_chunks {
@@ -400,7 +413,19 @@ pub fn ensure_embeddings(
 
         match stored_map.get(&key) {
             Some(existing) if existing.content_hash == chunk.content_hash => {
-                // Unchanged — skip
+                // Unchanged embed input. Metadata can still drift (e.g.
+                // speaker attribution arriving after the chunk was
+                // embedded); carry it into the store without re-embedding.
+                if chunk_metadata_differs(
+                    existing.metadata_json.as_deref(),
+                    chunk.metadata.as_ref(),
+                ) {
+                    let serialized = chunk
+                        .metadata
+                        .as_ref()
+                        .map(|m| serde_json::to_string(m).unwrap_or_default());
+                    to_refresh.push((existing.id, serialized));
+                }
             }
             _ => {
                 // New or changed
@@ -419,6 +444,15 @@ pub fn ensure_embeddings(
     // Delete orphans
     if !orphan_ids.is_empty() {
         store::delete_chunks(conn, &orphan_ids)?;
+    }
+
+    // Refresh drifted metadata on chunks whose embed input is unchanged
+    if !to_refresh.is_empty() {
+        eprintln!(
+            "[grans] Refreshing metadata for {} unchanged chunks.",
+            to_refresh.len()
+        );
+        store::update_chunk_metadata_batch(conn, &to_refresh)?;
     }
 
     // Embed new/changed chunks
@@ -978,6 +1012,69 @@ mod tests {
         )
         .unwrap();
         assert!(index.is_empty());
+    }
+
+    #[test]
+    fn test_chunk_metadata_differs() {
+        let desired = serde_json::json!({"speakers": ["Jane Doe"]});
+
+        assert!(!chunk_metadata_differs(None, None));
+        assert!(chunk_metadata_differs(None, Some(&desired)));
+        assert!(chunk_metadata_differs(Some(r#"{"speakers": []}"#), None));
+        assert!(chunk_metadata_differs(
+            Some(r#"{"speakers": []}"#),
+            Some(&desired)
+        ));
+        // Key order and whitespace don't count as drift.
+        assert!(!chunk_metadata_differs(
+            Some(r#"{ "speakers" : [ "Jane Doe" ] }"#),
+            Some(&desired)
+        ));
+        // Unparseable stored metadata counts as drifted so it gets repaired.
+        assert!(chunk_metadata_differs(Some("not json"), Some(&desired)));
+    }
+
+    #[test]
+    fn test_metadata_refresh_without_reembed() {
+        // The #110 invariant end to end: speaker names arriving after a
+        // corpus is embedded must flow into stored chunk metadata without
+        // a single chunk re-embedding.
+        let conn = setup_test_db();
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is document content that is long enough to meet the minimum character threshold for the embedding chunker.",
+            ],
+        );
+
+        let embedder = MockEmbedder::default();
+        let spec = config::EmbedSpec::default_for(512);
+
+        // First run embeds the corpus; nothing is attributed yet.
+        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &spec).unwrap();
+        assert!(index.stats.is_some());
+        let meta: serde_json::Value =
+            serde_json::from_str(index.vectors[0].metadata_json.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["speakers"], serde_json::json!([]));
+
+        // Attribution arrives (post-cutover sync).
+        conn.execute(
+            "UPDATE transcript_utterances SET source = 'system', speaker_name = 'Jane Doe'",
+            [],
+        )
+        .unwrap();
+        // Setting source changes the embed input ([Other] prefix), which
+        // WOULD re-embed; this test isolates the metadata path, so keep
+        // the input identical by only setting speaker_name.
+        conn.execute("UPDATE transcript_utterances SET source = NULL", [])
+            .unwrap();
+
+        let index = ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &spec).unwrap();
+        assert!(index.stats.is_none(), "metadata refresh must not re-embed");
+        let meta: serde_json::Value =
+            serde_json::from_str(index.vectors[0].metadata_json.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["speakers"], serde_json::json!(["Jane Doe"]));
     }
 
     #[test]

--- a/src/embed/store.rs
+++ b/src/embed/store.rs
@@ -14,12 +14,13 @@ pub struct StoredChunk {
     pub content_hash: String,
     #[allow(dead_code)]
     pub text: String,
+    pub metadata_json: Option<String>,
 }
 
 /// Get all stored chunks with their content hashes (for diffing).
 pub fn get_stored_chunks(conn: &Connection) -> Result<Vec<StoredChunk>> {
     let mut stmt = conn.prepare(
-        "SELECT id, source_type, source_id, document_id, content_hash, text FROM chunks",
+        "SELECT id, source_type, source_id, document_id, content_hash, text, metadata_json FROM chunks",
     )?;
 
     let rows = stmt.query_map([], |row| {
@@ -30,6 +31,7 @@ pub fn get_stored_chunks(conn: &Connection) -> Result<Vec<StoredChunk>> {
             document_id: row.get(3)?,
             content_hash: row.get(4)?,
             text: row.get(5)?,
+            metadata_json: row.get(6)?,
         })
     })?;
 
@@ -165,6 +167,27 @@ pub fn insert_chunks_with_embeddings_batch(
     }
 
     results
+}
+
+/// Update stored chunk metadata in place, leaving embeddings untouched.
+/// This is how metadata-only changes (e.g. speaker attribution arriving
+/// after a chunk was embedded) reach the database without a re-embed.
+pub fn update_chunk_metadata_batch(
+    conn: &Connection,
+    items: &[(i64, Option<String>)],
+) -> Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    let tx = conn.unchecked_transaction()?;
+    let mut stmt = tx.prepare("UPDATE chunks SET metadata_json = ?2 WHERE id = ?1")?;
+    for (id, metadata_json) in items {
+        stmt.execute(rusqlite::params![id, metadata_json])?;
+    }
+    drop(stmt);
+    tx.commit()?;
+    Ok(())
 }
 
 /// Delete chunks by their IDs.
@@ -379,7 +402,7 @@ pub fn get_stored_chunks_by_source(
     source_type: &ChunkSourceType,
 ) -> Result<Vec<StoredChunk>> {
     let mut stmt = conn.prepare(
-        "SELECT id, source_type, source_id, document_id, content_hash, text
+        "SELECT id, source_type, source_id, document_id, content_hash, text, metadata_json
          FROM chunks WHERE source_type = ?1",
     )?;
 
@@ -391,6 +414,7 @@ pub fn get_stored_chunks_by_source(
             document_id: row.get(3)?,
             content_hash: row.get(4)?,
             text: row.get(5)?,
+            metadata_json: row.get(6)?,
         })
     })?;
 
@@ -472,6 +496,59 @@ mod tests {
         assert_eq!(stored.len(), 1);
         assert_eq!(stored[0].source_id, "doc1:w0");
         assert_eq!(stored[0].content_hash, hash_content("test"));
+    }
+
+    #[test]
+    fn test_get_stored_chunks_includes_metadata() {
+        let conn = test_db();
+        let chunk = Chunk {
+            source_type: ChunkSourceType::TranscriptWindow,
+            source_id: "doc1:w0".to_string(),
+            document_id: "doc1".to_string(),
+            text: "test".to_string(),
+            content_hash: hash_content("test"),
+            metadata: Some(serde_json::json!({"speakers": ["Jane Doe"]})),
+            header: None,
+        };
+        insert_chunk_with_embedding(&conn, &chunk, &[1.0]).unwrap();
+
+        let stored = get_stored_chunks(&conn).unwrap();
+        assert_eq!(stored.len(), 1);
+        let meta: serde_json::Value =
+            serde_json::from_str(stored[0].metadata_json.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["speakers"], serde_json::json!(["Jane Doe"]));
+    }
+
+    #[test]
+    fn test_update_chunk_metadata_batch() {
+        let conn = test_db();
+        let chunk = Chunk {
+            source_type: ChunkSourceType::TranscriptWindow,
+            source_id: "doc1:w0".to_string(),
+            document_id: "doc1".to_string(),
+            text: "test".to_string(),
+            content_hash: hash_content("test"),
+            metadata: Some(serde_json::json!({"speakers": []})),
+            header: None,
+        };
+        let id = insert_chunk_with_embedding(&conn, &chunk, &[1.0, 2.0]).unwrap();
+
+        let new_meta = serde_json::json!({"speakers": ["Jane Doe"]}).to_string();
+        update_chunk_metadata_batch(&conn, &[(id, Some(new_meta))]).unwrap();
+
+        let stored = get_stored_chunks(&conn).unwrap();
+        let meta: serde_json::Value =
+            serde_json::from_str(stored[0].metadata_json.as_ref().unwrap()).unwrap();
+        assert_eq!(meta["speakers"], serde_json::json!(["Jane Doe"]));
+        // The embedding vector is untouched.
+        let vectors = load_all_vectors(&conn).unwrap();
+        assert_eq!(vectors[0].vector, vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn test_update_chunk_metadata_batch_empty() {
+        let conn = test_db();
+        update_chunk_metadata_batch(&conn, &[]).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #110. Part of #107; builds on the `speaker_name` column from #106.

## What this does

Transcript window chunks now carry a `speakers` array in their metadata: the distinct non-NULL speaker names of the window's utterances, in first-appearance order. The embed input is untouched, so `content_hash` is stable and nothing re-embeds.

Two pieces:

1. **Chunker** (`src/embed/chunker.rs`): the utterance query selects `speaker_name`, and the four transcript-chunk finalize sites build metadata through a shared `transcript_chunk_metadata` helper that includes `window_speakers()`.
2. **Metadata refresh** (`src/embed/mod.rs`, `src/embed/store.rs`): `ensure_embeddings` previously skipped hash-unchanged chunks entirely, so metadata computed by a newer binary could never reach chunks embedded before the data arrived. The diff now compares stored vs desired metadata for unchanged chunks and rewrites `metadata_json` in place, leaving the vectors alone.

## Decisions the issue delegated

- **Local user sentinel: none.** Microphone utterances never carry a `detected_speaker_name`, the `[You]` label in the chunk text already identifies the local user, and an invented name would sit in the same namespace that future `--speaker` filtering matches display names against. Documented on `window_speakers()`.
- **Empty array is the representation for unattributed windows** (the pre-cutover corpus and the ~8.8% unattributed post-cutover utterances), never an error and never an absent key.

## Hash-stability guarantee

- `test_speaker_name_does_not_change_content_hash`: identical text with and without names hashes identically.
- `test_metadata_refresh_without_reembed`: end to end, attribution arriving after a corpus is embedded flows into stored metadata with `stats: None` (zero chunks embedded).

## Verified against real data

Ran against a copy of the production database (464 MB, 35,827 chunks, redirected via `XDG_DATA_HOME`):

- One search pass logged `Refreshing metadata for 33387 unchanged chunks.` and embedded nothing.
- All 33,387 transcript chunks gained the `speakers` key; 1,360 (post-cutover) are non-empty, one sampled chunk had 4 speakers.
- Panel and notes chunks were untouched.
- A second run refreshed nothing (idempotent).

## Tests

Full suite: 1,008 tests across all six binaries, 0 failures (`cargo test --no-fail-fast`).