### PR TITLE
#126: Compute the search's chunk rebuild once, not twice

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -104,7 +104,15 @@ pub fn search(
     include_deleted: bool,
     ctx: &RunContext,
 ) -> Result<()> {
-    if !confirm_embedding_work(conn, opts.yes, ctx)? {
+    // Resolve via the model constant: this path must not load the ONNX
+    // model just to count pending chunks. The plan is the expensive chunk
+    // rebuild (~1s on a large database); computed once here, it feeds both
+    // the confirmation prompt and the embedding pass (#126).
+    let spec =
+        crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
+    let plan = crate::embed::EmbeddingPlan::compute(conn, spec)?;
+
+    if !confirm_embedding_work(&plan, conn, opts.yes, ctx)? {
         return Ok(());
     }
 
@@ -124,10 +132,12 @@ pub fn search(
         })
         .transpose()?;
 
-    let spec =
-        crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
-    let index =
-        crate::embed::ensure_embeddings(conn, &embedder, crate::embed::DEFAULT_BATCH_SIZE, &spec)?;
+    let index = crate::embed::ensure_embeddings_with_plan(
+        conn,
+        &embedder,
+        crate::embed::DEFAULT_BATCH_SIZE,
+        plan,
+    )?;
 
     let ranking = crate::query::hybrid::hybrid_ranked(
         conn,
@@ -274,12 +284,13 @@ fn render_ranked_meeting_list(
 /// Check embedding status and, on a TTY, prompt before a large or full
 /// re-embedding run. Returns false when the user declines (the search
 /// should stop). `yes` skips the prompt.
-fn confirm_embedding_work(conn: &Connection, yes: bool, ctx: &RunContext) -> Result<bool> {
-    // Resolve via the model constant: this path must not load the ONNX
-    // model just to count pending chunks.
-    let spec =
-        crate::embed::config::EmbedSpec::resolve_stored(conn, crate::embed::MODEL_MAX_TOKENS);
-    let status = crate::embed::get_embedding_status(conn, crate::embed::model::MODEL_NAME, &spec)?;
+fn confirm_embedding_work(
+    plan: &crate::embed::EmbeddingPlan,
+    conn: &Connection,
+    yes: bool,
+    ctx: &RunContext,
+) -> Result<bool> {
+    let status = plan.status(conn, crate::embed::model::MODEL_NAME)?;
     let needs_full_reembed = status.orphaned_chunks > 0
         || status.legacy_max_length_warning
         || status.model_changed_warning;

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -3,10 +3,13 @@ pub mod chunker;
 pub mod config;
 pub mod headers;
 pub mod model;
+pub mod plan;
 pub mod progress;
 pub mod rerank;
 pub mod search;
 pub mod store;
+
+pub use plan::EmbeddingPlan;
 
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -184,133 +187,7 @@ pub fn get_embedding_status(
     current_model: &str,
     spec: &config::EmbedSpec,
 ) -> Result<EmbeddingStatus> {
-    use chunk::ChunkSourceType;
-
-    let desired_chunks = desired_chunks_for_spec(conn, spec)?;
-
-    // Get stored chunks
-    let stored = store::get_stored_chunks(conn)?;
-    let stored_map: HashMap<(&str, &str), &store::StoredChunk> = stored
-        .iter()
-        .map(|s| ((s.source_type.as_str(), s.source_id.as_str()), s))
-        .collect();
-
-    // Build set of desired keys and count by type
-    let mut desired_keys: HashSet<(String, String)> = HashSet::new();
-    let mut pending_count = 0;
-    let mut total_by_type = SourceTypeBreakdown::default();
-    let mut pending_by_type = SourceTypeBreakdown::default();
-
-    for chunk in &desired_chunks {
-        let key = (chunk.source_type.as_str(), chunk.source_id.as_str());
-        desired_keys.insert((chunk.source_type.to_string(), chunk.source_id.clone()));
-
-        // Count total by type
-        match chunk.source_type {
-            ChunkSourceType::TranscriptWindow => total_by_type.transcript_window += 1,
-            ChunkSourceType::PanelSection => total_by_type.panel_section += 1,
-            ChunkSourceType::NotesParagraph => total_by_type.notes_paragraph += 1,
-        }
-
-        match stored_map.get(&key) {
-            Some(existing) if existing.content_hash == chunk.content_hash => {
-                // Unchanged — already embedded
-            }
-            _ => {
-                // New or changed — needs embedding
-                pending_count += 1;
-                match chunk.source_type {
-                    ChunkSourceType::TranscriptWindow => pending_by_type.transcript_window += 1,
-                    ChunkSourceType::PanelSection => pending_by_type.panel_section += 1,
-                    ChunkSourceType::NotesParagraph => pending_by_type.notes_paragraph += 1,
-                }
-            }
-        }
-    }
-
-    // Embeddings written by a different model are unusable: everything must
-    // be re-embedded, regardless of content hashes.
-    let model_name = store::get_model_name(conn);
-    let model_changed_warning =
-        model_name.is_some() && model_name.as_deref() != Some(current_model);
-    if model_changed_warning {
-        pending_count = desired_chunks.len();
-        pending_by_type = total_by_type.clone();
-    }
-
-    // Calculate embedded by type (total - pending)
-    let embedded_by_type = SourceTypeBreakdown {
-        transcript_window: total_by_type.transcript_window - pending_by_type.transcript_window,
-        panel_section: total_by_type.panel_section - pending_by_type.panel_section,
-        notes_paragraph: total_by_type.notes_paragraph - pending_by_type.notes_paragraph,
-    };
-
-    // Count orphans (stored but not in desired)
-    let orphan_count = stored
-        .iter()
-        .filter(|s| !desired_keys.contains(&(s.source_type.clone(), s.source_id.clone())))
-        .count();
-
-    // Get chunk size statistics
-    let chunk_size_stats = calculate_chunk_size_stats(conn)?;
-
-    // Get max_length setting
-    let max_length = store::get_max_length(conn);
-
-    // Determine if we should show legacy warning:
-    // Model exists but max_length is missing (legacy embeddings)
-    let legacy_max_length_warning = model_name.is_some() && max_length.is_none();
-
-    let chunking_changed_warning = spec.differs_from_stored(conn);
-
-    Ok(EmbeddingStatus {
-        total_chunks: desired_chunks.len(),
-        embedded_chunks: desired_chunks.len() - pending_count,
-        pending_chunks: pending_count,
-        orphaned_chunks: orphan_count,
-        total_by_type,
-        embedded_by_type,
-        pending_by_type,
-        model_name,
-        chunk_size_stats,
-        max_length,
-        legacy_max_length_warning,
-        model_changed_warning,
-        chunking_changed_warning,
-    })
-}
-
-/// Run all chunkers under `spec`, building contextual headers when the
-/// spec asks for them. This is the single definition of which chunks a
-/// database "should" contain; status and embedding both use it so their
-/// hashes always agree.
-fn desired_chunks_for_spec(conn: &Connection, spec: &config::EmbedSpec) -> Result<Vec<Chunk>> {
-    let doc_headers = if spec.contextual_headers {
-        Some(headers::build_doc_headers(conn)?)
-    } else {
-        None
-    };
-    let doc_headers = doc_headers.as_ref();
-
-    let mut chunks =
-        chunker::transcript_window_chunker_adaptive(conn, &spec.chunking, doc_headers)?;
-    chunks.extend(chunker::panel_section_chunker(
-        conn,
-        &spec.chunking,
-        doc_headers,
-    )?);
-    // Notes keep their historical 20-char minimum; cap and header budget
-    // come from the shared chunking spec.
-    let notes_config = chunker::ChunkingConfig {
-        min_chars: 20,
-        ..spec.chunking.clone()
-    };
-    chunks.extend(chunker::notes_paragraph_chunker(
-        conn,
-        &notes_config,
-        doc_headers,
-    )?);
-    Ok(chunks)
+    EmbeddingPlan::compute(conn, spec.clone())?.status(conn, current_model)
 }
 
 /// True when a chunk's desired metadata no longer matches what is stored.
@@ -384,10 +261,33 @@ pub fn ensure_embeddings(
     batch_size: usize,
     spec: &config::EmbedSpec,
 ) -> Result<EmbeddingIndex> {
+    let plan = EmbeddingPlan::compute(conn, spec.clone())?;
+    ensure_embeddings_with_plan(conn, embedder, batch_size, plan)
+}
+
+/// Like [`ensure_embeddings`], but consuming an already-computed
+/// [`EmbeddingPlan`]. Callers that also need an [`EmbeddingStatus`] (the
+/// search prompt) compute one plan and feed both, instead of paying for
+/// the chunk rebuild twice.
+pub fn ensure_embeddings_with_plan(
+    conn: &Connection,
+    embedder: &dyn Embedder,
+    batch_size: usize,
+    plan: EmbeddingPlan,
+) -> Result<EmbeddingIndex> {
     // Check model consistency — if model changed, all embeddings are wiped
     let model_consistent = store::check_model_consistency(conn, embedder.model_name())?;
 
-    let desired_chunks = desired_chunks_for_spec(conn, spec)?;
+    let EmbeddingPlan {
+        spec,
+        desired_chunks,
+        stored,
+    } = plan;
+
+    // The plan's stored snapshot predates the wipe a model change just
+    // triggered; after the wipe nothing is stored, so everything desired
+    // must be embedded.
+    let stored = if model_consistent { stored } else { Vec::new() };
 
     if desired_chunks.is_empty() {
         if !model_consistent {
@@ -405,8 +305,6 @@ pub fn ensure_embeddings(
         });
     }
 
-    // Get stored state
-    let stored = store::get_stored_chunks(conn)?;
     let stored_map: HashMap<(&str, &str), &store::StoredChunk> = stored
         .iter()
         .map(|s| ((s.source_type.as_str(), s.source_id.as_str()), s))
@@ -534,7 +432,7 @@ pub fn ensure_embeddings(
         embedder.dimension(),
         embedder.max_length(),
     )?;
-    store::set_chunking_metadata(conn, spec)?;
+    store::set_chunking_metadata(conn, &spec)?;
 
     // Load all vectors for search
     let vectors = store::load_all_vectors(conn)?;
@@ -718,6 +616,113 @@ mod tests {
             ])
             .unwrap();
         }
+    }
+
+    /// A MockEmbedder that reports a different model name, for exercising
+    /// model-change paths.
+    struct RenamedEmbedder {
+        inner: MockEmbedder,
+        name: &'static str,
+    }
+
+    impl Embedder for RenamedEmbedder {
+        fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+            self.inner.embed_batch(texts)
+        }
+        fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+            self.inner.embed_query(text)
+        }
+        fn dimension(&self) -> usize {
+            self.inner.dimension()
+        }
+        fn model_name(&self) -> &str {
+            self.name
+        }
+        fn max_length(&self) -> usize {
+            self.inner.max_length()
+        }
+    }
+
+    #[test]
+    fn embedding_plan_status_reports_pending_and_embedded() {
+        let conn = setup_test_db();
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is a longer utterance that contains enough characters to meet the minimum chunk size requirement for embedding.",
+            ],
+        );
+        let embedder = MockEmbedder::default();
+        let spec = config::EmbedSpec::default_for(512);
+        ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &spec).unwrap();
+
+        insert_utterances(
+            &conn,
+            "doc2",
+            &[
+                "A second document whose content is also long enough to clear the minimum chunk size threshold for embedding.",
+            ],
+        );
+
+        let plan = EmbeddingPlan::compute(&conn, spec).unwrap();
+        let status = plan.status(&conn, "mock-embedder").unwrap();
+        assert_eq!(status.total_chunks, 2);
+        assert_eq!(status.embedded_chunks, 1);
+        assert_eq!(status.pending_chunks, 1);
+        assert_eq!(status.orphaned_chunks, 0);
+        assert!(!status.model_changed_warning);
+    }
+
+    #[test]
+    fn ensure_embeddings_with_plan_embeds_pending_chunks() {
+        let conn = setup_test_db();
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is a longer utterance that contains enough characters to meet the minimum chunk size requirement for embedding.",
+            ],
+        );
+        let embedder = MockEmbedder::default();
+        let spec = config::EmbedSpec::default_for(512);
+
+        let plan = EmbeddingPlan::compute(&conn, spec.clone()).unwrap();
+        let index =
+            ensure_embeddings_with_plan(&conn, &embedder, DEFAULT_BATCH_SIZE, plan).unwrap();
+        assert_eq!(index.vectors.len(), 1);
+
+        let status = get_embedding_status(&conn, "mock-embedder", &spec).unwrap();
+        assert_eq!(status.pending_chunks, 0);
+    }
+
+    #[test]
+    fn ensure_embeddings_with_plan_model_change_reembeds_all() {
+        let conn = setup_test_db();
+        insert_utterances(
+            &conn,
+            "doc1",
+            &[
+                "This is a longer utterance that contains enough characters to meet the minimum chunk size requirement for embedding.",
+            ],
+        );
+        let embedder = MockEmbedder::default();
+        let spec = config::EmbedSpec::default_for(512);
+        ensure_embeddings(&conn, &embedder, DEFAULT_BATCH_SIZE, &spec).unwrap();
+
+        // The plan's stored snapshot predates the wipe that a model change
+        // triggers inside ensure; it must not suppress re-embedding.
+        let plan = EmbeddingPlan::compute(&conn, spec.clone()).unwrap();
+        let other = RenamedEmbedder {
+            inner: MockEmbedder::default(),
+            name: "other-model",
+        };
+        let index = ensure_embeddings_with_plan(&conn, &other, DEFAULT_BATCH_SIZE, plan).unwrap();
+        assert_eq!(index.vectors.len(), 1);
+
+        let status = get_embedding_status(&conn, "other-model", &spec).unwrap();
+        assert_eq!(status.pending_chunks, 0);
+        assert!(!status.model_changed_warning);
     }
 
     #[test]

