### PR TITLE
#82: Load the reranker while retrieval runs

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -109,6 +109,18 @@ pub fn search(
     }
 
     let embedder = crate::embed::model::FastEmbedModel::new()?;
+
+    // The reranker's model load needs nothing retrieval produces, so start
+    // it here and let embedding and retrieval run in front of it. Starting
+    // it any earlier makes the two loads race for the one-time ONNX runtime
+    // init and costs the embedder more than it saves.
+    let pending_reranker = opts
+        .rerank
+        .then(|| {
+            crate::embed::rerank::PendingReranker::spawn(crate::embed::rerank::DEFAULT_RERANK_MODEL)
+        })
+        .transpose()?;
+
     let spec =
         crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
     let index =
@@ -125,36 +137,18 @@ pub fn search(
         include_deleted,
     )?;
 
-    // Ranked (id, score) pairs; ordering is the pipeline's and is not
-    // touched again below.
-    let ordered: Vec<(String, Option<f32>)> = if opts.rerank {
-        let reranker = crate::embed::rerank::FastEmbedReranker::new(
-            crate::embed::rerank::DEFAULT_RERANK_MODEL,
-        )?;
-        let ranking_ctx = crate::query::adjust::RankingContext::load(conn)?;
-        let cfg = crate::query::adjust::RankingConfig::default();
-        let mut reranked = crate::query::rerank::rerank_hybrid(
-            conn,
-            &reranker,
-            query,
-            &ranking,
-            &ranking_ctx,
-            &cfg,
-        )?;
-        if let Some(min) = opts.min_score {
-            reranked.retain(|d| d.score >= min);
-        }
-        reranked
-            .into_iter()
-            .map(|d| (d.document_id, Some(d.score)))
-            .collect()
-    } else {
-        ranking
-            .fused
-            .iter()
-            .map(|d| (d.document_id.clone(), None))
-            .collect()
-    };
+    let reranker = pending_reranker
+        .map(crate::embed::rerank::PendingReranker::join)
+        .transpose()?;
+    let ordered = order_candidates(
+        conn,
+        query,
+        &ranking,
+        reranker
+            .as_ref()
+            .map(|r| r as &dyn crate::embed::rerank::Reranker),
+        opts.min_score,
+    )?;
 
     let ids: Vec<String> = ordered.iter().map(|(id, _)| id.clone()).collect();
     let docs = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