--- a/src/embed/plan.rs
+++ b/src/embed/plan.rs
@@ -1,0 +1,172 @@
+//! The shared pre-model snapshot behind embedding status and embedding.
+//!
+//! Computing the desired chunk set is the expensive part of both the
+//! status check and `ensure_embeddings`: it re-reads every source table
+//! and re-runs all chunkers, about a second on a large database. A single
+//! search needs both a status (for the confirmation prompt) and an
+//! embedding pass; `EmbeddingPlan` computes the snapshot once so the
+//! search pays that cost once instead of twice (#126).
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::chunk::{Chunk, ChunkSourceType};
+use super::config::EmbedSpec;
+use super::{
+    EmbeddingStatus, SourceTypeBreakdown, calculate_chunk_size_stats, chunker, headers, store,
+};
+
+/// Everything the embedding phase needs that can be computed without
+/// loading a model: the chunks the database should contain under `spec`,
+/// and the chunks it currently stores. Both status and
+/// `ensure_embeddings_with_plan` diff the same snapshot, so the prompt a
+/// user confirms and the work that then runs always agree.
+pub struct EmbeddingPlan {
+    pub(super) spec: EmbedSpec,
+    pub(super) desired_chunks: Vec<Chunk>,
+    pub(super) stored: Vec<store::StoredChunk>,
+}
+
+impl EmbeddingPlan {
+    /// Run all chunkers under `spec` and read the stored chunk state.
+    pub fn compute(conn: &Connection, spec: EmbedSpec) -> Result<Self> {
+        let desired_chunks = desired_chunks_for_spec(conn, &spec)?;
+        let stored = store::get_stored_chunks(conn)?;
+        Ok(EmbeddingPlan {
+            spec,
+            desired_chunks,
+            stored,
+        })
+    }
+
+    /// Derive the embedding status from this snapshot. `current_model`
+    /// identifies the embedder that will be used; stored embeddings from a
+    /// different model are unusable and reported as pending.
+    pub fn status(&self, conn: &Connection, current_model: &str) -> Result<EmbeddingStatus> {
+        let stored_map: HashMap<(&str, &str), &store::StoredChunk> = self
+            .stored
+            .iter()
+            .map(|s| ((s.source_type.as_str(), s.source_id.as_str()), s))
+            .collect();
+
+        // Build set of desired keys and count by type
+        let mut desired_keys: HashSet<(String, String)> = HashSet::new();
+        let mut pending_count = 0;
+        let mut total_by_type = SourceTypeBreakdown::default();
+        let mut pending_by_type = SourceTypeBreakdown::default();
+
+        for chunk in &self.desired_chunks {
+            let key = (chunk.source_type.as_str(), chunk.source_id.as_str());
+            desired_keys.insert((chunk.source_type.to_string(), chunk.source_id.clone()));
+
+            // Count total by type
+            match chunk.source_type {
+                ChunkSourceType::TranscriptWindow => total_by_type.transcript_window += 1,
+                ChunkSourceType::PanelSection => total_by_type.panel_section += 1,
+                ChunkSourceType::NotesParagraph => total_by_type.notes_paragraph += 1,
+            }
+
+            match stored_map.get(&key) {
+                Some(existing) if existing.content_hash == chunk.content_hash => {
+                    // Unchanged — already embedded
+                }
+                _ => {
+                    // New or changed — needs embedding
+                    pending_count += 1;
+                    match chunk.source_type {
+                        ChunkSourceType::TranscriptWindow => pending_by_type.transcript_window += 1,
+                        ChunkSourceType::PanelSection => pending_by_type.panel_section += 1,
+                        ChunkSourceType::NotesParagraph => pending_by_type.notes_paragraph += 1,
+                    }
+                }
+            }
+        }
+
+        // Embeddings written by a different model are unusable: everything must
+        // be re-embedded, regardless of content hashes.
+        let model_name = store::get_model_name(conn);
+        let model_changed_warning =
+            model_name.is_some() && model_name.as_deref() != Some(current_model);
+        if model_changed_warning {
+            pending_count = self.desired_chunks.len();
+            pending_by_type = total_by_type.clone();
+        }
+
+        // Calculate embedded by type (total - pending)
+        let embedded_by_type = SourceTypeBreakdown {
+            transcript_window: total_by_type.transcript_window - pending_by_type.transcript_window,
+            panel_section: total_by_type.panel_section - pending_by_type.panel_section,
+            notes_paragraph: total_by_type.notes_paragraph - pending_by_type.notes_paragraph,
+        };
+
+        // Count orphans (stored but not in desired)
+        let orphan_count = self
+            .stored
+            .iter()
+            .filter(|s| !desired_keys.contains(&(s.source_type.clone(), s.source_id.clone())))
+            .count();
+
+        // Get chunk size statistics
+        let chunk_size_stats = calculate_chunk_size_stats(conn)?;
+
+        // Get max_length setting
+        let max_length = store::get_max_length(conn);
+
+        // Determine if we should show legacy warning:
+        // Model exists but max_length is missing (legacy embeddings)
+        let legacy_max_length_warning = model_name.is_some() && max_length.is_none();
+
+        let chunking_changed_warning = self.spec.differs_from_stored(conn);
+
+        Ok(EmbeddingStatus {
+            total_chunks: self.desired_chunks.len(),
+            embedded_chunks: self.desired_chunks.len() - pending_count,
+            pending_chunks: pending_count,
+            orphaned_chunks: orphan_count,
+            total_by_type,
+            embedded_by_type,
+            pending_by_type,
+            model_name,
+            chunk_size_stats,
+            max_length,
+            legacy_max_length_warning,
+            model_changed_warning,
+            chunking_changed_warning,
+        })
+    }
+}
+
+/// Run all chunkers under `spec`, building contextual headers when the
+/// spec asks for them. This is the single definition of which chunks a
+/// database "should" contain; status and embedding both use it so their
+/// hashes always agree.
+fn desired_chunks_for_spec(conn: &Connection, spec: &EmbedSpec) -> Result<Vec<Chunk>> {
+    let doc_headers = if spec.contextual_headers {
+        Some(headers::build_doc_headers(conn)?)
+    } else {
+        None
+    };
+    let doc_headers = doc_headers.as_ref();
+
+    let mut chunks =
+        chunker::transcript_window_chunker_adaptive(conn, &spec.chunking, doc_headers)?;
+    chunks.extend(chunker::panel_section_chunker(
+        conn,
+        &spec.chunking,
+        doc_headers,
+    )?);
+    // Notes keep their historical 20-char minimum; cap and header budget
+    // come from the shared chunking spec.
+    let notes_config = chunker::ChunkingConfig {
+        min_chars: 20,
+        ..spec.chunking.clone()
+    };
+    chunks.extend(chunker::notes_paragraph_chunker(
+        conn,
+        &notes_config,
+        doc_headers,
+    )?);
+    Ok(chunks)
+}


### PR DESCRIPTION
Closes #126.

A single `grans search` ran the full desired-chunk rebuild twice: once in `confirm_embedding_work` (via `get_embedding_status`) and once in `ensure_embeddings`. On the 924-document database each rebuild costs ~1.1s, so roughly 2.2s of a ~4.6s search went to deciding twice that nothing needs embedding.

## Measurement (the issue's open question)

Instrumented `get_embedding_status` on the real database, release build; cold and warm runs were within noise of each other:

| phase | cost |
|---|---|
| transcript read+group (SQLite -> structs, 522k utterances) | ~580ms |
| transcript chunk+hash (CPU) | ~193ms |
| panel + notes chunkers | ~18ms |
| `get_stored_chunks` | ~105ms |
| `calculate_chunk_size_stats` | ~86ms |

The SQLite read dominates (~65%), not chunker CPU. That settles the fingerprint question the issue raised: a content fingerprint that still reads the source rows would only save the ~193ms of chunking CPU. Avoiding the read entirely would need write-path invalidation to satisfy the "row edited without changing counts must invalidate" constraint, which is a much larger design for a smaller remaining win. So this PR does the collapse and stops there.

## Change

- New `EmbeddingPlan` (src/embed/plan.rs): snapshots the desired-chunk set and stored chunk state once. `desired_chunks_for_spec` and the status derivation move here from `embed::mod`.
- `get_embedding_status` and `ensure_embeddings` keep their signatures as thin wrappers; `ensure_embeddings_with_plan` consumes a precomputed plan.
- `search` computes one plan and feeds both the confirmation prompt and the embedding pass. A side benefit: the prompt and the work that follows now describe the same snapshot instead of two independently computed ones.
- Model-change semantics preserved: `check_model_consistency` wipes the store inside ensure, so the plan's pre-wipe stored snapshot is dropped there and everything desired is re-embedded. `ensure_embeddings_with_plan_model_change_reembeds_all` is the regression test for exactly that hazard (with a stale stored snapshot it would silently skip re-embedding).

## Results

Same database, same query, `search --fast --yes`, CPU release build, 3 runs each:

| | wall time |
|---|---|
| before | 4227 / 3776 / 3665 ms |
| after | 2424 / 2437 / 2600 ms |

## Tests

Three new unit tests in `embed::tests` (plan status counts, plan-based embedding, model-change re-embed). Full suite: 947 unit + 82 integration, all passing on Windows via PowerShell with `--no-fail-fast`.

🤖 Generated with AI agents