@@ -191,6 +185,38 @@ pub fn search(
 
     render_ranked_meeting_list(&shaped, query, ranking.keyword_total, &opts, ctx);
     Ok(())
+}
+
+/// Ranked (id, score) pairs for the fused candidates. With a reranker the
+/// cross-encoder decides the order and supplies the score; without one the
+/// fusion order stands and no score is shown, since RRF ranks are not
+/// comparable across queries. `min_score` applies to rerank scores only.
+fn order_candidates(
+    conn: &Connection,
+    query: &str,
+    ranking: &crate::query::hybrid::HybridRanking,
+    reranker: Option<&dyn crate::embed::rerank::Reranker>,
+    min_score: Option<f32>,
+) -> Result<Vec<(String, Option<f32>)>> {
+    let Some(reranker) = reranker else {
+        return Ok(ranking
+            .fused
+            .iter()
+            .map(|d| (d.document_id.clone(), None))
+            .collect());
+    };
+
+    let ranking_ctx = crate::query::adjust::RankingContext::load(conn)?;
+    let cfg = crate::query::adjust::RankingConfig::default();
+    let mut reranked =
+        crate::query::rerank::rerank_hybrid(conn, reranker, query, ranking, &ranking_ctx, &cfg)?;
+    if let Some(min) = min_score {
+        reranked.retain(|d| d.score >= min);
+    }
+    Ok(reranked
+        .into_iter()
+        .map(|d| (d.document_id, Some(d.score)))
+        .collect())
 }
 
 /// Header for ranked results: claims only what is shown, never a total.

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -111,9 +111,12 @@ pub fn search(
     let embedder = crate::embed::model::FastEmbedModel::new()?;
 
     // The reranker's model load needs nothing retrieval produces, so start
-    // it here and let embedding and retrieval run in front of it. Starting
-    // it any earlier makes the two loads race for the one-time ONNX runtime
-    // init and costs the embedder more than it saves.
+    // it here and let embedding and retrieval run in front of it. Spawning
+    // at the top of the command hides the load just as completely but races
+    // the embedder for the one-time ONNX runtime init, slowing embedder
+    // init by ~70ms (placement A/B in #82's PR). Only statement order and
+    // this comment keep the spawn after the embedder; moving it up still
+    // compiles and passes, it just pays that contention again.
     let pending_reranker = opts
         .rerank
         .then(|| {
@@ -140,15 +143,12 @@ pub fn search(
     let reranker = pending_reranker
         .map(crate::embed::rerank::PendingReranker::join)
         .transpose()?;
-    let ordered = order_candidates(
-        conn,
-        query,
-        &ranking,
-        reranker
-            .as_ref()
-            .map(|r| r as &dyn crate::embed::rerank::Reranker),
-        opts.min_score,
-    )?;
+    let reranker = reranker
+        .as_ref()
+        .map(|r| r as &dyn crate::embed::rerank::Reranker);
+    // `ordered` is the pipeline's final order; nothing below re-sorts it.
+    let ordered =
+        crate::query::rerank::order_candidates(conn, query, &ranking, reranker, opts.min_score)?;
 
     let ids: Vec<String> = ordered.iter().map(|(id, _)| id.clone()).collect();
     let docs = crate::db::meetings::get_meetings_by_ids(conn, &ids)?;
@@ -185,38 +185,6 @@ pub fn search(
 
     render_ranked_meeting_list(&shaped, query, ranking.keyword_total, &opts, ctx);
     Ok(())
-}
-
-/// Ranked (id, score) pairs for the fused candidates. With a reranker the
-/// cross-encoder decides the order and supplies the score; without one the
-/// fusion order stands and no score is shown, since RRF ranks are not
-/// comparable across queries. `min_score` applies to rerank scores only.
-fn order_candidates(
-    conn: &Connection,
-    query: &str,
-    ranking: &crate::query::hybrid::HybridRanking,
-    reranker: Option<&dyn crate::embed::rerank::Reranker>,
-    min_score: Option<f32>,
-) -> Result<Vec<(String, Option<f32>)>> {
-    let Some(reranker) = reranker else {
-        return Ok(ranking
-            .fused
-            .iter()
-            .map(|d| (d.document_id.clone(), None))
-            .collect());
-    };
-
-    let ranking_ctx = crate::query::adjust::RankingContext::load(conn)?;
-    let cfg = crate::query::adjust::RankingConfig::default();
-    let mut reranked =
-        crate::query::rerank::rerank_hybrid(conn, reranker, query, ranking, &ranking_ctx, &cfg)?;
-    if let Some(min) = min_score {
-        reranked.retain(|d| d.score >= min);
-    }
-    Ok(reranked
-        .into_iter()
-        .map(|d| (d.document_id, Some(d.score)))
-        .collect())
 }
 
 /// Header for ranked results: claims only what is shown, never a total.

--- a/src/embed/model.rs
+++ b/src/embed/model.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::env;
+use std::sync::OnceLock;
 
 use anyhow::Result;
 
@@ -34,15 +35,26 @@ pub(crate) fn hf_cache_dir() -> Result<std::path::PathBuf> {
 }
 
 /// Set HF_HOME so fastembed's hf-hub downloads land in [`hf_cache_dir`].
+///
+/// The write happens at most once per process. Model init reads the
+/// environment, and since a reranker can load on its own thread (see
+/// [`crate::embed::rerank::PendingReranker`]) two models can be reading it
+/// at once; a single ordered write is what keeps that sound.
 pub(crate) fn set_hf_cache_dir() -> Result<()> {
-    let cache_dir = hf_cache_dir()?;
+    static HF_HOME: OnceLock<Result<(), String>> = OnceLock::new();
 
-    // SAFETY: called during model initialization (single-threaded context),
-    // before any threads the model wrappers spawn.
-    unsafe {
-        env::set_var("HF_HOME", cache_dir);
-    }
-    Ok(())
+    HF_HOME
+        .get_or_init(|| {
+            let cache_dir = hf_cache_dir().map_err(|e| e.to_string())?;
+            // SAFETY: the process's only environment write, and OnceLock
+            // orders it before every read that follows on any thread.
+            unsafe {
+                env::set_var("HF_HOME", cache_dir);
+            }
+            Ok(())
+        })
+        .clone()
+        .map_err(anyhow::Error::msg)
 }
 
 /// Hardware execution providers enabled by cargo features. CPU is always

--- a/src/embed/model.rs
+++ b/src/embed/model.rs
@@ -36,25 +36,30 @@ pub(crate) fn hf_cache_dir() -> Result<std::path::PathBuf> {
 
 /// Set HF_HOME so fastembed's hf-hub downloads land in [`hf_cache_dir`].
 ///
-/// The write happens at most once per process. Model init reads the
-/// environment, and since a reranker can load on its own thread (see
-/// [`crate::embed::rerank::PendingReranker`]) two models can be reading it
-/// at once; a single ordered write is what keeps that sound.
+/// Callers must invoke this before spawning any thread that might read the
+/// process environment. Model loader threads do read it, not for HF_HOME
+/// but for the platform paths (XDG_DATA_HOME, HOME, USERPROFILE) and
+/// hf-hub's HF_ENDPOINT and HF_TOKEN, and setenv racing any getenv is
+/// undefined behavior regardless of which variable each touches. The write
+/// happens at most once per process; later calls only re-resolve the cache
+/// directory, so a failed [`hf_cache_dir`] is retried rather than memoized.
 pub(crate) fn set_hf_cache_dir() -> Result<()> {
-    static HF_HOME: OnceLock<Result<(), String>> = OnceLock::new();
+    static HF_HOME: OnceLock<()> = OnceLock::new();
 
-    HF_HOME
-        .get_or_init(|| {
-            let cache_dir = hf_cache_dir().map_err(|e| e.to_string())?;
-            // SAFETY: the process's only environment write, and OnceLock
-            // orders it before every read that follows on any thread.
-            unsafe {
-                env::set_var("HF_HOME", cache_dir);
-            }
-            Ok(())
-        })
-        .clone()
-        .map_err(anyhow::Error::msg)
+    let cache_dir = hf_cache_dir()?;
+    HF_HOME.get_or_init(|| {
+        // SAFETY: sound only under the contract above. The first caller
+        // runs before any environment-reading thread exists, so
+        // thread::spawn's happens-before edge (not this OnceLock, which
+        // those readers never touch) orders the write ahead of every
+        // getenv on a later thread. What the OnceLock adds is that the
+        // write cannot recur once loader threads are running: every call
+        // after the first is read-only.
+        unsafe {
+            env::set_var("HF_HOME", cache_dir);
+        }
+    });
+    Ok(())
 }
 
 /// Hardware execution providers enabled by cargo features. CPU is always

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -81,6 +81,11 @@ impl FastEmbedReranker {
 /// while the query is embedded and retrieval fuses its candidates.
 /// [`join`](Self::join) then waits only for whatever load time did not fit
 /// behind that work, which on a warm model cache is none of it.
+///
+/// Dropping without joining (an error aborting the search between spawn
+/// and join) detaches the loader thread: the process exits without waiting
+/// for a model nothing can use anymore. That is deliberate; blocking the
+/// error path on an abandoned load would only delay it.
 pub struct PendingReranker {
     handle: JoinHandle<Result<FastEmbedReranker>>,
 }
@@ -98,9 +103,10 @@ impl PendingReranker {
         // run before the thread exists; the full ordering argument lives on
         // that function.
         super::model::set_hf_cache_dir()?;
-        Ok(Self {
-            handle: std::thread::spawn(move || FastEmbedReranker::new(choice)),
-        })
+        let handle = std::thread::Builder::new()
+            .name("reranker-load".to_string())
+            .spawn(move || FastEmbedReranker::new(choice))?;
+        Ok(Self { handle })
     }
 
     /// Wait for the model, or for whatever went wrong loading it.
@@ -185,9 +191,11 @@ mod tests {
 
     #[test]
     fn reranker_can_be_loaded_off_thread() {
-        // PendingReranker moves a loaded model back to the caller. If a
-        // fastembed upgrade makes TextRerank thread-bound, this stops
-        // compiling rather than failing at runtime.
+        // Documentation, not an independent guard: the spawn inside
+        // PendingReranker::spawn already requires FastEmbedReranker: Send
+        // for the crate to compile, so that is what catches a fastembed
+        // upgrade making TextRerank thread-bound. This restates the
+        // requirement where tests are read.
         fn assert_send<T: Send>() {}
         assert_send::<FastEmbedReranker>();
     }

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -6,6 +6,7 @@
 //! the top fused candidates (see [`crate::query::rerank`]).
 
 use std::cell::RefCell;
+use std::thread::JoinHandle;
 
 use anyhow::Result;
 
@@ -74,6 +75,43 @@ impl FastEmbedReranker {
     }
 }
 
+/// A reranker loading on a background thread.
+///
+/// The load depends on nothing the search pipeline produces, so it can run
+/// while the query is embedded and retrieval fuses its candidates.
+/// [`join`](Self::join) then waits only for whatever load time did not fit
+/// behind that work, which on a warm model cache is none of it.
+pub struct PendingReranker {
+    handle: JoinHandle<Result<FastEmbedReranker>>,
+}
+
+impl PendingReranker {
+    /// Begin loading `choice`.
+    pub fn spawn(choice: RerankModel) -> Result<Self> {
+        // Model init reads the process environment; `set_hf_cache_dir`
+        // writes it. Do the write here, while this thread is still the
+        // only one, so the loader can never read it mid-write.
+        super::model::set_hf_cache_dir()?;
+        Ok(Self {
+            handle: std::thread::spawn(move || FastEmbedReranker::new(choice)),
+        })
+    }
+
+    /// Wait for the model, or for whatever went wrong loading it.
+    pub fn join(self) -> Result<FastEmbedReranker> {
+        join_loader(self.handle)
+    }
+}
+
+/// Wait for a loader thread, re-raising a panic on the joining thread so
+/// moving the load off-thread does not turn a crash into a caught error.
+fn join_loader<T>(handle: JoinHandle<Result<T>>) -> Result<T> {
+    match handle.join() {
+        Ok(loaded) => loaded,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
 impl Reranker for FastEmbedReranker {
     fn rerank(&self, query: &str, documents: &[&str]) -> Result<Vec<f32>> {
         if documents.is_empty() {
@@ -137,6 +175,35 @@ mod tests {
         let opts = init_options(RerankModel::JinaTurbo).unwrap();
         let expected = crate::platform::data_dir().unwrap().join("fastembed_cache");
         assert_eq!(opts.cache_dir, expected);
+    }
+
+    #[test]
+    fn reranker_can_be_loaded_off_thread() {
+        // PendingReranker moves a loaded model back to the caller. If a
+        // fastembed upgrade makes TextRerank thread-bound, this stops
+        // compiling rather than failing at runtime.
+        fn assert_send<T: Send>() {}
+        assert_send::<FastEmbedReranker>();
+    }
+
+    #[test]
+    fn join_loader_returns_the_loaded_value() {
+        let handle = std::thread::spawn(|| Ok(7_u32));
+        assert_eq!(join_loader(handle).unwrap(), 7);
+    }
+
+    #[test]
+    fn join_loader_propagates_a_loader_error() {
+        let handle = std::thread::spawn(|| Err::<u32, _>(anyhow::anyhow!("model download failed")));
+        let err = join_loader(handle).unwrap_err();
+        assert_eq!(err.to_string(), "model download failed");
+    }
+
+    #[test]
+    #[should_panic(expected = "ort blew up")]
+    fn join_loader_repanics_when_the_loader_panics() {
+        let handle = std::thread::spawn(|| -> Result<u32> { panic!("ort blew up") });
+        let _ = join_loader(handle);
     }
 
     #[test]

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -87,10 +87,16 @@ pub struct PendingReranker {
 
 impl PendingReranker {
     /// Begin loading `choice`.
+    ///
+    /// Before spawning anything this resolves and creates the model cache
+    /// directory on disk and, on the process's first call, writes the
+    /// `HF_HOME` environment variable via
+    /// [`set_hf_cache_dir`](super::model::set_hf_cache_dir).
     pub fn spawn(choice: RerankModel) -> Result<Self> {
-        // Model init reads the process environment; `set_hf_cache_dir`
-        // writes it. Do the write here, while this thread is still the
-        // only one, so the loader can never read it mid-write.
+        // The loader thread reads the process environment (platform paths,
+        // hf-hub's endpoint and token variables), so set_hf_cache_dir must
+        // run before the thread exists; the full ordering argument lives on
+        // that function.
         super::model::set_hf_cache_dir()?;
         Ok(Self {
             handle: std::thread::spawn(move || FastEmbedReranker::new(choice)),

--- a/src/embed/rerank.rs
+++ b/src/embed/rerank.rs
@@ -54,10 +54,13 @@ pub struct FastEmbedReranker {
 /// hardware execution providers. `TextRerank` resolves its cache from these
 /// options alone (it ignores HF_HOME, unlike `TextEmbedding`), so the cache
 /// directory must be explicit.
-fn init_options(choice: RerankModel) -> Result<fastembed::RerankInitOptions> {
+fn init_options(
+    choice: RerankModel,
+    show_download_progress: bool,
+) -> Result<fastembed::RerankInitOptions> {
     let mut opts = fastembed::RerankInitOptions::new(choice.fastembed_model())
         .with_cache_dir(super::model::hf_cache_dir()?)
-        .with_show_download_progress(true);
+        .with_show_download_progress(show_download_progress);
 
     let providers = super::model::execution_providers();
     if !providers.is_empty() {
@@ -67,8 +70,14 @@ fn init_options(choice: RerankModel) -> Result<fastembed::RerankInitOptions> {
 }
 
 impl FastEmbedReranker {
+    /// Load in the foreground, drawing a download progress bar on stderr
+    /// when the model cache is cold.
     pub fn new(choice: RerankModel) -> Result<Self> {
-        let model = fastembed::TextRerank::try_new(init_options(choice)?)?;
+        Self::load(choice, true)
+    }
+
+    fn load(choice: RerankModel, show_download_progress: bool) -> Result<Self> {
+        let model = fastembed::TextRerank::try_new(init_options(choice, show_download_progress)?)?;
         Ok(Self {
             model: RefCell::new(model),
         })
@@ -103,14 +112,28 @@ impl PendingReranker {
         // run before the thread exists; the full ordering argument lives on
         // that function.
         super::model::set_hf_cache_dir()?;
+        // The background load must not draw hf-hub's download bar: the
+        // main thread draws its own embedding progress bar on the same
+        // stderr cursor, and two uncoordinated indicatif bars garble each
+        // other (hf-hub offers no way to share a MultiProgress). A cold
+        // cache downloads silently here; join announces the wait instead.
         let handle = std::thread::Builder::new()
             .name("reranker-load".to_string())
-            .spawn(move || FastEmbedReranker::new(choice))?;
+            .spawn(move || FastEmbedReranker::load(choice, false))?;
         Ok(Self { handle })
     }
 
     /// Wait for the model, or for whatever went wrong loading it.
+    ///
+    /// The background load downloads without a progress bar (see
+    /// [`spawn`](Self::spawn)), so if the load is still running when the
+    /// pipeline needs it, this says what it is waiting on before blocking.
+    /// On a warm cache the load finishes behind retrieval and no message
+    /// prints.
     pub fn join(self) -> Result<FastEmbedReranker> {
+        if !self.handle.is_finished() {
+            eprintln!("[grans] Waiting for the reranker model; a first search downloads it...");
+        }
         join_loader(self.handle)
     }
 }
@@ -184,9 +207,19 @@ mod tests {
         // ignores HF_HOME, unlike TextEmbedding), so the data-dir cache
         // must be set explicitly or models land in a CWD-relative
         // .fastembed_cache.
-        let opts = init_options(RerankModel::JinaTurbo).unwrap();
+        let opts = init_options(RerankModel::JinaTurbo, true).unwrap();
         let expected = crate::platform::data_dir().unwrap().join("fastembed_cache");
         assert_eq!(opts.cache_dir, expected);
+    }
+
+    #[test]
+    fn init_options_thread_the_download_progress_flag() {
+        // The background load passes false so hf-hub's download bar cannot
+        // interleave with the embedding progress bar on the main thread.
+        let quiet = init_options(RerankModel::JinaTurbo, false).unwrap();
+        assert!(!quiet.show_download_progress);
+        let loud = init_options(RerankModel::JinaTurbo, true).unwrap();
+        assert!(loud.show_download_progress);
     }
 
     #[test]

--- a/src/query/rerank.rs
+++ b/src/query/rerank.rs
@@ -132,6 +132,38 @@ pub fn rerank_hybrid(
     )
 }
 
+/// Ranked (id, score) pairs for the fused candidates of a hybrid ranking.
+/// With a reranker the cross-encoder decides the order and supplies the
+/// score; without one the fusion order stands and no score is attached,
+/// since RRF ranks are not comparable across queries. `min_score` applies
+/// to rerank scores only.
+pub fn order_candidates(
+    conn: &Connection,
+    query: &str,
+    ranking: &HybridRanking,
+    reranker: Option<&dyn Reranker>,
+    min_score: Option<f32>,
+) -> Result<Vec<(String, Option<f32>)>> {
+    let Some(reranker) = reranker else {
+        return Ok(ranking
+            .fused
+            .iter()
+            .map(|d| (d.document_id.clone(), None))
+            .collect());
+    };
+
+    let ctx = RankingContext::load(conn)?;
+    let cfg = RankingConfig::default();
+    let mut reranked = rerank_hybrid(conn, reranker, query, ranking, &ctx, &cfg)?;
+    if let Some(min) = min_score {
+        reranked.retain(|d| d.score >= min);
+    }
+    Ok(reranked
+        .into_iter()
+        .map(|d| (d.document_id, Some(d.score)))
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -475,5 +507,74 @@ mod tests {
 
         assert_eq!(reranked.len(), RERANK_POOL);
         assert!(reranked.iter().all(|d| d.document_id != "doc-59"));
+    }
+
+    /// Documents whose fused order is the reverse of cross-encoder
+    /// relevance: doc-chunk matches "kumquat" twice via its chunk,
+    /// doc-title once via its title, doc-none not at all.
+    fn order_candidates_fixture() -> (Connection, HybridRanking) {
+        let conn = build_test_db(&json!({
+            "documents": {
+                "doc-none": {"id": "doc-none", "title": "Unrelated", "created_at": "2026-01-01T10:00:00Z"},
+                "doc-title": {"id": "doc-title", "title": "Kumquat sync", "created_at": "2026-01-02T10:00:00Z"},
+                "doc-chunk": {"id": "doc-chunk", "title": "Planning", "created_at": "2026-01-03T10:00:00Z"}
+            }
+        }));
+        let ranking = make_ranking(
+            fused(&["doc-none", "doc-title", "doc-chunk"]),
+            HashMap::from([("doc-chunk".to_string(), chunk("kumquat kumquat"))]),
+        );
+        (conn, ranking)
+    }
+
+    #[test]
+    fn order_candidates_without_reranker_keeps_fusion_order_unscored() {
+        // min_score applies to rerank scores only: with no reranker the
+        // fusion order must survive unfiltered even with a threshold set.
+        let (conn, ranking) = order_candidates_fixture();
+
+        let ordered = order_candidates(&conn, "kumquat", &ranking, None, Some(0.9)).unwrap();
+
+        assert_eq!(
+            ordered,
+            vec![
+                ("doc-none".to_string(), None),
+                ("doc-title".to_string(), None),
+                ("doc-chunk".to_string(), None),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_candidates_with_reranker_reorders_and_scores() {
+        let (conn, ranking) = order_candidates_fixture();
+
+        let ordered =
+            order_candidates(&conn, "kumquat", &ranking, Some(&MockReranker), None).unwrap();
+
+        assert_eq!(
+            ordered,
+            vec![
+                ("doc-chunk".to_string(), Some(2.0)),
+                ("doc-title".to_string(), Some(1.0)),
+                ("doc-none".to_string(), Some(0.0)),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_candidates_min_score_drops_low_scoring_candidates() {
+        let (conn, ranking) = order_candidates_fixture();
+
+        let ordered =
+            order_candidates(&conn, "kumquat", &ranking, Some(&MockReranker), Some(0.5)).unwrap();
+
+        assert_eq!(
+            ordered,
+            vec![
+                ("doc-chunk".to_string(), Some(2.0)),
+                ("doc-title".to_string(), Some(1.0)),
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #82.

## What changed

A full `grans search` loaded its cross-encoder only after fusion had produced the candidate pool, so the load sat on the critical path between retrieval and reranking. `PendingReranker` now starts that load on its own thread and hands the model back at `join`.

The spawn sits **after** the embedder is up, not at the top of the command as the issue proposed. Starting it earlier makes the two model loads race for the one-time ONNX runtime init, which costs the embedder more than the earlier start saves (numbers below).

`set_hf_cache_dir` writes `HF_HOME` through a `OnceLock`. Two models can now be initializing at once and model init reads the environment, so the write has to happen exactly once and be ordered before every read. The old `unsafe` block's safety comment ("single-threaded context") stopped being true the moment a second model could load concurrently.

`order_candidates` is the old inline rerank/fusion branch extracted, since the reranker is now constructed well before the point where it is used.

## Measurements

Release build with `--features directml`, RTX 3080, 924-document database, cold invocations. Two interleaved A/B samples of 8 runs per arm, alternating binaries within each round:

| | sample 1 | sample 2 |
|---|---|---|
| `search` before | 5279ms | 5128ms |
| `search` after | 4988ms | 4845ms |
| **delta** | **-291ms** | **-283ms** |
| `search --fast` before | 4156ms | 4026ms |
| `search --fast` after | 4128ms | 3987ms |
| delta (control) | -28ms | -39ms |

`--fast` never loads a reranker, so it is the control: it moves within noise while the full search moves consistently.

Why after the embedder rather than before, measured the same way (8 interleaved runs per placement):

| placement | wall | embedder init |
|---|---|---|
| sequential (today) | 4843ms | 742ms |
| spawn at command start | 4629ms | 811ms |
| spawn after embedder init | 4553ms | 759ms |

Both placements hide the load completely (the join costs under 0.1ms in every run). The earlier spawn just pays 69ms of contention on the cold ORT/DirectML init to do it.

## The issue's cost model was wrong

#82 budgeted ~3.7s for ONNX and embedding-model init and ~870ms for the reranker load, and predicted a full search would land within ~0.3-0.4s of `--fast`. Instrumenting the pipeline gives a different breakdown for a ~4.6s search:

| stage | cost |
|---|---|
| process start, DB open, arg parse | ~290ms |
| `confirm_embedding_work` | ~1130ms |
| embedder init (ONNX + nomic) | ~790ms |
| retrieval (query embed, FTS, semantic, fusion) | ~1740ms |
| rerank (load now hidden, inference remains) | ~600ms |
| evidence extraction and render | ~15ms |

The reranker load is ~320ms sequentially, not ~870ms: by the time it runs, the ORT runtime and DirectML device are already warm, so it is the cheap second session. That is the whole size of the prize here, and the change collects it.

The `--fast` delta therefore does not collapse the way #82 predicted. What remains between them is rerank inference (~600ms), which no amount of overlapping removes.

## Follow-ups filed

The instrumented breakdown turned up a larger lever than this one, and it invalidates the premise of #83. Details in #126 and in comments on #82/#83.

## Testing

- 4 new unit tests in `src/embed/rerank.rs`: a `Send` bound assertion on `FastEmbedReranker` (a fastembed upgrade that makes `TextRerank` thread-bound breaks the build rather than the runtime), plus loader-join behavior for the success, error, and panic paths. A panic in model init re-raises on the joining thread via `resume_unwind`, so moving the load off-thread does not convert a crash into a caught error.
- Full suite green on Windows: 1022 tests across all six binaries (`cargo test --no-fail-fast`).
- `cargo clippy --features directml` clean on all three touched files.

No CLI surface change, so no README update. The README and search-roadmap latency figures are warm-process per-query numbers and are unaffected.
